### PR TITLE
Change Checked C keywords to avoid conflicts with existing identifiers.

### DIFF
--- a/include/stdchecked.h
+++ b/include/stdchecked.h
@@ -1,0 +1,10 @@
+#ifndef __STDCHECKED_H
+#define __STDCHECKED_H
+
+#define ptr _Ptr
+#define array_ptr _Array_ptr
+#define checked _Checked
+#define unchecked _Unchecked
+#define where _Where
+
+#endif /* __STDCHECKED_H */

--- a/tests/parsing/checked_array_types.c
+++ b/tests/parsing/checked_array_types.c
@@ -16,6 +16,8 @@
 // parameter have new checked array types
 //
 
+#include "../../include/stdchecked.h"
+
 extern void f1(int a checked[], int y) {
 }
 

--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -4,6 +4,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
+#include "../../include/stdchecked.h"
 
 // Top level declarations with different storage classes and
 // storage classes omitted.

--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -4,6 +4,8 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
+#include "../../include/stdchecked.h"
+
 struct S1 {
   array_ptr<int> arr : count(5);
 };

--- a/tests/parsing/parameter_bounds.c
+++ b/tests/parsing/parameter_bounds.c
@@ -4,6 +4,8 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
+#include "../../include/stdchecked.h"
+
 extern void f1(array_ptr<int> arr : count(5)) {
 }
 

--- a/tests/parsing/pointer_types.c
+++ b/tests/parsing/pointer_types.c
@@ -13,6 +13,7 @@
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 // expected-no-diagnostics
 
+#include "../../include/stdchecked.h"
 
 //
 // parameter have new pointer types

--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -5,6 +5,8 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
+#include "../../include/stdchecked.h"
+
 // Parsing of function declarations
 extern array_ptr<void> alloc(unsigned size) : byte_count(size);
 extern array_ptr<int> f2(array_ptr<int> arr : count(5)) : count(3 + 2);

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -7,6 +7,8 @@
 // Test expressions with standard signed and unsigned integers types as
 // arguments to count and byte_count.
 
+#include "../../include/stdchecked.h"
+
 static int A = 8;
 static long long int B = 8;
 

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -274,9 +274,21 @@ extern void bounds_exprs(void) {
 
    array_ptr<char> char_array_ptr_lb = (array_ptr<char>) i, char_array_ptr_ub = (array_ptr<char>) i + 1;
    ptr<char> char_ptr_lb = (ptr<char>) i, char_ptr_ub = (ptr<char>)  (i + 1);
-   int *char_unchecked_ptr_lb = i, *char_unchecked_ptr_ub = i + 1;
+   char *char_unchecked_ptr_lb = (char *) i, *char_unchecked_ptr_ub = (char *) i + 1;
 
-   array_ptr<int> t17 : bounds(int_array_ptr_lb, char_array_ptr_ub) = i; // expected-error {{pointer type mismatch}}
+   array_ptr<int> t20 : bounds(int_array_ptr_lb, char_array_ptr_ub) = i;     // expected-error {{pointer type mismatch}}
+   array_ptr<int> t21 : bounds(int_ptr_lb, char_array_ptr_ub) = i;           // expected-error {{pointer type mismatch}}
+   array_ptr<int> t22 : bounds(int_unchecked_ptr_lb, char_array_ptr_ub) = i; // expected-error {{pointer type mismatch}}
+   array_ptr<char> t23 : bounds(char_array_ptr_lb, int_array_ptr_ub) = (array_ptr<char>) i;     // expected-error {{pointer type mismatch}}
+   array_ptr<char> t24 : bounds(char_ptr_lb, int_array_ptr_ub) = (array_ptr<char>) i;           // expected-error {{pointer type mismatch}}
+   array_ptr<char> t25 : bounds(char_unchecked_ptr_lb, int_array_ptr_ub) = (array_ptr<char>) i; // expected-error {{pointer type mismatch}}
+
+   array_ptr<int> t30 : bounds(int_array_ptr_lb, char_ptr_ub) = i;     // expected-error {{pointer type mismatch}}
+   array_ptr<int> t31 : bounds(int_ptr_lb, char_ptr_ub) = i;           // expected-error {{pointer type mismatch}}
+   array_ptr<int> t32 : bounds(int_unchecked_ptr_lb, char_ptr_ub) = i; // expected-error {{pointer type mismatch}}
+   array_ptr<char> t33 : bounds(char_array_ptr_lb, int_ptr_ub) = (array_ptr<char>) i;     // expected-error {{pointer type mismatch}}
+   array_ptr<char> t34 : bounds(char_ptr_lb, int_ptr_ub) = (array_ptr<char>) i;           // expected-error {{pointer type mismatch}}
+   array_ptr<char> t35 : bounds(char_unchecked_ptr_lb, int_ptr_ub) = (array_ptr<char>) i; // expected-error {{pointer type mismatch}}
 }
 
 //

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -179,6 +179,13 @@ extern void bounds_exprs(void) {
    array_ptr<int> t8 : bounds(ptr_lb, unchecked_ptr_ub) = i;
    array_ptr<int> t9 : bounds(unchecked_ptr_lb, unchecked_ptr_ub);
 
+   // use an array-typed value as the lower bound.  This value
+   // should be converted implicitly to be a pointer type.
+
+   array_ptr<int> t10 : bounds(i, i + 1) = i;
+   array_ptr<int> t11 : bounds(i, array_ptr_ub) = i;
+   array_ptr<int> t13 : bounds(i, ptr_ub) = i;
+
    array_ptr<void> void_array_ptr_lb = i, void_array_ptr_ub = i + 1;
    ptr<void> void_ptr_lb = i, void_ptr_ub = i + 1;
    void *void_unchecked_ptr_lb = i, *void_unchecked_ptr_ub = i + 1;
@@ -213,7 +220,7 @@ extern void bounds_exprs(void) {
    array_ptr<int> t55 : bounds(void_ptr_lb, unchecked_ptr_ub) = i;
    array_ptr<int> t56 : bounds(ptr_lb, void_unchecked_ptr_ub) = i;
 
-   // spot check cases array the value being declared has a different pointer type
+   // spot check cases where the value being declared has a different pointer type
    // than the bounds.
    array_ptr<char> t71 : bounds(array_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
    array_ptr<char> t72 : bounds(ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
@@ -221,6 +228,11 @@ extern void bounds_exprs(void) {
    array_ptr<char> t75 : bounds(void_array_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
    array_ptr<char> t76 : bounds(void_unchecked_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
    array_ptr<char> t77 : bounds(array_ptr_lb, void_unchecked_ptr_ub) = (array_ptr<char>) i;
+
+   // use an array-typed value as the lower bound.  This should be converted
+   // implicitly to be a pointer type.
+   array_ptr<char> t78 : bounds(i, array_ptr_ub) = (array_ptr<char>) i;
+   array_ptr<char> t79 : bounds(i, ptr_ub) = (array_ptr<char>) i;
 
    // spot check that typechecking looks through typedefs
    typedef array_ptr<int> int_array_ptr;
@@ -240,6 +252,54 @@ extern void bounds_exprs(void) {
    array_ptr<int> t97 : bounds(unchecked_ptr_lb, typedef_ptr_ub) = i;
    array_ptr<int> t98 : bounds(ptr_lb, typedef_unchecked_ptr_ub) = i;
    array_ptr<int> t99 : bounds(typedef_unchecked_ptr_lb, unchecked_ptr_ub);
+
+   // check that type qualifiers are discarded when comparing pointer types
+   // in bounds expressions
+
+   // permutations of array_ptr and const
+   array_ptr<const int> array_ptr_const_lb = i;
+   const array_ptr<int> const_array_ptr_lb = i;
+   const array_ptr<const int> const_array_ptr_const_lb = i;
+   array_ptr<const int> array_ptr_const_ub = i + 1;
+   const array_ptr<int> const_array_ptr_ub = i + 1;
+   const array_ptr<const int> const_array_ptr_const_ub = i + 1;
+
+   // permutations of ptr and const
+   ptr<int const> ptr_const_lb = i;
+   const ptr<int> const_ptr_lb = i;
+   const ptr<const int> const_ptr_const_lb = i;
+   ptr<int const> ptr_const_ub = i + 1;
+   const ptr<int> const_ptr_ub = i + 1;
+   const ptr<const int> const_ptr_const_ub = i + 1;
+
+   // permutations of unchecked pointers and const
+   int *const const_unchecked_ptr_lb = i;
+   const int *unchecked_ptr_const_lb = i;
+   const int *const const_unchecked_ptr_const_lb = i;
+   int *const const_unchecked_ptr_ub = i + 1;
+   const int *unchecked_ptr_const_ub = i + 1;
+   const int *const const_unchecked_ptr_const_ub = i + 1;
+
+   array_ptr<int> t121 : bounds(array_ptr_const_lb, array_ptr_ub) = i;
+   array_ptr<int> t122 : bounds(const_array_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t123 : bounds(const_array_ptr_const_lb, array_ptr_ub) = i;
+
+   array_ptr<int> t124 : bounds(array_ptr_lb, array_ptr_const_ub) = i;
+   array_ptr<int> t125 : bounds(array_ptr_lb, const_array_ptr_ub) = i;
+   array_ptr<int> t126 : bounds(array_ptr_lb, const_array_ptr_const_ub) = i;
+
+   array_ptr<int> t127 : bounds(const_array_ptr_lb, array_ptr_const_ub) = i;
+   array_ptr<int> t128 : bounds(array_ptr_const_lb, const_array_ptr_ub) = i;
+   array_ptr<int> t129 : bounds(const_array_ptr_const_lb, const_array_ptr_const_ub) = i;
+
+   array_ptr<int> t130 : bounds(ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t131 : bounds(array_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t132 : bounds(unchecked_ptr_lb, array_ptr_ub);
+   array_ptr<int> t133 : bounds(array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t134 : bounds(ptr_lb, ptr_ub) = i;
+   array_ptr<int> t135 : bounds(unchecked_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t136 : bounds(ptr_lb, unchecked_ptr_ub) = i;
+   array_ptr<int> t137 : bounds(unchecked_ptr_lb, unchecked_ptr_ub);
  }
 
  extern void invalid_bounds_exprs(void) {
@@ -263,6 +323,8 @@ extern void bounds_exprs(void) {
    union U1 c15 = { 0 };
 
    void(*func_ptr)(void) = test_func;
+   int *single_indir = 0;
+   int **double_indir = 0;
 
 #ifndef __STDC_NO_COMPLEX__
    float _Complex c17 = 8.0;
@@ -284,6 +346,10 @@ extern void bounds_exprs(void) {
    array_ptr<int> t14 : bounds(c14, c14) = 0; // expected-error 2 {{expected expression with pointer type}}
    array_ptr<int> t15 : bounds(c15, c15) = 0; // expected-error 2 {{expected expression with pointer type}}
    array_ptr<int> t16 : bounds(test_func, test_func) = 0; // expected-error 2 {{invalid argument type 'void (*)(void)' to bounds expression}}
+
+   // have values with different levels of indirection
+   array_ptr<int> t17 : bounds(double_indir, c3) = 0; // expected-error {{expected expression with pointer type}}
+   array_ptr<int> t18 : bounds(double_indir, single_indir) = 0; // expected-error {{pointer type mismatch}}
 
    // test mismatched bounds expression types
    int i[2];

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -161,6 +161,124 @@ extern void invalid_count_exprs(void) {
 #endif
 }
 
+extern void bounds_exprs(void) {
+   int i[2];
+   // check combinations of different kinds of pointers to the same
+   // object type.
+
+   array_ptr<int> array_ptr_lb = i, array_ptr_ub = i + 1;
+   ptr<int> ptr_lb = i, ptr_ub = i + 1;
+   int *unchecked_ptr_lb = i, *unchecked_ptr_ub = i + 1;
+   array_ptr<int> t1 : bounds(array_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t2 : bounds(ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t3 : bounds(array_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t4 : bounds(unchecked_ptr_lb, array_ptr_ub);
+   array_ptr<int> t5 : bounds(array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t6 : bounds(ptr_lb, ptr_ub) = i;
+   array_ptr<int> t7 : bounds(unchecked_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t8 : bounds(ptr_lb, unchecked_ptr_ub) = i;
+   array_ptr<int> t9 : bounds(unchecked_ptr_lb, unchecked_ptr_ub);
+
+   array_ptr<void> void_array_ptr_lb = i, void_array_ptr_ub = i + 1;
+   ptr<void> void_ptr_lb = i, void_ptr_ub = i + 1;
+   void *void_unchecked_ptr_lb = i, *void_unchecked_ptr_ub = i + 1;
+
+   // check combinations of differents kinds of pointers to void
+   array_ptr<int> t21 : bounds(void_array_ptr_lb, void_array_ptr_ub) = i;
+   array_ptr<int> t22 : bounds(void_ptr_lb, void_array_ptr_ub) = i;
+   array_ptr<int> t23 : bounds(void_array_ptr_lb, void_ptr_ub) = i;
+   array_ptr<int> t24 : bounds(void_unchecked_ptr_lb, void_array_ptr_ub);
+   array_ptr<int> t25 : bounds(void_array_ptr_lb, void_unchecked_ptr_ub);
+   array_ptr<int> t26 : bounds(void_ptr_lb, void_ptr_ub) = i;
+   array_ptr<int> t27 : bounds(void_unchecked_ptr_lb, void_ptr_ub) = i;
+   array_ptr<int> t28 : bounds(void_ptr_lb, void_unchecked_ptr_ub) = i;
+   array_ptr<int> t29 : bounds(void_unchecked_ptr_lb, void_unchecked_ptr_ub);
+
+   // check combinations of pointers to void and pointers to non-void types
+
+   array_ptr<int> t42 : bounds(array_ptr_lb, void_array_ptr_ub) = i;
+   array_ptr<int> t43 : bounds(ptr_lb, void_array_ptr_ub) = i;
+   array_ptr<int> t44 : bounds(void_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t45 : bounds(void_array_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t46 : bounds(array_ptr_lb, void_ptr_ub) = i;
+   array_ptr<int> t47 : bounds(unchecked_ptr_lb, void_array_ptr_ub);
+   array_ptr<int> t48 : bounds(void_unchecked_ptr_lb, array_ptr_ub);
+   array_ptr<int> t49 : bounds(void_array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t50 : bounds(array_ptr_lb, void_unchecked_ptr_ub);
+
+   array_ptr<int> t51 : bounds(void_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t52 : bounds(ptr_lb, void_ptr_ub) = i;
+   array_ptr<int> t53 : bounds(unchecked_ptr_lb, void_ptr_ub) = i;
+   array_ptr<int> t54 : bounds(void_unchecked_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t55 : bounds(void_ptr_lb, unchecked_ptr_ub) = i;
+   array_ptr<int> t56 : bounds(ptr_lb, void_unchecked_ptr_ub) = i;
+
+   // spot check cases array the value being declared has a different pointer type
+   // than the bounds.
+   array_ptr<char> t71 : bounds(array_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
+   array_ptr<char> t72 : bounds(ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
+   array_ptr<char> t73 : bounds(unchecked_ptr_lb, ptr_ub) = (array_ptr<char>) i;
+   array_ptr<char> t75 : bounds(void_array_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
+   array_ptr<char> t76 : bounds(void_unchecked_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
+   array_ptr<char> t77 : bounds(array_ptr_lb, void_unchecked_ptr_ub) = (array_ptr<char>) i;
+ }
+
+ extern void invalid_bounds_exprs(void) {
+   // test types that should not work as arguments to bounds expressions
+   char c1 = 8;
+   short c2 = 8;
+   int c3 = 8;
+   long int c4 = 8;
+   long long int c5 = 8;
+
+   _Bool c6 = 1;
+   unsigned char c7 = 8;
+   unsigned short c8 = 8;
+   unsigned int c9 = 8;
+   unsigned long int c10 = 8;
+   unsigned long long int c11 = 8;
+
+   float c12 = 8.0;
+   double c13 = 8.0;
+   struct S1 c14 = { 0 };
+   union U1 c15 = { 0 };
+
+   void(*func_ptr)(void) = test_func;
+
+#ifndef __STDC_NO_COMPLEX__
+   float _Complex c17 = 8.0;
+#endif
+
+   array_ptr<int> t1 : bounds(c1, c1) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t2 : bounds(c2, c2) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t3 : bounds(c3, c3) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t4 : bounds(c4, c4) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t5 : bounds(c5, c5) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t6 : bounds(c6, c6) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t7 : bounds(c7, c7) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t8 : bounds(c8, c8) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t9 : bounds(c9, c9) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t10 : bounds(c10, c10) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t11 : bounds(c11, c11) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t12 : bounds(c12, c12) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t13 : bounds(c13, c13) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t14 : bounds(c14, c14) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t15 : bounds(c15, c15) = 0; // expected-error 2 {{expected expression with pointer type}}
+   array_ptr<int> t16 : bounds(test_func, test_func) = 0; // expected-error 2 {{invalid argument type 'void (*)(void)' to bounds expression}}
+
+   // test mismatched bounds expression types
+   int i[2];
+   array_ptr<int> int_array_ptr_lb = i, int_array_ptr_ub = i + 1;
+   ptr<int> int_ptr_lb = i, int_ptr_ub = i + 1;
+   int *int_unchecked_ptr_lb = i, *int_unchecked_ptr_ub = i + 1;
+
+   array_ptr<char> char_array_ptr_lb = (array_ptr<char>) i, char_array_ptr_ub = (array_ptr<char>) i + 1;
+   ptr<char> char_ptr_lb = (ptr<char>) i, char_ptr_ub = (ptr<char>)  (i + 1);
+   int *char_unchecked_ptr_lb = i, *char_unchecked_ptr_ub = i + 1;
+
+   array_ptr<int> t17 : bounds(int_array_ptr_lb, char_array_ptr_ub) = i; // expected-error {{pointer type mismatch}}
+}
+
 //
 // Test type requirements for bounds declarations.   There are various 
 // requirements for the types of variables with bounds declaration.

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -221,6 +221,25 @@ extern void bounds_exprs(void) {
    array_ptr<char> t75 : bounds(void_array_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
    array_ptr<char> t76 : bounds(void_unchecked_ptr_lb, array_ptr_ub) = (array_ptr<char>) i;
    array_ptr<char> t77 : bounds(array_ptr_lb, void_unchecked_ptr_ub) = (array_ptr<char>) i;
+
+   // spot check that typechecking looks through typedefs
+   typedef array_ptr<int> int_array_ptr;
+   typedef ptr<int> int_ptr;
+   typedef int *int_unchecked_ptr;
+
+   int_array_ptr typedef_array_ptr_lb = i, typedef_array_ptr_ub = i + 1;
+   int_ptr typedef_ptr_lb = i, typedef_ptr_ub = i + 1;
+   int_unchecked_ptr typedef_unchecked_ptr_lb = i, typedef_unchecked_ptr_ub = i + 1;
+
+   array_ptr<int> t91 : bounds(typedef_array_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t92 : bounds(ptr_lb, typedef_array_ptr_ub) = i;
+   array_ptr<int> t93 : bounds(array_ptr_lb, typedef_ptr_ub) = i;
+   array_ptr<int> t94 : bounds(typedef_unchecked_ptr_lb, array_ptr_ub);
+   array_ptr<int> t95 : bounds(typedef_array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t96 : bounds(typedef_ptr_lb, ptr_ub) = i;
+   array_ptr<int> t97 : bounds(unchecked_ptr_lb, typedef_ptr_ub) = i;
+   array_ptr<int> t98 : bounds(ptr_lb, typedef_unchecked_ptr_ub) = i;
+   array_ptr<int> t99 : bounds(typedef_unchecked_ptr_lb, unchecked_ptr_ub);
  }
 
  extern void invalid_bounds_exprs(void) {

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -4,6 +4,8 @@
 // RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
+#include "../../include/stdchecked.h"
+
 extern void check_indirection_unchecked(int p[10], const int const_p[10], int y) {
   *p = y;
   y = *p;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -4,6 +4,8 @@
 // RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
+#include "../../include/stdchecked.h"
+
 extern void check_indirection_unsafe_ptr(int *p, const int *const_p, int y) {
 	*p = y;
 	y = *p;


### PR DESCRIPTION
We're updating the clang implementation so that Checked C keywords start with an underscore and a capital letter. This avoids conflicts with existing C identifiers.

The keyword change follows the rules in the C Standard: all identifiers beginning with an underscore followed by a capital letter or underscore are reserved for implementation use.  This allows them to be used for language extensions without conflicting with existing identifiers. Of course, some programs do not follow the standard and use these identifiers.

This change adds a header file stdchecked.h that has macros that maps the existing non-prefix, lower case keywords to the new keywords.  It updates the tests to include that header file.

Testing:
- Updated version of clang passes these new tests.


