### PR TITLE
Tests for checking type requirements for bounds declarations.

### DIFF
--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -75,6 +75,10 @@ In a bounds declaration of the form \boundsdecl{\var{x}}{\var{bounds-exp}},
 \var{x} must have an \arrayptr\ or a checked array type. 
 For the form  \boundsdecl{\var{x}}{\boundscount{\var{e1}}},  the type of 
 \var{x} cannot be \arrayptrvoid\ and the type of \var{e1} must be an integral type. 
+The usual C integer conversions are applied to \var{e1}\footnote{If the 
+type of \var{e1} is a character, a short integer, a bit field, or an enumeration type,
+the expression is promoted to an \keyword{int} type if that is large
+enough to  hold all values of the type or an \keyword{unsigned int} type otherwise.}.
 For \boundsdecl{\var{x}}{\bounds{\var{e1}}{\var{e2}}}, \var{e1} and
 \var{e2} must have the same \arrayptr\ type. The type of x is
 typically the same type as \var{e1} and \var{e2}, but it can be a
@@ -907,7 +911,8 @@ The bounds declaration \boundsdecl{\var{x}}{\boundsbytecount{\var{e1}}}
 describes the number of bytes that are accessible beginning at \var{x}. 
 Only memory that is at or above \var{x} and below \texttt{(\arrayptrchar)}
 \var{x} \texttt{+} \var{e1} can be accessed through \var{x}. The type
-of \var{e1} must be an integral type. This bounds declaration is a synonym for 
+of \var{e1} must be an integral type.  The usual C integer conversions are
+applied to \var{e1}.  This bounds declaration is a synonym for 
 \boundsdecl{\var{x}}
            {\boundsrel{(\arrayptrchar) \var{x}}
                       {(\arrayptrchar) \var{x} \texttt{+} \var{e1}}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -82,7 +82,7 @@ enough to  hold all values of the type or an \keyword{unsigned int} type otherwi
 For \boundsdecl{\var{x}}{\bounds{\var{e1}}{\var{e2}}}, \var{e1} and
 \var{e2} must be pointers to the same type.  Typically \var{x} is also 
 a pointer to that type or an array of that type.  
-However, \var{x} can point to or be an array of a different type.
+However, \var{x} can be a pointer to or an array of a different type.
 This is useful for describing the results of casts and
 bounds for \arrayptrvoid\ pointers.
 

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -72,18 +72,18 @@ Section~\ref{section:non-modifying-expressions}  describes
 non-modifying expressions in detail.
 
 In a bounds declaration of the form \boundsdecl{\var{x}}{\var{bounds-exp}},
-\var{x} must have an \arrayptr\ or a checked array type. 
-For the form  \boundsdecl{\var{x}}{\boundscount{\var{e1}}},  the type of 
-\var{x} cannot be \arrayptrvoid\ and the type of \var{e1} must be an integral type. 
-The usual C integer conversions are applied to \var{e1}\footnote{If the 
+\var{x} can have an \arrayptr\ or a checked array type.
+For the form  \boundsdecl{\var{x}}{\boundscount{\var{e1}}},  the type of
+\var{x} cannot be \arrayptrvoid\ and the type of \var{e1} must be an integral type.
+The usual C integer conversions are applied to \var{e1}.\footnote{If the
 type of \var{e1} is a character, a short integer, a bit field, or an enumeration type,
 the expression is promoted to an \keyword{int} type if that is large
-enough to  hold all values of the type or an \keyword{unsigned int} type otherwise.}.
+enough to  hold all values of the type or an \keyword{unsigned int} type otherwise.}
 For \boundsdecl{\var{x}}{\bounds{\var{e1}}{\var{e2}}}, \var{e1} and
-\var{e2} must have the same \arrayptr\ type. The type of x is
-typically the same type as \var{e1} and \var{e2}, but it can be a
-different \arrayptr\ or checked array type. Allowing the types
-to be different is useful for describing the results of pointer casts and
+\var{e2} must be pointers to the same type.  Typically \var{x} is also 
+a pointer to that type or an array of that type.  
+However, \var{x} can point to or be an array of a different type.
+This is useful for describing the results of casts and
 bounds for \arrayptrvoid\ pointers.
 
 For any variable with a bounds declaration, the variable must be

--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -101,7 +101,7 @@ extern void f5() {
   auto int arr5 checked[5] : bounds(arr5, arr5 + 5);
   auto int arr6 checked[5] : bounds(arr5, arr5 + len);
 
-  static int cache[5] : count(5);
+  static int cache checked[5] : count(5);
   static array_ptr<int> cache_ptr : bounds(cache - 2, cache + 3);
 }
 

--- a/tests/parsing/parameter_bounds.c
+++ b/tests/parsing/parameter_bounds.c
@@ -131,7 +131,7 @@ extern void f24(int arr : count(len)) { // expected-error {{use of undeclared id
 
 // Check parsing of a function with lots of arguments.
 extern void f25(int a, int b, int c, int d, float f, int g, int h, int i,
-                int j, int k, int len, int arr : count(len)) {
+                int j, int k, int len, array_ptr<int> arr : count(len)) {
 }
 
 // Misspell bounds to cause a parsing error.
@@ -156,16 +156,16 @@ extern void f29(int len,
 
 //  Bounds expressions with parenthesized subexpressions.
 extern void f30(int len,
-                int arr : bounds(arr, (arr + len))) {
+                array_ptr<int> arr : bounds(arr, (arr + len))) {
 }
 
 extern void f31(int len,
-                int arr : bounds((arr + len - (len)), (arr + len))) {
+                array_ptr<int> arr : bounds((arr + len - (len)), (arr + len))) {
 }
 
 
 extern void f32(int len,
-                int arr : count((len)),
+                array_ptr<int> arr : count((len)),
                 int flag) {
 }
 

--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -215,7 +215,7 @@ extern array_ptr<char> f26() : count(len) { // expected-error {{use of undeclare
 }
 
 // Misspell bounds to cause a parsing error.
-extern array_ptr<int> f27(int len,int arr : count(len)) : boounds(arr, arr + len)) { // expected-error {{expected bounds expression}}
+extern array_ptr<int> f27(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len)) { // expected-error {{expected bounds expression}}
   return 0;
 }
 
@@ -225,12 +225,12 @@ extern array_ptr<int> f28(int len) : coount(len) { // expected-error {{expected 
 }
 
 // Omit an argument to bounds to cause a parsing error
-extern array_ptr<int> f29(int len, int arr : count(len)) : bounds(arr)) { // expected-error {{expected ','}}
+extern array_ptr<int> f29(int len, array_ptr<int> arr : count(len)) : bounds(arr)) { // expected-error {{expected ','}}
   return 0;
 }
 
 // Omit both arguments to bounds to cause a parsing error
-extern array_ptr<int> f30(int len, int arr : count(len)) : bounds()) { // expected-error {{expected expression}}
+extern array_ptr<int> f30(int len, array_ptr<int> arr : count(len)) : bounds()) { // expected-error {{expected expression}}
   return 0;
 }
 

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -555,7 +555,7 @@ struct s8 {
 };
 
 //
-// Test functionr return bounds declarations.
+// Test function return bounds declarations.
 // 
 
 //

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -28,7 +28,6 @@ enum E1 {
 };
 
 extern void count_exprs(void) {
-
   char c1 = 8;
   short c2 = 8;
   int c3 = 8;
@@ -103,7 +102,7 @@ extern void count_exprs_with_integral_operands(void) {
 
 float globalFloat = 8;
 
-extern void f1(void) {}
+extern void test_func(void) {}
 
 // Test types that should not work as arguments for count and byte_count.
 extern void invalid_count_exprs(void) {
@@ -120,7 +119,7 @@ extern void invalid_count_exprs(void) {
 
   struct S2 s = { 8.0 };
 
-  void (*func_ptr)(void) = f1;
+  void (*func_ptr)(void) = test_func;
 
 #ifndef __STDC_NO_COMPLEX__
  float _Complex c8 = 8.0;
@@ -134,7 +133,7 @@ extern void invalid_count_exprs(void) {
   array_ptr<int> t6 : count(c6) = 0;   // expected-error {{invalid argument type}}
   array_ptr<int> t7 : count(c7) = 0;   // expected-error {{invalid argument type}}
   array_ptr<int> t8 : count(s.f) = 0;  // expected-error {{invalid argument type}}
-  array_ptr<int> t9 : count(f1) = 0; // expected-error {{invalid argument type}}
+  array_ptr<int> t9 : count(test_func) = 0; // expected-error {{invalid argument type}}
   array_ptr<int> t10 : count(func_ptr) = 0; // expected-error {{invalid argument type}}
   array_ptr<int> t11 : count("test") = 0; // expected-error {{invalid argument type}}
   array_ptr<int> t12 : count(5.0f) = 0; // expected-error {{invalid argument type}}
@@ -163,31 +162,140 @@ extern void invalid_count_exprs(void) {
 }
 
 //
-// Check bounds declarations
+// Test type requirements for bounds declarations.   There are various 
+// requirements for the types of variables with bounds declaration.
 //
-// We need to check typechecking for the cross-product of (variable or member
-// declaration, scope (local or global), the kind of the bounds expression,
-// type for the variable).
+// We need to test the cross-product of (variable or member 
+//  declaration, scope for variables (global or local), the kind of the bounds
+// expression, and the type for the variable).
+//
+// The test sfollow a specific pattern: there is a set of tests for global
+// variables that covers most of the different requirements.   The tests
+// for the other cases (local variables, parameter variables, member 
+// declarations, and return bounds declarations) are specialized clones
+//  of the cases for global variables.  The syntax is altered where necessary,
+// prefixes for variables and members are renamed to avoid overlapping names
+// and a small number of tests are added/removed.  The numbering for variables
+//  and members should be kept the same across the different cases.
+// 
+// The tests themselves are ordered by the kind of bounds expression and then
+// grouped by kind of type within that.
+
+//
+// Test global variable declarations
+//
+
+//
+// Valid bounds declarations for global variables
+//
+
+// count
+array_ptr<int> g1 : count(5) = 0;
+int *g2 : count(5) = 0;
+int g3 checked[5] : count(5);
+int g3a[5] : count(5);
+
+// byte_count
+array_ptr<int> g4 : byte_count(5 * sizeof(int)) = 0;
+array_ptr<void> g5 : byte_count(5 * sizeof(int)) = 0;
+int *g6 : byte_count(5 * sizeof(int)) = 0;
+int g7 checked[5] : byte_count(5 * sizeof(int));
+unsigned int g8 checked[5] : byte_count(5 * sizeof(int));
+unsigned int g9[5] : byte_count(5 * sizeof(int));
+
+// bounds
+array_ptr<int> g10 : bounds(g10, g10 + 5) = 0;
+// The use of 'g3' is intentional - pointer arithmetic is not
+// allowed on pointers to void types
+array_ptr<void> g11 : bounds(g3, g3 + 5);
+int *g12 : bounds(g12, g12 + 5) = 0;
+int g13 checked[5] : bounds(g13, g13 + 5);
+unsigned int g14 checked[5] : bounds(g14, g14 + 5);
+int g15[5] : bounds(g15, g15 + 5);
+unsigned int g16[5] : bounds(g16, g16 + 5);
+
+//
+// Valid bounds declarations for integer-typed global variables.
+//
+
+int s1 checked[16];
+
+// byte_count
+// Cannot initialize this at compile time.
+// short int g20 : byte_count(5 * sizeof(int)) = (short int) s1;
+int g21 : byte_count(5 * sizeof(int)) = (int)s1;
+long int g22 : byte_count(5 * sizeof(int)) = (long int)s1;
+unsigned long int g23 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
+enum E1 g24 : byte_count(8) = EnumVal1;
+
+// bounds
+int g25 : bounds(s1, s1 + 5) = (int)s1;
+long int g26 : bounds(s1, s1 + 5) = (int)s1;
+unsigned long int g27 : bounds(s1, s1 + 5) = (int)s1;
+enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
+
+//
+// Test invalid bounds declarations for global variables
+//
+
+// count
+char g41 : count(5) = 0;           // expected-error {{expected 'g41' to have a pointer or array type}}
+_Bool g42 : count(5) = 0;          // expected-error {{expected 'g42' to have a pointer or array type}}
+short int g43 : count(5) = 0;      // expected-error {{expected 'g43' to have a pointer or array type}}
+int g44 : count(5) = 0;            // expected-error {{expected 'g44' to have a pointer or array type}}
+long int g45 : count(5) = 0;       // expected-error {{expected 'g45' to have a pointer or array type}}
+unsigned short int g46 : count(5) = 0; // expected-error {{expected 'g46' to have a pointer or array type}}
+unsigned int g47 : count(5) = 0;       // expected-error {{expected 'g47' to have a pointer or array type}}
+unsigned long int g48 : count(5) = 0;  // expected-error {{expected 'g48' to have a pointer or array type}}
+
+float g49 : count(5) = 0;           // expected-error {{expected 'g49' to have a pointer or array type}}
+double g50 : count(5) = 0;          // expected-error {{expected 'g50' to have a pointer or array type}}
+struct S1 g51 : count(5) = { 0 };   // expected-error {{expected 'g51' to have a pointer or array type}}
+union U1 g52 : count(5) = { 0 };    // expected-error {{expected 'g52' to have a pointer or array type}}
+enum E1 g53 : count(5) = EnumVal1;  // expected-error {{expected 'g53' to have a pointer or array type}}
+ptr<int> g54: count(1) = 0;         // expected-error {{bounds declaration not allowed because 'g54' has a ptr type}}
+array_ptr<void> g55 : count(1) = 0; // expected-error {{expected 'g55' to have a non-void pointer type}}
+void((*g56)(void)) : count(1);      // expected-error {{bounds declaration not allowed because 'g56' has a function pointer type}}
+
+// byte_count
+float g60 : byte_count(8);             // expected-error {{expected 'g60' to have a pointer, array, or integer type}}
+double g61 : byte_count(8);            // expected-error {{expected 'g61' to have a pointer, array, or integer type}}
+struct S1 g62 : byte_count(8) = { 0 }; // expected-error {{expected 'g62' to have a pointer, array, or integer type}}
+union U1 g63 : byte_count(8) = { 0 };  // expected-error {{expected 'g63' to have a pointer, array, or integer type}}
+ptr<int> g64 : byte_count(8) = 0;      // expected-error {{bounds declaration not allowed because 'g64' has a ptr type}}
+void((*g65)(void)) : byte_count(1);    // expected-error {{bounds declaration not allowed because 'g65' has a function pointer type}}
+
+// bounds
+float g70 : bounds(s1, s1 + 1);             // expected-error {{expected 'g70' to have a pointer, array, or integer type}}
+double g71 : bounds(s1, s1 + 1);            // expected-error {{expected 'g71' to have a pointer, array, or integer type}}
+struct S1 g72 : bounds(s1, s1 + 1) = { 0 }; // expected-error {{expected 'g72' to have a pointer, array, or integer type}}
+union U1 g73 : bounds(s1, s1 + 1) = { 0 };  // expected-error {{expected 'g73' to have a pointer, array, or integer type}}
+ptr<int> g74 : bounds(s1, s1 + 1) = 0;      // expected-error {{bounds declaration not allowed because 'g74' has a ptr type}}
+void((*g75)(void)) : bounds(s1, s1 + 1);    // expected-error {{bounds declaration not allowed because 'g75' has a function pointer type}}
+
+//
+// Test bounds declarations for local variables.
+//
 
 void local_var_bounds_decl(void)
 {
-   // count
-   array_ptr<int> t1 : count(5) = 0;
-   int t2 checked[5] : count(5);
+  // count
+  array_ptr<int> t1 : count(5) = 0;
+  int t3 checked[5] : count(5);
 
-   // byte_count
-   array_ptr<int> t3 : byte_count(5 * sizeof(int)) = 0;
-   int t4 checked[5] : byte_count(5 * sizeof(int));
-   unsigned int t5 checked[5] : byte_count(5 * sizeof(int));
-   array_ptr<void> t6 : byte_count(8) = 0;
+  // byte_count
+  array_ptr<int> t4 : byte_count(5 * sizeof(int)) = 0;
+  array_ptr<void> t5 : byte_count(5 * sizeof(int)) = 0;
+  int t7 checked[5] : byte_count(5 * sizeof(int));
+  unsigned int t8 checked[5] : byte_count(5 * sizeof(int));
 
-   // bounds
-   array_ptr<int> t7 : bounds(t7, t7 + 5) = 0;
-   // The use of 't2' is intentional - pointer arithmetic is not
-   // allowed on pointers to void types.
-   array_ptr<void> t8 : bounds(t2, t2 + 5) = t2;
-   int t9 checked[5] : bounds(t9, t9 + 5);
-   unsigned int t10 checked[5] : bounds(t10, t10 + 5);
+  // bounds
+  array_ptr<int> t10 : bounds(t10, t10 + 5) = 0;
+  // The use of 't3' is intentional - pointer arithmetic is not
+  // allowed on pointers to void types.
+  array_ptr<void> t11 : bounds(t3, t3 + 5) = t3;
+  int t13 checked[5] : bounds(t13, t13 + 5);
+  unsigned int t14 checked[5] : bounds(t14, t14 + 5);
 }
 
 void int_local_var_bounds_decl(void) {
@@ -195,228 +303,330 @@ void int_local_var_bounds_decl(void) {
   // casting of pointers to integers and back.  We usually expect this
   // to happen within expressions, but to allow uniform use of language
   // features, we allow bounds on integer-typed variables.
-  int t1 checked[5];
+  int a1 checked[5];
 
   // byte_count
-  short int t2 : byte_count(5 * sizeof(int)) = (short int)t1;
-  int t3 : byte_count(5 * sizeof(int)) = (int)t1;
-  long int t4 : byte_count(5 * sizeof(int)) = (long int)t1;
-  unsigned long int t5 : byte_count(5 * sizeof(int)) = (unsigned long int) t1;
-  enum E1 t6 : byte_count(8) = EnumVal1;
+  short int t20 : byte_count(5 * sizeof(int)) = (short int)a1;
+  int t21 : byte_count(5 * sizeof(int)) = (int)a1;
+  long int t22 : byte_count(5 * sizeof(int)) = (long int)a1;
+  unsigned long int t23 : byte_count(5 * sizeof(int)) = (unsigned long int) a1;
+  enum E1 t24 : byte_count(8) = EnumVal1;
 
   // bounds
-  int t7 : bounds(t1, t1 + 5) = (int) t1;
-  long int t8 : bounds(t1, t1 + 5) = (int) t1;
-  unsigned long int t9 : bounds(t1, t1 + 5) = (int) t1;
-  enum E1 t10 : bounds(t1, t1 + 5) = (int) t1;
+  int t25 : bounds(a1, a1 + 5) = (int)a1;
+  long int t26 : bounds(a1, a1 + 5) = (int)a1;
+  unsigned long int t27 : bounds(a1, a1 + 5) = (int)a1;
+  enum E1 t28 : bounds(a1, a1 + 5) = (int)a1;
 }
 
 void invalid_local_var_bounds_decl(void)
 {
   int arr[16];
-  char t1 : count(5) = 0;           // expected-error {{expected 't1' to have pointer or array type}}
-  _Bool t2 : count(5) = 0;          // expected-error {{expected 't2' to have pointer or array type}}
-  short int t3 : count(5) = 0;      // expected-error {{expected 't3' to have pointer or array type}}
-  int t4 : count(5) = 0;            // expected-error {{expected 't4' to have pointer or array type}}
-  long int t5 : count(5) = 0;       // expected-error {{expected 't5' to have pointer or array type}}
-  unsigned short int t6 : count(5) = 0; // expected-error {{expected 't6' to have pointer or array type}}
-  unsigned int t7 : count(5) = 0;       // expected-error {{expected 't7' to have pointer or array type}}
-  unsigned long int t8 : count(5) = 0;  // expected-error {{expected 't8' to have pointer or array type}}
+  char t41 : count(5) = 0;           // expected-error {{expected 't41' to have a pointer or array type}}
+  _Bool t42 : count(5) = 0;          // expected-error {{expected 't42' to have a pointer or array type}}
+  short int t43 : count(5) = 0;      // expected-error {{expected 't43' to have a pointer or array type}}
+  int t44 : count(5) = 0;            // expected-error {{expected 't44' to have a pointer or array type}}
+  long int t45 : count(5) = 0;       // expected-error {{expected 't45' to have a pointer or array type}}
+  unsigned short int t46 : count(5) = 0; // expected-error {{expected 't46' to have a pointer or array type}}
+  unsigned int t47 : count(5) = 0;       // expected-error {{expected 't47' to have a pointer or array type}}
+  unsigned long int t48 : count(5) = 0;  // expected-error {{expected 't48' to have a pointer or array type}}
 
-  float t9 : count(5) = 0;          // expected-error {{expected 't9' to have pointer or array type}}
-  double t10 : count(5) = 0;        // expected-error {{expected 't10' to have pointer or array type}}
-  struct S1 t11 : count(5) = { 0 }; // expected-error {{expected 't11' to have pointer or array type}}
-  union U1 t12 : count(5) = { 0 };  // expected-error {{expected 't12' to have pointer or array type}}
-  enum E1 t13 : count(5) = EnumVal1; // expected-error {{expected 't13' to have pointer or array type}}
+  float t49 : count(5) = 0;          // expected-error {{expected 't49' to have a pointer or array type}}
+  double t50 : count(5) = 0;         // expected-error {{expected 't50' to have a pointer or array type}}
+  struct S1 t51 : count(5) = { 0 };  // expected-error {{expected 't51' to have a pointer or array type}}
+  union U1 t52 : count(5) = { 0 };   // expected-error {{expected 't52' to have a pointer or array type}}
+  enum E1 t53 : count(5) = EnumVal1; // expected-error {{expected 't53' to have a pointer or array type}}
+  ptr<int> t54 : count(1) = 0;       // expected-error {{bounds declaration not allowed because 't54' has a ptr type}}
+  array_ptr<void> t55 : count(1) = 0; // expected-error {{expected 't55' to have a non-void pointer type}}
+  void((*t56)(void)) : count(1);      // expected-error {{bounds declaration not allowed because 't56' has a function pointer type}}
 
-  int *t14 : count(1) = 0;          // expected-error {{expected local variable 't14' to have array_ptr type}}
-  ptr<int> t15 : count(1) = 0;      // expected-error {{bounds declaration not allowed because 't15' has ptr type}}
-  int t16[5] : count(5);            // expected-error {{expected local variable 't16' to have checked array type}}
-  array_ptr<void> t17 : count(1) = 0; // expected-error {{expected 't17' to have non-void pointer type}}
+  int *t57 : count(1) = 0;          // expected-error {{expected local variable 't57' to have array_ptr type}}
+  int t58[5] : count(5);            // expected-error {{expected local variable 't58' to have checked array type}}
 
   // byte_count
-  float t30 : byte_count(8);              // expected-error {{expected 't30' to have pointer, array, or integer type}}
-  double t31 : byte_count(8);             // expected-error {{expected 't31' to have pointer, array, or integer type}}
-  struct S1 t32 : byte_count(8) = { 0 };  // expected-error {{expected 't32' to have pointer, array, or integer type}}
-  union U1 t33 : byte_count(8) = { 0 } ;  // expected-error {{expected 't33' to have pointer, array, or integer type}}
+  float t60 : byte_count(8);                  // expected-error {{expected 't60' to have a pointer, array, or integer type}}
+  double t61 : byte_count(8);                 // expected-error {{expected 't61' to have a pointer, array, or integer type}}
+  struct S1 t62 : byte_count(8) = { 0 };      // expected-error {{expected 't62' to have a pointer, array, or integer type}}
+  union U1 t63 : byte_count(8) = { 0 };       // expected-error {{expected 't63' to have a pointer, array, or integer type}}
+  ptr<int> t64 : byte_count(sizeof(int)) = 0; // expected-error {{bounds declaration not allowed because 't64' has a ptr type}}
+  void((*t65)(void)) : byte_count(1);         // expected-error {{bounds declaration not allowed because 't65' has a function pointer type}}
 
-  int *t34 : byte_count(sizeof(int)) = 0;       // expected-error {{expected local variable 't34' to have array_ptr type}}
-  ptr<int> t35 : byte_count(sizeof(int)) = 0;   // expected-error {{bounds declaration not allowed because 't35' has ptr type}}
-  int t36[5] : byte_count(5 * sizeof(int));     // expected-error {{expected local variable 't36' to have checked array type}}
+  int *t67 : byte_count(sizeof(int)) = 0;     // expected-error {{expected local variable 't67' to have array_ptr type}}
+  int t68[5] : byte_count(5 * sizeof(int));   // expected-error {{expected local variable 't68' to have checked array type}}
 
   // bounds
-  float t40 : bounds(arr, arr + 1);              // expected-error {{expected 't40' to have pointer, array, or integer type}}
-  double t41 : bounds(arr, arr + 1);             // expected-error {{expected 't41' to have pointer, array, or integer type}}
-  struct S1 t42 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't42' to have pointer, array, or integer type}}
-  union U1 t43 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't43' to have pointer, array, or integer type}}
+  float t70 : bounds(arr, arr + 1);             // expected-error {{expected 't70' to have a pointer, array, or integer type}}
+  double t71 : bounds(arr, arr + 1);            // expected-error {{expected 't71' to have a pointer, array, or integer type}}
+  struct S1 t72 : bounds(arr, arr + 1) = { 0 }; // expected-error {{expected 't72' to have a pointer, array, or integer type}}
+  union U1 t73 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't73' to have a pointer, array, or integer type}}
+  ptr<int> t74 : bounds(arr, arr + 1) = 0;      // expected-error {{bounds declaration not allowed because 't74' has a ptr type}}
+  void((*t75)(void)) : bounds(arr, arr + 1);    // expected-error {{bounds declaration not allowed because 't75' has a function pointer type}}
 
-  int *t44 : bounds(arr, arr + 1) = 0;          // expected-error {{expected local variable 't44' to have array_ptr type}}
-  ptr<int> t45 : bounds(arr, arr + 1) = 0;      // expected-error {{bounds declaration not allowed because 't45' has ptr type}}
-  int t46[5] : bounds(arr, arr + 1);            // expected-error {{expected local variable 't46' to have checked array type}}
+  int *t78 : bounds(arr, arr + 1) = 0;          // expected-error {{expected local variable 't78' to have array_ptr type}}
+  int t79[5] : bounds(arr, arr + 1);            // expected-error {{expected local variable 't79' to have checked array type}}
 }
 
 //
-// Test global variable declarations
-//
+// Test parameter variable bounds declarations.
+// 
 
-// Valid bounds declarations for global variables
+void param_var_bounds_decl(
+  // count
+  array_ptr<int> t1 : count(5),
+  int *t2 : count(5),
+  int t3 checked[5] : count(5),
+  int t3a[5] : count(5),
 
-// count
-array_ptr<int> g1 : count(5) = 0;
-int g2 checked[5] : count(5);
+  // byte_count
+  array_ptr<int> t4 : byte_count(5 * sizeof(int)),
+  array_ptr<void> t5 : byte_count(5 * sizeof(int)),
+  int *t6 : byte_count(5 * sizeof(int)),
+  int t7 checked[5] : byte_count(5 * sizeof(int)),
+  unsigned int t8 checked[5] : byte_count(5 * sizeof(int)),
+  unsigned int t9[5] : byte_count(5 * sizeof(int)),
 
-// byte_count
-array_ptr<int> g3 : byte_count(5 * sizeof(int)) = 0;
-int g4 checked[5] : byte_count(5 * sizeof(int));
-unsigned int g5 checked[5] : byte_count(5 * sizeof(int));
-unsigned int g6[5] : byte_count(5 * sizeof(int));
-array_ptr<void> g7 : byte_count(8) = 0;
+  // bounds
+  array_ptr<int> t10 : bounds(t10, t10 + 5),
+  // The use of 't3' is intentional - pointer arithmetic is not
+  // allowed on pointers to void types.
+  array_ptr<void> t11 : bounds(t3, t3 + 5),
+  int *t12 : bounds(t12, t12 + 5),
+  int t13 checked[5] : bounds(t13, t13 + 5),
+  unsigned int t14 checked[5] : bounds(t14, t14 + 5),
+  int t15[5] : bounds(t15, t15 + 5),
+  unsigned int t16[5] : bounds(t16, t16 + 5))
+{
+}
 
-// bounds
-array_ptr<int> g8 : bounds(g8, g8 + 5) = 0;
-// The use of 'g2' is intentional - pointer arithmetic is not
-// allowed on pointers to void types
-array_ptr<void> g9 : bounds(g2, g2 + 5) = g2;
-int g10 checked[5] : bounds(g10, g10 + 5);
-unsigned int g11 checked[5] : bounds(g11, g11 + 5);
-int g12[5] : bounds(g12, g12 + 5);
-unsigned int g13[5] : bounds(g13, g13 + 5);
-int *g14 : count(1) = 0;
+void int_param_var_bounds_decl(
+  int s1 checked[16],
+  int t21 : byte_count(5 * sizeof(int)),
+  long int t22 : byte_count(5 * sizeof(int)),
+  unsigned long int t23 : byte_count(5 * sizeof(int)),
+  enum E1 t24 : byte_count(8),
 
-// Valid bounds declarations for integer-typed global variables.
+  // bounds
+  int t25 : bounds(s1, s1 + 5),
+  long int t26 : bounds(s1, s1 + 5),
+  unsigned long int t27 : bounds(s1, s1 + 5),
+  enum E1 t28 : bounds(s1, s1 + 5))
+{
+}
 
-int s1 checked[16];
+void invalid_param_var_bounds_decl(
+  // count
+  int s1 checked[16],
+  char t41 : count(5),           // expected-error {{expected 't41' to have a pointer or array type}}
+  _Bool t42 : count(5),          // expected-error {{expected 't42' to have a pointer or array type}}
+  short int t43 : count(5),      // expected-error {{expected 't43' to have a pointer or array type}}
+  int t44 : count(5),            // expected-error {{expected 't44' to have a pointer or array type}}
+  long int t45 : count(5),       // expected-error {{expected 't45' to have a pointer or array type}}
+  unsigned short int t46 : count(5), // expected-error {{expected 't46' to have a pointer or array type}}
+  unsigned int t47 : count(5),       // expected-error {{expected 't47' to have a pointer or array type}}
+  unsigned long int t48 : count(5),  // expected-error {{expected 't48' to have a pointer or array type}}
 
-// byte_count
-int g20 : byte_count(5 * sizeof(int)) = (int)s1;
-long int g21 : byte_count(5 * sizeof(int)) = (long int)s1;
-unsigned long int g22 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
-enum E1 g23 : byte_count(8) = EnumVal1;
+  float t49 : count(5),          // expected-error {{expected 't49' to have a pointer or array type}}
+  double t50 : count(5),         // expected-error {{expected 't50' to have a pointer or array type}}
+  struct S1 t51 : count(5),      // expected-error {{expected 't51' to have a pointer or array type}}
+  union U1 t52 : count(5),       // expected-error {{expected 't52' to have a pointer or array type}}
+  enum E1 t53 : count(5),        // expected-error {{expected 't53' to have a pointer or array type}}
+  ptr<int> t54: count(1),        // expected-error {{bounds declaration not allowed because 't54' has a ptr type}}
+  array_ptr<void> t55 : count(1), // expected-error {{expected 't55' to have a non-void pointer type}}
+  void((*t56)(void)) : count(1),  // expected-error {{bounds declaration not allowed because 't56' has a function pointer type}}
 
-// bounds
-int g24 : bounds(s1, s1 + 5) = (int)s1;
-long int g25 : bounds(s1, s1 + 5) = (int)s1;
-unsigned long int g26 : bounds(s1, s1 + 5) = (int)s1;
-enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
+  // byte_count
+  float t60 : byte_count(8),         // expected-error {{expected 't60' to have a pointer, array, or integer type}}
+  double t61 : byte_count(8),        // expected-error {{expected 't61' to have a pointer, array, or integer type}}
+  struct S1 t62 : byte_count(8),     // expected-error {{expected 't62' to have a pointer, array, or integer type}}
+  union U1 t63 : byte_count(8),      // expected-error {{expected 't63' to have a pointer, array, or integer type}}
+  ptr<int> t64 : byte_count(8),      // expected-error {{bounds declaration not allowed because 't64' has a ptr type}}
+  void((*t65)(void)) : byte_count(1),// expected-error {{bounds declaration not allowed because 't65' has a function pointer type}}
 
-// Invalid bounds declarations for global variables
-
-// count
-char g41 : count(5) = 0;           // expected-error {{expected 'g41' to have pointer or array type}}
-_Bool g42 : count(5) = 0;          // expected-error {{expected 'g42' to have pointer or array type}}
-short int g43 : count(5) = 0;      // expected-error {{expected 'g43' to have pointer or array type}}
-int g44 : count(5) = 0;            // expected-error {{expected 'g44' to have pointer or array type}}
-long int g45 : count(5) = 0;       // expected-error {{expected 'g45' to have pointer or array type}}
-unsigned short int g46 : count(5) = 0; // expected-error {{expected 'g46' to have pointer or array type}}
-unsigned int g47 : count(5) = 0;       // expected-error {{expected 'g47' to have pointer or array type}}
-unsigned long int g48 : count(5) = 0;  // expected-error {{expected 'g48' to have pointer or array type}}
-
-float g49 : count(5) = 0;          // expected-error {{expected 'g49' to have pointer or array type}}
-double g50 : count(5) = 0;         // expected-error {{expected 'g50' to have pointer or array type}}
-struct S1 g51 : count(5) = { 0 };  // expected-error {{expected 'g51' to have pointer or array type}}
-union U1 g52 : count(5) = { 0 };   // expected-error {{expected 'g52' to have pointer or array type}}
-enum E1 g53 : count(5) = EnumVal1; // expected-error {{expected 'g53' to have pointer or array type}}
-ptr<int> g54: count(1) = 0;        // expected-error {{bounds declaration not allowed because 'g54' has ptr type}}
-array_ptr<void> g55 : count(1) = 0; // expected-error {{expected 'g55' to have non-void pointer type}}
-
-// byte_count
-float g60 : byte_count(8);             // expected-error {{expected 'g60' to have pointer, array, or integer type}}
-double g61 : byte_count(8);            // expected-error {{expected 'g61' to have pointer, array, or integer type}}
-struct S1 g62 : byte_count(8) = { 0 }; // expected-error {{expected 'g62' to have pointer, array, or integer type}}
-union U1 g63 : byte_count(8) = { 0 };  // expected-error {{expected 'g63' to have pointer, array, or integer type}}
-ptr<int> g64 : byte_count(8) = 0;      // expected-error {{bounds declaration not allowed because 'g64' has ptr type}}
-
-// bounds
-float g70 : bounds(s1, s1 + 1);              // expected-error {{expected 'g70' to have pointer, array, or integer type}}
-double g71 : bounds(s1, s1 + 1);             // expected-error {{expected 'g71' to have pointer, array, or integer type}}
-struct S1 g72 : bounds(s1, s1 + 1) = { 0 };  // expected-error {{expected 'g72' to have pointer, array, or integer type}}
-union U1 g73 : bounds(s1, s1 + 1) = { 0 };  // expected-error {{expected 'g73' to have pointer, array, or integer type}}
-ptr<int> g74 : bounds(s1, s1 + 1) = 0;      // expected-error {{bounds declaration not allowed because 'g74' has ptr type}}
+  // bounds
+  float t70 : bounds(s1, s1 + 1),          // expected-error {{expected 't70' to have a pointer, array, or integer type}}
+  double t71 : bounds(s1, s1 + 1),         // expected-error {{expected 't71' to have a pointer, array, or integer type}}
+  struct S1 t72 : bounds(s1, s1 + 1),      // expected-error {{expected 't72' to have a pointer, array, or integer type}}
+  union U1 t73 : bounds(s1, s1 + 1),       // expected-error {{expected 't73' to have a pointer, array, or integer type}}
+  ptr<int> t74 : bounds(s1, s1 + 1),       // expected-error {{bounds declaration not allowed because 't74' has a ptr type}}
+  void((*t75)(void)) : bounds(s1, s1 + 1) // expected-error {{bounds declaration not allowed because 't75' has a function pointer type}}
+  )
+{
+}
 
 //
 // Test member bounds declarations
 //
 
+//
 // Test valid member bounds declarations
+//
 
 // count
 struct S3 {
   array_ptr<int> f1 : count(5);
-  int f2 checked[5] : count(5);
+  int *f2 : count(5);
+  int f3 checked[5] : count(5);
+  int f3a[5] : count(5);
 };
 
 // byte_count
 struct S4 {
-  array_ptr<int> f3 : byte_count(5 * sizeof(int));
-  int f4 checked[5] : byte_count(5 * sizeof(int));
-  unsigned int f5 checked[5] : byte_count(5 * sizeof(int));
-  unsigned int f6[5] : byte_count(5 * sizeof(int));
-  array_ptr<void> f7 : byte_count(8);
+  array_ptr<int> f4 : byte_count(5 * sizeof(int));
+  array_ptr<void> f5 : byte_count(5 * sizeof(int));
+  int *f6 : byte_count(5 * sizeof(int));
+  int f7 checked[5] : byte_count(5 * sizeof(int));
+  unsigned int f8 checked[5] : byte_count(5 * sizeof(int));
+  unsigned int f9[5] : byte_count(5 * sizeof(int));
 };
 
 // bounds
 struct S6 {
-  array_ptr<int> f8 : bounds(f8, f8 + 5);
-  // The use of 'g2' is intentional - pointer arithmetic is not
+  array_ptr<int> f10 : bounds(f10, f10 + 5);
+  // The use of 'f10' is intentional - pointer arithmetic is not
   // allowed on pointers to void types
-  array_ptr<void> f9 : bounds(f8, f8 + 5);
-  int f10 checked[5] : bounds(f10, f10 + 5);
-  unsigned int f11 checked[5] : bounds(f11, f11 + 5);
-  int f12[5] : bounds(f12, f12 + 5);
-  unsigned int f13[5] : bounds(f13, f13 + 5);
-  int *f14 : count(1);
+  array_ptr<void> f11 : bounds(f10, f10 + 5);
+  int *f12 : bounds(f12, f12 + 5);
+  int f13 checked[5] : bounds(f13, f13 + 5);
+  unsigned int f14 checked[5] : bounds(f14, f14 + 5);
+  int f15[5] : bounds(f15, f15 + 5);
+  unsigned int f16[5] : bounds(f16, f16 + 5);
 };
 
+//
 // Test valid member bounds declarations on integer-typed members
+//
 
 struct S7 {
-  int f1[16];
-  // byte_count
-  int f20 : byte_count(5 * sizeof(int));
-  long int f21 : byte_count(5 * sizeof(int));
-  unsigned long int f22 : byte_count(5 * sizeof(int));
-  enum E1 f23 : byte_count(8);
+  int f1 checked[16];
+  short int f20 : byte_count(5 * sizeof(int));
+  int f21 : byte_count(5 * sizeof(int));
+  long int f22 : byte_count(5 * sizeof(int));
+  unsigned long int f23 : byte_count(5 * sizeof(int));
+  enum E1 f24 : byte_count(8);
 
   // bounds
-  int f24 : bounds(f1, f1 + 5);
-  long int f25 : bounds(f1, f1 + 5);
-  unsigned long int f26 : bounds(f1, f1 + 5);
+  int f25 : bounds(f1, f1 + 5);
+  long int f26 : bounds(f1, f1 + 5);
+  unsigned long int f27 : bounds(f1, f1 + 5);
   enum E1 f28 : bounds(f1, f1 + 5);
+
 };
 
-// Test invalid member bounds declarations for integer-typed members.
+//
+// Test invalid member bounds declarations.
+//
 
 struct s8 {
   // count
-  char g41 : count(5);           // expected-error {{expected 'g41' to have pointer or array type}}
-  _Bool g42 : count(5);          // expected-error {{expected 'g42' to have pointer or array type}}
-  short int g43 : count(5);      // expected-error {{expected 'g43' to have pointer or array type}}
-  int g44 : count(5);            // expected-error {{expected 'g44' to have pointer or array type}}
-  long int g45 : count(5);       // expected-error {{expected 'g45' to have pointer or array type}}
-  unsigned short int g46 : count(5); // expected-error {{expected 'g46' to have pointer or array type}}
-  unsigned int g47 : count(5);       // expected-error {{expected 'g47' to have pointer or array type}}
-  unsigned long int g48 : count(5);  // expected-error {{expected 'g48' to have pointer or array type}}
+  int s1 checked[16];
+  char g41 : count(5);           // expected-error {{expected 'g41' to have a pointer or array type}}
+  _Bool g42 : count(5);          // expected-error {{expected 'g42' to have a pointer or array type}}
+  short int g43 : count(5);      // expected-error {{expected 'g43' to have a pointer or array type}}
+  int g44 : count(5);            // expected-error {{expected 'g44' to have a pointer or array type}}
+  long int g45 : count(5);       // expected-error {{expected 'g45' to have a pointer or array type}}
+  unsigned short int g46 : count(5); // expected-error {{expected 'g46' to have a pointer or array type}}
+  unsigned int g47 : count(5);       // expected-error {{expected 'g47' to have a pointer or array type}}
+  unsigned long int g48 : count(5);  // expected-error {{expected 'g48' to have a pointer or array type}}
 
-  float g49 : count(5);      // expected-error {{expected 'g49' to have pointer or array type}}
-  double g50 : count(5);     // expected-error {{expected 'g50' to have pointer or array type}}
-  struct S1 g51 : count(5);  // expected-error {{expected 'g51' to have pointer or array type}}
-  union U1 g52 : count(5);   // expected-error {{expected 'g52' to have pointer or array type}}
-  enum E1 g53 : count(5);    // expected-error {{expected 'g53' to have pointer or array type}}
-  ptr<int> g54: count(1);    // expected-error {{bounds declaration not allowed because 'g54' has ptr type}}
-  array_ptr<void> g55 : count(1); // expected-error {{expected 'g55' to have non-void pointer type}}
+  float g49 : count(5);           // expected-error {{expected 'g49' to have a pointer or array type}}
+  double g50 : count(5);          // expected-error {{expected 'g50' to have a pointer or array type}}
+  struct S1 g51 : count(5);       // expected-error {{expected 'g51' to have a pointer or array type}}
+  union U1 g52 : count(5);        // expected-error {{expected 'g52' to have a pointer or array type}}
+  enum E1 g53 : count(5);         // expected-error {{expected 'g53' to have a pointer or array type}}
+  ptr<int> g54: count(1);         // expected-error {{bounds declaration not allowed because 'g54' has a ptr type}}
+  array_ptr<void> g55 : count(1); // expected-error {{expected 'g55' to have a non-void pointer type}}
+  void((*g56)(void)) : count(1);  // expected-error {{bounds declaration not allowed because 'g56' has a function pointer type}}
 
   // byte_count
-  float g60 : byte_count(8);       // expected-error {{expected 'g60' to have pointer, array, or integer type}}
-  double g61 : byte_count(8);      // expected-error {{expected 'g61' to have pointer, array, or integer type}}
-  struct S1 g62 : byte_count(8);   // expected-error {{expected 'g62' to have pointer, array, or integer type}}
-  union U1 g63 : byte_count(8);    // expected-error {{expected 'g63' to have pointer, array, or integer type}}
-  ptr<int> g64 : byte_count(8);    // expected-error {{bounds declaration not allowed because 'g64' has ptr type}}
+  float g60 : byte_count(8);      // expected-error {{expected 'g60' to have a pointer, array, or integer type}}
+  double g61 : byte_count(8);     // expected-error {{expected 'g61' to have a pointer, array, or integer type}}
+  struct S1 g62 : byte_count(8);  // expected-error {{expected 'g62' to have a pointer, array, or integer type}}
+  union U1 g63 : byte_count(8);   // expected-error {{expected 'g63' to have a pointer, array, or integer type}}
+  ptr<int> g64 : byte_count(8);   // expected-error {{bounds declaration not allowed because 'g64' has a ptr type}}
+  void((*g65)(void)) : byte_count(1);    // expected-error {{bounds declaration not allowed because 'g65' has a function pointer type}}
 
-  int s1[16];
   // bounds
-  float g70 : bounds(s1, s1 + 1);     // expected-error {{expected 'g70' to have pointer, array, or integer type}}
-  double g71 : bounds(s1, s1 + 1);    // expected-error {{expected 'g71' to have pointer, array, or integer type}}
-  struct S1 g72 : bounds(s1, s1 + 1); // expected-error {{expected 'g72' to have pointer, array, or integer type}}
-  union U1 g73 : bounds(s1, s1 + 1);  // expected-error {{expected 'g73' to have pointer, array, or integer type}}
-  ptr<int> g74 : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'g74' has ptr type}}
+  float g70 : bounds(s1, s1 + 1);          // expected-error {{expected 'g70' to have a pointer, array, or integer type}}
+  double g71 : bounds(s1, s1 + 1);         // expected-error {{expected 'g71' to have a pointer, array, or integer type}}
+  struct S1 g72 : bounds(s1, s1 + 1);      // expected-error {{expected 'g72' to have a pointer, array, or integer type}}
+  union U1 g73 : bounds(s1, s1 + 1);       // expected-error {{expected 'g73' to have a pointer, array, or integer type}}
+  ptr<int> g74 : bounds(s1, s1 + 1);       // expected-error {{bounds declaration not allowed because 'g74' has a ptr type}}
+  void((*g75)(void)) : bounds(s1, s1 + 1); // expected-error {{bounds declaration not allowed because 'g75' has a function pointer type}}
 };
+
+//
+// Test functionr return bounds declarations.
+// 
+
+//
+// Test valid function return bounds declarations
+//
+
+// count
+array_ptr<int> fn1() : count(5) { return 0; }
+int *fn2() : count(5) { return 0; }
+
+// byte_count
+extern array_ptr<int> fn4() : byte_count(5 * sizeof(int));
+extern array_ptr<void> fn5() : byte_count(5 * sizeof(int));
+extern int *fn6() : byte_count(5 * sizeof(int));
+
+// bounds
+array_ptr<int> fn10() : bounds(s1, s1 + 5) { return 0; }
+array_ptr<void> fn11() : bounds(s1, s1 + 5) { return 0; }
+int *fn12() : bounds(s1, s1 + 5) { return 0; }
+
+// Test valid rEturn bounds declarations for integer-typed values
+short int fn20() : byte_count(5 * sizeof(int)) { return (short int) s1; }
+int fn21() : byte_count(5 * sizeof(int)) { return (short int)s1; }
+long int fn22() : byte_count(5 * sizeof(int)) { return (short int)s1; }
+unsigned long int fn23() : byte_count(5 * sizeof(int)) { return (short int)s1; }
+enum E1 fn24() : byte_count(8) { return (short int)s1; }
+
+// bounds
+extern int fn25() : bounds(s1, s1 + 5);
+extern long int fn26() : bounds(s1, s1 + 5);
+extern unsigned long int fn27 : bounds(s1, s1 + 5);
+extern enum E1 fn28() : bounds(s1, s1 + 5);
+
+//
+// Test invalid return bounds declarations
+//
+
+// count
+char fn41() : count(5);         // expected-error {{expected 'fn41' to have a pointer or array return type}}
+_Bool fn42() : count(5);        // expected-error {{expected 'fn42' to have a pointer or array return type}}
+short int fn43() : count(5);    // expected-error {{expected 'fn43' to have a pointer or array return type}}
+int fn44() : count(5);          // expected-error {{expected 'fn44' to have a pointer or array return type}}
+long int fn45() : count(5);     // expected-error {{expected 'fn45' to have a pointer or array return type}}
+unsigned short int fn46() : count(5); // expected-error {{expected 'fn46' to have a pointer or array return type}}
+unsigned int fn47() : count(5);       // expected-error {{expected 'fn47' to have a pointer or array return type}}
+unsigned long int fn48() : count(5);  // expected-error {{expected 'fn48' to have a pointer or array return type}}
+
+float fn49() : count(5);        // expected-error {{expected 'fn49' to have a pointer or array return type}}
+double fn50() : count(5);       // expected-error {{expected 'fn50' to have a pointer or array return type}}
+struct S1 fn51() : count(5);    // expected-error {{expected 'fn51' to have a pointer or array return type}}
+union U1 fn52() : count(5);     // expected-error {{expected 'fn52' to have a pointer or array return type}}
+enum E1 fn53() : count(5);      // expected-error {{expected 'fn53' to have a pointer or array return type}}
+ptr<int> fn54() : count(1);     // expected-error {{bounds declaration not allowed because 'fn54' has a ptr return type}}
+array_ptr<void> fn55() : count(1);     // expected-error {{expected 'fn55' to have a non-void pointer return type}}
+void (*fn56(void) : count(1))(int);    // expected-error {{bounds declaration not allowed because 'fn56' has a function pointer return type}}
+ptr<void(int)> fn57(void) : count(1); // expected-error {{bounds declaration not allowed because 'fn57' has a ptr return type}}
+
+// byte_count
+float fn60() : byte_count(8);     // expected-error {{expected 'fn60' to have a pointer, array, or integer return type}}
+double fn61() : byte_count(8);    // expected-error {{expected 'fn61' to have a pointer, array, or integer return type}}
+struct S1 fn62() : byte_count(8); // expected-error {{expected 'fn62' to have a pointer, array, or integer return type}}
+union U1 fn63() : byte_count(8);  // expected-error {{expected 'fn63' to have a pointer, array, or integer return type}}
+ptr<int> fn64() : byte_count(sizeof(int)); // expected-error {{bounds declaration not allowed because 'fn64' has a ptr return type}}
+void (*fn65(void) : byte_count(1))(int);   // expected-error {{bounds declaration not allowed because 'fn65' has a function pointer return type}}
+ptr<void(int)> fn66(void) : byte_count(1); // expected-error {{bounds declaration not allowed because 'fn66' has a ptr return type}}
+
+// bounds
+float fn70() : bounds(s1, s1 + 1);      // expected-error {{expected 'fn70' to have a pointer, array, or integer return type}}
+double fn71() : bounds(s1, s1 + 1);     // expected-error {{expected 'fn71' to have a pointer, array, or integer return type}}
+struct S1 fn72() : bounds(s1, s1 + 1);  // expected-error {{expected 'fn72' to have a pointer, array, or integer return type}}
+union U1 fn73() : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' to have a pointer, array, or integer return type}}
+ptr<int> fn74() : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a ptr return type}}
+void (*fn75(void) : bounds(s1, s1 + 1))(int);  // expected-error {{bounds declaration not allowed because 'fn75' has a function pointer return type}}
+ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'fn76' has a ptr return type}}

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -10,7 +10,24 @@
 static int A = 8;
 static long long int B = 8;
 
-extern void f1(void) {
+struct S1 {
+  int f;
+};
+
+struct S2 {
+  float f;
+};
+
+union U1 {
+  int f;
+};
+
+enum E1 {
+  EnumVal1,
+  EnumVal2
+};
+
+extern void count_exprs(void) {
 
   char c1 = 8;
   short c2 = 8;
@@ -68,13 +85,13 @@ extern void f1(void) {
 
 // Test expressions involving enum names and member bit fields that can be
 // converted to integer types as arguments to count and byte_count.
-extern void f2(void) {
-  enum E {
+extern void count_exprs_with_integral_operands(void) {
+  enum E2 {
     c1 = 8,
     c2
   };
 
-  struct S {
+  struct S3 {
     int f : 5;
   } s;
   s.f = 8;
@@ -86,29 +103,24 @@ extern void f2(void) {
 
 float globalFloat = 8;
 
+extern void f1(void) {}
+
 // Test types that should not work as arguments for count and byte_count.
-extern void f3(void) {
+extern void invalid_count_exprs(void) {
 
   float c1 = 8.0;
   double c2 = 8.0;
   char *c3 = 0;
   double *c4 = 0;
 
-  struct S1 {
-    int f;
-  } c5 = {0};
-
-  union U1 {
-    int f;
-  } c6 = {0};
+  struct S1 c5 = {0};
+  union U1 c6 = {0};
 
   double c7[10];
 
-  struct S2 {
-    float f;
-  } s = { 8.0 };
+  struct S2 s = { 8.0 };
 
-  void (*func_ptr)(void) = f2;
+  void (*func_ptr)(void) = f1;
 
 #ifndef __STDC_NO_COMPLEX__
  float _Complex c8 = 8.0;
@@ -122,7 +134,7 @@ extern void f3(void) {
   array_ptr<int> t6 : count(c6) = 0;   // expected-error {{invalid argument type}}
   array_ptr<int> t7 : count(c7) = 0;   // expected-error {{invalid argument type}}
   array_ptr<int> t8 : count(s.f) = 0;  // expected-error {{invalid argument type}}
-  array_ptr<int> t9 : count(f2) = 0; // expected-error {{invalid argument type}}
+  array_ptr<int> t9 : count(f1) = 0; // expected-error {{invalid argument type}}
   array_ptr<int> t10 : count(func_ptr) = 0; // expected-error {{invalid argument type}}
   array_ptr<int> t11 : count("test") = 0; // expected-error {{invalid argument type}}
   array_ptr<int> t12 : count(5.0f) = 0; // expected-error {{invalid argument type}}
@@ -150,3 +162,261 @@ extern void f3(void) {
 #endif
 }
 
+//
+// Check bounds declarations
+//
+// We need to check typechecking for the cross-product of (variable or member
+// declaration, scope (local or global), the kind of the bounds expression,
+// type for the variable).
+
+void local_var_bounds_decl(void)
+{
+   // count
+   array_ptr<int> t1 : count(5) = 0;
+   int t2 checked[5] : count(5);
+
+   // byte_count
+   array_ptr<int> t3 : byte_count(5 * sizeof(int)) = 0;
+   int t4 checked[5] : byte_count(5 * sizeof(int));
+   unsigned int t5 checked[5] : byte_count(5 * sizeof(int));
+   array_ptr<void> t6 : byte_count(8) = 0;
+
+   // bounds
+   array_ptr<int> t7 : bounds(t7, t7 + 5) = 0;
+   // The use of 't2' is intentional - pointer arithmetic is not
+   // allowed on pointers to void types.
+   array_ptr<void> t8 : bounds(t2, t2 + 5) = t2;
+   int t9 checked[5] : bounds(t9, t9 + 5);
+   unsigned int t10 checked[5] : bounds(t10, t10 + 5);
+}
+
+void int_local_var_bounds_decl(void) {
+  // bounds declarations are allowed for integer variables to support
+  // casting of pointers to integers and back.  We usually expect this
+  // to happen within expressions, but to allow uniform use of language
+  // features, we allow bounds on integer-typed variables.
+  int t1 checked[5];
+
+  // byte_count
+  short int t2 : byte_count(5 * sizeof(int)) = (short int)t1;
+  int t3 : byte_count(5 * sizeof(int)) = (int)t1;
+  long int t4 : byte_count(5 * sizeof(int)) = (long int)t1;
+  unsigned long int t5 : byte_count(5 * sizeof(int)) = (unsigned long int) t1;
+  enum E1 t6 : byte_count(8) = EnumVal1;
+
+  // bounds
+  int t7 : bounds(t1, t1 + 5) = (int) t1;
+  long int t8 : bounds(t1, t1 + 5) = (int) t1;
+  unsigned long int t9 : bounds(t1, t1 + 5) = (int) t1;
+  enum E1 t10 : bounds(t1, t1 + 5) = (int) t1;
+}
+
+void invalid_local_var_bounds_decl(void)
+{
+  int arr[16];
+  char t1 : count(5) = 0;           // expected-error {{expected 't1' to have pointer or array type}}
+  _Bool t2 : count(5) = 0;          // expected-error {{expected 't2' to have pointer or array type}}
+  short int t3 : count(5) = 0;      // expected-error {{expected 't3' to have pointer or array type}}
+  int t4 : count(5) = 0;            // expected-error {{expected 't4' to have pointer or array type}}
+  long int t5 : count(5) = 0;       // expected-error {{expected 't5' to have pointer or array type}}
+  unsigned short int t6 : count(5) = 0; // expected-error {{expected 't6' to have pointer or array type}}
+  unsigned int t7 : count(5) = 0;       // expected-error {{expected 't7' to have pointer or array type}}
+  unsigned long int t8 : count(5) = 0;  // expected-error {{expected 't8' to have pointer or array type}}
+
+  float t9 : count(5) = 0;          // expected-error {{expected 't9' to have pointer or array type}}
+  double t10 : count(5) = 0;        // expected-error {{expected 't10' to have pointer or array type}}
+  struct S1 t11 : count(5) = { 0 }; // expected-error {{expected 't11' to have pointer or array type}}
+  union U1 t12 : count(5) = { 0 };  // expected-error {{expected 't12' to have pointer or array type}}
+  enum E1 t13 : count(5) = EnumVal1; // expected-error {{expected 't13' to have pointer or array type}}
+
+  int *t14 : count(1) = 0;          // expected-error {{expected local variable 't14' to have array_ptr type}}
+  ptr<int> t15 : count(1) = 0;      // expected-error {{bounds declaration not allowed because 't15' has ptr type}}
+  int t16[5] : count(5);            // expected-error {{expected local variable 't16' to have checked array type}}
+  array_ptr<void> t17 : count(1) = 0; // expected-error {{expected 't17' to have non-void pointer type}}
+
+  // byte_count
+  float t30 : byte_count(8);              // expected-error {{expected 't30' to have pointer, array, or integer type}}
+  double t31 : byte_count(8);             // expected-error {{expected 't31' to have pointer, array, or integer type}}
+  struct S1 t32 : byte_count(8) = { 0 };  // expected-error {{expected 't32' to have pointer, array, or integer type}}
+  union U1 t33 : byte_count(8) = { 0 } ;  // expected-error {{expected 't33' to have pointer, array, or integer type}}
+
+  int *t34 : byte_count(sizeof(int)) = 0;       // expected-error {{expected local variable 't34' to have array_ptr type}}
+  ptr<int> t35 : byte_count(sizeof(int)) = 0;   // expected-error {{bounds declaration not allowed because 't35' has ptr type}}
+  int t36[5] : byte_count(5 * sizeof(int));     // expected-error {{expected local variable 't36' to have checked array type}}
+
+  // bounds
+  float t40 : bounds(arr, arr + 1);              // expected-error {{expected 't40' to have pointer, array, or integer type}}
+  double t41 : bounds(arr, arr + 1);             // expected-error {{expected 't41' to have pointer, array, or integer type}}
+  struct S1 t42 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't42' to have pointer, array, or integer type}}
+  union U1 t43 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't43' to have pointer, array, or integer type}}
+
+  int *t44 : bounds(arr, arr + 1) = 0;          // expected-error {{expected local variable 't44' to have array_ptr type}}
+  ptr<int> t45 : bounds(arr, arr + 1) = 0;      // expected-error {{bounds declaration not allowed because 't45' has ptr type}}
+  int t46[5] : bounds(arr, arr + 1);            // expected-error {{expected local variable 't46' to have checked array type}}
+}
+
+//
+// Test global variable declarations
+//
+
+// Valid bounds declarations for global variables
+
+// count
+array_ptr<int> g1 : count(5) = 0;
+int g2 checked[5] : count(5);
+
+// byte_count
+array_ptr<int> g3 : byte_count(5 * sizeof(int)) = 0;
+int g4 checked[5] : byte_count(5 * sizeof(int));
+unsigned int g5 checked[5] : byte_count(5 * sizeof(int));
+unsigned int g6[5] : byte_count(5 * sizeof(int));
+array_ptr<void> g7 : byte_count(8) = 0;
+
+// bounds
+array_ptr<int> g8 : bounds(g8, g8 + 5) = 0;
+// The use of 'g2' is intentional - pointer arithmetic is not
+// allowed on pointers to void types
+array_ptr<void> g9 : bounds(g2, g2 + 5) = g2;
+int g10 checked[5] : bounds(g10, g10 + 5);
+unsigned int g11 checked[5] : bounds(g11, g11 + 5);
+int g12[5] : bounds(g12, g12 + 5);
+unsigned int g13[5] : bounds(g13, g13 + 5);
+int *g14 : count(1) = 0;
+
+// Valid bounds declarations for integer-typed global variables.
+
+int s1 checked[16];
+
+// byte_count
+int g20 : byte_count(5 * sizeof(int)) = (int)s1;
+long int g21 : byte_count(5 * sizeof(int)) = (long int)s1;
+unsigned long int g22 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
+enum E1 g23 : byte_count(8) = EnumVal1;
+
+// bounds
+int g24 : bounds(s1, s1 + 5) = (int)s1;
+long int g25 : bounds(s1, s1 + 5) = (int)s1;
+unsigned long int g26 : bounds(s1, s1 + 5) = (int)s1;
+enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
+
+// Invalid bounds declarations for global variables
+
+// count
+char g41 : count(5) = 0;           // expected-error {{expected 'g41' to have pointer or array type}}
+_Bool g42 : count(5) = 0;          // expected-error {{expected 'g42' to have pointer or array type}}
+short int g43 : count(5) = 0;      // expected-error {{expected 'g43' to have pointer or array type}}
+int g44 : count(5) = 0;            // expected-error {{expected 'g44' to have pointer or array type}}
+long int g45 : count(5) = 0;       // expected-error {{expected 'g45' to have pointer or array type}}
+unsigned short int g46 : count(5) = 0; // expected-error {{expected 'g46' to have pointer or array type}}
+unsigned int g47 : count(5) = 0;       // expected-error {{expected 'g47' to have pointer or array type}}
+unsigned long int g48 : count(5) = 0;  // expected-error {{expected 'g48' to have pointer or array type}}
+
+float g49 : count(5) = 0;          // expected-error {{expected 'g49' to have pointer or array type}}
+double g50 : count(5) = 0;         // expected-error {{expected 'g50' to have pointer or array type}}
+struct S1 g51 : count(5) = { 0 };  // expected-error {{expected 'g51' to have pointer or array type}}
+union U1 g52 : count(5) = { 0 };   // expected-error {{expected 'g52' to have pointer or array type}}
+enum E1 g53 : count(5) = EnumVal1; // expected-error {{expected 'g53' to have pointer or array type}}
+ptr<int> g54: count(1) = 0;        // expected-error {{bounds declaration not allowed because 'g54' has ptr type}}
+array_ptr<void> g55 : count(1) = 0; // expected-error {{expected 'g55' to have non-void pointer type}}
+
+// byte_count
+float g60 : byte_count(8);             // expected-error {{expected 'g60' to have pointer, array, or integer type}}
+double g61 : byte_count(8);            // expected-error {{expected 'g61' to have pointer, array, or integer type}}
+struct S1 g62 : byte_count(8) = { 0 }; // expected-error {{expected 'g62' to have pointer, array, or integer type}}
+union U1 g63 : byte_count(8) = { 0 };  // expected-error {{expected 'g63' to have pointer, array, or integer type}}
+ptr<int> g64 : byte_count(8) = 0;      // expected-error {{bounds declaration not allowed because 'g64' has ptr type}}
+
+// bounds
+float g70 : bounds(s1, s1 + 1);              // expected-error {{expected 'g70' to have pointer, array, or integer type}}
+double g71 : bounds(s1, s1 + 1);             // expected-error {{expected 'g71' to have pointer, array, or integer type}}
+struct S1 g72 : bounds(s1, s1 + 1) = { 0 };  // expected-error {{expected 'g72' to have pointer, array, or integer type}}
+union U1 g73 : bounds(s1, s1 + 1) = { 0 };  // expected-error {{expected 'g73' to have pointer, array, or integer type}}
+ptr<int> g74 : bounds(s1, s1 + 1) = 0;      // expected-error {{bounds declaration not allowed because 'g74' has ptr type}}
+
+//
+// Test member bounds declarations
+//
+
+// Test valid member bounds declarations
+
+// count
+struct S3 {
+  array_ptr<int> f1 : count(5);
+  int f2 checked[5] : count(5);
+};
+
+// byte_count
+struct S4 {
+  array_ptr<int> f3 : byte_count(5 * sizeof(int));
+  int f4 checked[5] : byte_count(5 * sizeof(int));
+  unsigned int f5 checked[5] : byte_count(5 * sizeof(int));
+  unsigned int f6[5] : byte_count(5 * sizeof(int));
+  array_ptr<void> f7 : byte_count(8);
+};
+
+// bounds
+struct S6 {
+  array_ptr<int> f8 : bounds(f8, f8 + 5);
+  // The use of 'g2' is intentional - pointer arithmetic is not
+  // allowed on pointers to void types
+  array_ptr<void> f9 : bounds(f8, f8 + 5);
+  int f10 checked[5] : bounds(f10, f10 + 5);
+  unsigned int f11 checked[5] : bounds(f11, f11 + 5);
+  int f12[5] : bounds(f12, f12 + 5);
+  unsigned int f13[5] : bounds(f13, f13 + 5);
+  int *f14 : count(1);
+};
+
+// Test valid member bounds declarations on integer-typed members
+
+struct S7 {
+  int f1[16];
+  // byte_count
+  int f20 : byte_count(5 * sizeof(int));
+  long int f21 : byte_count(5 * sizeof(int));
+  unsigned long int f22 : byte_count(5 * sizeof(int));
+  enum E1 f23 : byte_count(8);
+
+  // bounds
+  int f24 : bounds(f1, f1 + 5);
+  long int f25 : bounds(f1, f1 + 5);
+  unsigned long int f26 : bounds(f1, f1 + 5);
+  enum E1 f28 : bounds(f1, f1 + 5);
+};
+
+// Test invalid member bounds declarations for integer-typed members.
+
+struct s8 {
+  // count
+  char g41 : count(5);           // expected-error {{expected 'g41' to have pointer or array type}}
+  _Bool g42 : count(5);          // expected-error {{expected 'g42' to have pointer or array type}}
+  short int g43 : count(5);      // expected-error {{expected 'g43' to have pointer or array type}}
+  int g44 : count(5);            // expected-error {{expected 'g44' to have pointer or array type}}
+  long int g45 : count(5);       // expected-error {{expected 'g45' to have pointer or array type}}
+  unsigned short int g46 : count(5); // expected-error {{expected 'g46' to have pointer or array type}}
+  unsigned int g47 : count(5);       // expected-error {{expected 'g47' to have pointer or array type}}
+  unsigned long int g48 : count(5);  // expected-error {{expected 'g48' to have pointer or array type}}
+
+  float g49 : count(5);      // expected-error {{expected 'g49' to have pointer or array type}}
+  double g50 : count(5);     // expected-error {{expected 'g50' to have pointer or array type}}
+  struct S1 g51 : count(5);  // expected-error {{expected 'g51' to have pointer or array type}}
+  union U1 g52 : count(5);   // expected-error {{expected 'g52' to have pointer or array type}}
+  enum E1 g53 : count(5);    // expected-error {{expected 'g53' to have pointer or array type}}
+  ptr<int> g54: count(1);    // expected-error {{bounds declaration not allowed because 'g54' has ptr type}}
+  array_ptr<void> g55 : count(1); // expected-error {{expected 'g55' to have non-void pointer type}}
+
+  // byte_count
+  float g60 : byte_count(8);       // expected-error {{expected 'g60' to have pointer, array, or integer type}}
+  double g61 : byte_count(8);      // expected-error {{expected 'g61' to have pointer, array, or integer type}}
+  struct S1 g62 : byte_count(8);   // expected-error {{expected 'g62' to have pointer, array, or integer type}}
+  union U1 g63 : byte_count(8);    // expected-error {{expected 'g63' to have pointer, array, or integer type}}
+  ptr<int> g64 : byte_count(8);    // expected-error {{bounds declaration not allowed because 'g64' has ptr type}}
+
+  int s1[16];
+  // bounds
+  float g70 : bounds(s1, s1 + 1);     // expected-error {{expected 'g70' to have pointer, array, or integer type}}
+  double g71 : bounds(s1, s1 + 1);    // expected-error {{expected 'g71' to have pointer, array, or integer type}}
+  struct S1 g72 : bounds(s1, s1 + 1); // expected-error {{expected 'g72' to have pointer, array, or integer type}}
+  union U1 g73 : bounds(s1, s1 + 1);  // expected-error {{expected 'g73' to have pointer, array, or integer type}}
+  ptr<int> g74 : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'g74' has ptr type}}
+};


### PR DESCRIPTION
There is a pull request for the checked-clang repo (https://github.com/Microsoft/checkedc-clang/pull/42) that adds checking of type requirements for bounds declarations to clang.  See the pull request for details. 

This commit adds the matching tests.   It includes both positive tests (that are supposed to work) and negative tests that should fail with an error message.    We have added the expected error message from the clang implementation for the negative tests, so that the tests can be used in the clang test infrastructure.  This commit also fixes issues in existing tests that the checking uncovered.
