### PR TITLE
Alternative designs for bounds of address-of a pointer dereference.

### DIFF
--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -148,6 +148,7 @@ and \var{x} has a known number of elements \var{n}, then
 \end{itemize}
 
 \subsection{Address-of expressions}
+\label{section:address-of-expression-bounds}
 
 There are three kinds of address-of expressions:
 \begin{itemize}

--- a/spec/bounds_safety/design-alternatives.tex
+++ b/spec/bounds_safety/design-alternatives.tex
@@ -230,6 +230,66 @@ introduces an invisible failure point in a program where one does not
 otherwise exist. Pointer arithmetic is not normally bounds checked, so
 it is not expected fail.
 
+\section{Alternate bounds for the address-of operator applied to a pointer dereference}
+\label{section:alternate-address-of-pointer-bounds}
+
+The bounds for \verb|&*|\var{e} are defined to be the bounds of \var{e} in 
+Section~\ref{section:address-of-expression-bounds}.  We considered
+using narrower bounds for \verb|&*|\var{e} of \bounds{\var{e}}{\var{e}\texttt{ + 1}},
+where the bounds describe memory containing only a single value.
+We rejected this choice for two reasons.
+
+First, the narrower bounds use \var{e}.  This is a problem because expressions used within
+bounds expressions must be non-modifying expressions. These are a subset of C expressions that do 
+not modify variables or memory.  The expression \var{e} might not be a valid non-modifying 
+expression, in which case there would be no way to write the narrower bounds expression.  We could try to restrict \verb|&*|\var{e} so that \var{e} must be a non-modifying expression.  We do not know
+the extent of changes that this could require in existing C programs.
+
+Second, the meaning of \verb|&*|\var{e} is ambiguous in C.   This ambiguity often
+arises when programmers take the address of array elements: \verb|&|\var{e1}\verb|[|\var{e2}\verb|]|
+is a synonym for \verb|&*|\verb|(|\var{e1}\verb|+|\var{e2}\verb|)|.  It is not clear whether
+programmers mean to refer to single elements or multiple elements of arrays.
+In some cases, programmers mean
+to refer to only single elements:
+\begin{verbatim}
+void swap(int *p, int *q) {
+    tmp = *p;
+    *p = *q;
+    *q = *tmp;
+}
+
+void f() {
+    int arr[5] = {0, 1, 2, 3, 4};
+    swap(&arr[0], &arr[5]);
+}
+\end{verbatim}
+
+In other cases, programmers mean to refer to a range of elements:
+\begin{verbatim}
+int sum(int *start, int count) {
+   int total = 0;
+   for (int i = 0; i < count; i++) {
+       total += start[i];
+   }
+   return total;
+}
+
+void f() {
+    int arr[5] = {0, 1, 2, 3, 4};
+    sum(&arr[3], 3);
+}
+\end{verbatim}
+
+C provides no way to differentiate between the two cases. 
+This leads us to choose the more general bounds (the wider bounds).
+A programmer can always narrow the bounds if desired.  The converse is not
+true.
+
+Some programming languages provide the notion of array slices and have syntax for slices. 
+An array slice is a section of an array.
+However, extending C with new syntax for array slices would violate the design
+principle of minimizing changes to C.
+
 \section{Alternate semantics for bounds declarations}
 \label{section:bounds-declarations-alternate-semantics}
 

--- a/spec/bounds_safety/design-alternatives.tex
+++ b/spec/bounds_safety/design-alternatives.tex
@@ -286,7 +286,7 @@ A programmer can always narrow the bounds if desired.  The converse is not
 true.
 
 Some programming languages provide the notion of array slices and have syntax for slices. 
-An array slice is a section of an array.
+An array slice is a sub-section of an array with a designated beginning and ending.
 However, extending C with new syntax for array slices would violate the design
 principle of minimizing changes to C.
 


### PR DESCRIPTION
This change adds a description of alternative bounds choices for &*e.  This finishes the remaining work for  issue #18.