### PR TITLE
Fix test breaks due to type rename.

### DIFF
--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -470,7 +470,7 @@ double g50 : count(5) = 0;          // expected-error {{expected 'g50' to have a
 struct S1 g51 : count(5) = { 0 };   // expected-error {{expected 'g51' to have a pointer or array type}}
 union U1 g52 : count(5) = { 0 };    // expected-error {{expected 'g52' to have a pointer or array type}}
 enum E1 g53 : count(5) = EnumVal1;  // expected-error {{expected 'g53' to have a pointer or array type}}
-ptr<int> g54: count(1) = 0;         // expected-error {{bounds declaration not allowed because 'g54' has a ptr type}}
+ptr<int> g54: count(1) = 0;         // expected-error {{bounds declaration not allowed because 'g54' has a _Ptr type}}
 array_ptr<void> g55 : count(1) = 0; // expected-error {{expected 'g55' to have a non-void pointer type}}
 void((*g56)(void)) : count(1);      // expected-error {{bounds declaration not allowed because 'g56' has a function pointer type}}
 
@@ -479,7 +479,7 @@ float g60 : byte_count(8);             // expected-error {{expected 'g60' to hav
 double g61 : byte_count(8);            // expected-error {{expected 'g61' to have a pointer, array, or integer type}}
 struct S1 g62 : byte_count(8) = { 0 }; // expected-error {{expected 'g62' to have a pointer, array, or integer type}}
 union U1 g63 : byte_count(8) = { 0 };  // expected-error {{expected 'g63' to have a pointer, array, or integer type}}
-ptr<int> g64 : byte_count(8) = 0;      // expected-error {{bounds declaration not allowed because 'g64' has a ptr type}}
+ptr<int> g64 : byte_count(8) = 0;      // expected-error {{bounds declaration not allowed because 'g64' has a _Ptr type}}
 void((*g65)(void)) : byte_count(1);    // expected-error {{bounds declaration not allowed because 'g65' has a function pointer type}}
 
 // bounds
@@ -487,7 +487,7 @@ float g70 : bounds(s1, s1 + 1);             // expected-error {{expected 'g70' t
 double g71 : bounds(s1, s1 + 1);            // expected-error {{expected 'g71' to have a pointer, array, or integer type}}
 struct S1 g72 : bounds(s1, s1 + 1) = { 0 }; // expected-error {{expected 'g72' to have a pointer, array, or integer type}}
 union U1 g73 : bounds(s1, s1 + 1) = { 0 };  // expected-error {{expected 'g73' to have a pointer, array, or integer type}}
-ptr<int> g74 : bounds(s1, s1 + 1) = 0;      // expected-error {{bounds declaration not allowed because 'g74' has a ptr type}}
+ptr<int> g74 : bounds(s1, s1 + 1) = 0;      // expected-error {{bounds declaration not allowed because 'g74' has a _Ptr type}}
 void((*g75)(void)) : bounds(s1, s1 + 1);    // expected-error {{bounds declaration not allowed because 'g75' has a function pointer type}}
 
 //
@@ -553,11 +553,11 @@ void invalid_local_var_bounds_decl(void)
   struct S1 t51 : count(5) = { 0 };  // expected-error {{expected 't51' to have a pointer or array type}}
   union U1 t52 : count(5) = { 0 };   // expected-error {{expected 't52' to have a pointer or array type}}
   enum E1 t53 : count(5) = EnumVal1; // expected-error {{expected 't53' to have a pointer or array type}}
-  ptr<int> t54 : count(1) = 0;       // expected-error {{bounds declaration not allowed because 't54' has a ptr type}}
+  ptr<int> t54 : count(1) = 0;       // expected-error {{bounds declaration not allowed because 't54' has a _Ptr type}}
   array_ptr<void> t55 : count(1) = 0; // expected-error {{expected 't55' to have a non-void pointer type}}
   void((*t56)(void)) : count(1);      // expected-error {{bounds declaration not allowed because 't56' has a function pointer type}}
 
-  int *t57 : count(1) = 0;          // expected-error {{expected local variable 't57' to have array_ptr type}}
+  int *t57 : count(1) = 0;          // expected-error {{expected local variable 't57' to have _Array_ptr type}}
   int t58[5] : count(5);            // expected-error {{expected local variable 't58' to have checked array type}}
 
   // byte_count
@@ -565,10 +565,10 @@ void invalid_local_var_bounds_decl(void)
   double t61 : byte_count(8);                 // expected-error {{expected 't61' to have a pointer, array, or integer type}}
   struct S1 t62 : byte_count(8) = { 0 };      // expected-error {{expected 't62' to have a pointer, array, or integer type}}
   union U1 t63 : byte_count(8) = { 0 };       // expected-error {{expected 't63' to have a pointer, array, or integer type}}
-  ptr<int> t64 : byte_count(sizeof(int)) = 0; // expected-error {{bounds declaration not allowed because 't64' has a ptr type}}
+  ptr<int> t64 : byte_count(sizeof(int)) = 0; // expected-error {{bounds declaration not allowed because 't64' has a _Ptr type}}
   void((*t65)(void)) : byte_count(1);         // expected-error {{bounds declaration not allowed because 't65' has a function pointer type}}
 
-  int *t67 : byte_count(sizeof(int)) = 0;     // expected-error {{expected local variable 't67' to have array_ptr type}}
+  int *t67 : byte_count(sizeof(int)) = 0;     // expected-error {{expected local variable 't67' to have _Array_ptr type}}
   int t68[5] : byte_count(5 * sizeof(int));   // expected-error {{expected local variable 't68' to have checked array type}}
 
   // bounds
@@ -576,10 +576,10 @@ void invalid_local_var_bounds_decl(void)
   double t71 : bounds(arr, arr + 1);            // expected-error {{expected 't71' to have a pointer, array, or integer type}}
   struct S1 t72 : bounds(arr, arr + 1) = { 0 }; // expected-error {{expected 't72' to have a pointer, array, or integer type}}
   union U1 t73 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't73' to have a pointer, array, or integer type}}
-  ptr<int> t74 : bounds(arr, arr + 1) = 0;      // expected-error {{bounds declaration not allowed because 't74' has a ptr type}}
+  ptr<int> t74 : bounds(arr, arr + 1) = 0;      // expected-error {{bounds declaration not allowed because 't74' has a _Ptr type}}
   void((*t75)(void)) : bounds(arr, arr + 1);    // expected-error {{bounds declaration not allowed because 't75' has a function pointer type}}
 
-  int *t78 : bounds(arr, arr + 1) = 0;          // expected-error {{expected local variable 't78' to have array_ptr type}}
+  int *t78 : bounds(arr, arr + 1) = 0;          // expected-error {{expected local variable 't78' to have _Array_ptr type}}
   int t79[5] : bounds(arr, arr + 1);            // expected-error {{expected local variable 't79' to have checked array type}}
 }
 
@@ -647,7 +647,7 @@ void invalid_param_var_bounds_decl(
   struct S1 t51 : count(5),      // expected-error {{expected 't51' to have a pointer or array type}}
   union U1 t52 : count(5),       // expected-error {{expected 't52' to have a pointer or array type}}
   enum E1 t53 : count(5),        // expected-error {{expected 't53' to have a pointer or array type}}
-  ptr<int> t54: count(1),        // expected-error {{bounds declaration not allowed because 't54' has a ptr type}}
+  ptr<int> t54: count(1),        // expected-error {{bounds declaration not allowed because 't54' has a _Ptr type}}
   array_ptr<void> t55 : count(1), // expected-error {{expected 't55' to have a non-void pointer type}}
   void((*t56)(void)) : count(1),  // expected-error {{bounds declaration not allowed because 't56' has a function pointer type}}
 
@@ -656,7 +656,7 @@ void invalid_param_var_bounds_decl(
   double t61 : byte_count(8),        // expected-error {{expected 't61' to have a pointer, array, or integer type}}
   struct S1 t62 : byte_count(8),     // expected-error {{expected 't62' to have a pointer, array, or integer type}}
   union U1 t63 : byte_count(8),      // expected-error {{expected 't63' to have a pointer, array, or integer type}}
-  ptr<int> t64 : byte_count(8),      // expected-error {{bounds declaration not allowed because 't64' has a ptr type}}
+  ptr<int> t64 : byte_count(8),      // expected-error {{bounds declaration not allowed because 't64' has a _Ptr type}}
   void((*t65)(void)) : byte_count(1),// expected-error {{bounds declaration not allowed because 't65' has a function pointer type}}
 
   // bounds
@@ -664,7 +664,7 @@ void invalid_param_var_bounds_decl(
   double t71 : bounds(s1, s1 + 1),         // expected-error {{expected 't71' to have a pointer, array, or integer type}}
   struct S1 t72 : bounds(s1, s1 + 1),      // expected-error {{expected 't72' to have a pointer, array, or integer type}}
   union U1 t73 : bounds(s1, s1 + 1),       // expected-error {{expected 't73' to have a pointer, array, or integer type}}
-  ptr<int> t74 : bounds(s1, s1 + 1),       // expected-error {{bounds declaration not allowed because 't74' has a ptr type}}
+  ptr<int> t74 : bounds(s1, s1 + 1),       // expected-error {{bounds declaration not allowed because 't74' has a _Ptr type}}
   void((*t75)(void)) : bounds(s1, s1 + 1) // expected-error {{bounds declaration not allowed because 't75' has a function pointer type}}
   )
 {
@@ -750,7 +750,7 @@ struct s8 {
   struct S1 g51 : count(5);       // expected-error {{expected 'g51' to have a pointer or array type}}
   union U1 g52 : count(5);        // expected-error {{expected 'g52' to have a pointer or array type}}
   enum E1 g53 : count(5);         // expected-error {{expected 'g53' to have a pointer or array type}}
-  ptr<int> g54: count(1);         // expected-error {{bounds declaration not allowed because 'g54' has a ptr type}}
+  ptr<int> g54: count(1);         // expected-error {{bounds declaration not allowed because 'g54' has a _Ptr type}}
   array_ptr<void> g55 : count(1); // expected-error {{expected 'g55' to have a non-void pointer type}}
   void((*g56)(void)) : count(1);  // expected-error {{bounds declaration not allowed because 'g56' has a function pointer type}}
 
@@ -759,7 +759,7 @@ struct s8 {
   double g61 : byte_count(8);     // expected-error {{expected 'g61' to have a pointer, array, or integer type}}
   struct S1 g62 : byte_count(8);  // expected-error {{expected 'g62' to have a pointer, array, or integer type}}
   union U1 g63 : byte_count(8);   // expected-error {{expected 'g63' to have a pointer, array, or integer type}}
-  ptr<int> g64 : byte_count(8);   // expected-error {{bounds declaration not allowed because 'g64' has a ptr type}}
+  ptr<int> g64 : byte_count(8);   // expected-error {{bounds declaration not allowed because 'g64' has a _Ptr type}}
   void((*g65)(void)) : byte_count(1);    // expected-error {{bounds declaration not allowed because 'g65' has a function pointer type}}
 
   // bounds
@@ -767,7 +767,7 @@ struct s8 {
   double g71 : bounds(s1, s1 + 1);         // expected-error {{expected 'g71' to have a pointer, array, or integer type}}
   struct S1 g72 : bounds(s1, s1 + 1);      // expected-error {{expected 'g72' to have a pointer, array, or integer type}}
   union U1 g73 : bounds(s1, s1 + 1);       // expected-error {{expected 'g73' to have a pointer, array, or integer type}}
-  ptr<int> g74 : bounds(s1, s1 + 1);       // expected-error {{bounds declaration not allowed because 'g74' has a ptr type}}
+  ptr<int> g74 : bounds(s1, s1 + 1);       // expected-error {{bounds declaration not allowed because 'g74' has a _Ptr type}}
   void((*g75)(void)) : bounds(s1, s1 + 1); // expected-error {{bounds declaration not allowed because 'g75' has a function pointer type}}
 };
 
@@ -825,25 +825,25 @@ double fn50() : count(5);       // expected-error {{expected 'fn50' to have a po
 struct S1 fn51() : count(5);    // expected-error {{expected 'fn51' to have a pointer or array return type}}
 union U1 fn52() : count(5);     // expected-error {{expected 'fn52' to have a pointer or array return type}}
 enum E1 fn53() : count(5);      // expected-error {{expected 'fn53' to have a pointer or array return type}}
-ptr<int> fn54() : count(1);     // expected-error {{bounds declaration not allowed because 'fn54' has a ptr return type}}
+ptr<int> fn54() : count(1);     // expected-error {{bounds declaration not allowed because 'fn54' has a _Ptr return type}}
 array_ptr<void> fn55() : count(1);     // expected-error {{expected 'fn55' to have a non-void pointer return type}}
 void (*fn56(void) : count(1))(int);    // expected-error {{bounds declaration not allowed because 'fn56' has a function pointer return type}}
-ptr<void(int)> fn57(void) : count(1); // expected-error {{bounds declaration not allowed because 'fn57' has a ptr return type}}
+ptr<void(int)> fn57(void) : count(1); // expected-error {{bounds declaration not allowed because 'fn57' has a _Ptr return type}}
 
 // byte_count
 float fn60() : byte_count(8);     // expected-error {{expected 'fn60' to have a pointer, array, or integer return type}}
 double fn61() : byte_count(8);    // expected-error {{expected 'fn61' to have a pointer, array, or integer return type}}
 struct S1 fn62() : byte_count(8); // expected-error {{expected 'fn62' to have a pointer, array, or integer return type}}
 union U1 fn63() : byte_count(8);  // expected-error {{expected 'fn63' to have a pointer, array, or integer return type}}
-ptr<int> fn64() : byte_count(sizeof(int)); // expected-error {{bounds declaration not allowed because 'fn64' has a ptr return type}}
+ptr<int> fn64() : byte_count(sizeof(int)); // expected-error {{bounds declaration not allowed because 'fn64' has a _Ptr return type}}
 void (*fn65(void) : byte_count(1))(int);   // expected-error {{bounds declaration not allowed because 'fn65' has a function pointer return type}}
-ptr<void(int)> fn66(void) : byte_count(1); // expected-error {{bounds declaration not allowed because 'fn66' has a ptr return type}}
+ptr<void(int)> fn66(void) : byte_count(1); // expected-error {{bounds declaration not allowed because 'fn66' has a _Ptr return type}}
 
 // bounds
 float fn70() : bounds(s1, s1 + 1);      // expected-error {{expected 'fn70' to have a pointer, array, or integer return type}}
 double fn71() : bounds(s1, s1 + 1);     // expected-error {{expected 'fn71' to have a pointer, array, or integer return type}}
 struct S1 fn72() : bounds(s1, s1 + 1);  // expected-error {{expected 'fn72' to have a pointer, array, or integer return type}}
 union U1 fn73() : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' to have a pointer, array, or integer return type}}
-ptr<int> fn74() : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a ptr return type}}
+ptr<int> fn74() : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a _Ptr return type}}
 void (*fn75(void) : bounds(s1, s1 + 1))(int);  // expected-error {{bounds declaration not allowed because 'fn75' has a function pointer return type}}
-ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'fn76' has a ptr return type}}
+ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'fn76' has a _Ptr return type}}

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -103,12 +103,12 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   int *t16 = s2d[0];     // expected-error {{expression of incompatible type 'int checked[10]'}}
   int *t17 = t2d[0];
   int *t18 = u2d[0];     // expected-error {{expression of incompatible type 'int checked[10]'}}
-  int(*t19)[10] = s2d;   // expected-error {{expression of incompatible type 'array_ptr<int checked[10]>'}}
+  int(*t19)[10] = s2d;   // expected-error {{expression of incompatible type '_Array_ptr<int checked[10]>'}}
                          // assignment of checked array to unchecked array not allowed
   int (*t20)[10] = t2d;
   int (*t21)[10] = u2d;  // expected-error {{expression of incompatible type 'int checked[10][10]'}}
                          // assignment of checked array to unchecked array not allowed
-  array_ptr<int[10]> t22 = s2d; // expected-error {{expression of incompatible type 'array_ptr<int checked[10]>'}}
+  array_ptr<int[10]> t22 = s2d; // expected-error {{expression of incompatible type '_Array_ptr<int checked[10]>'}}
                                 // assignment of checked to unchecked not allowed
   array_ptr<int[10]> t23 = t2d;
   array_ptr<int[10]> t24 = u2d; // expected-error {{expression of incompatible type 'int checked[10][10]'}}
@@ -124,7 +124,7 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   r = s;
   s = r;
   r = t;
-  p = r;  // expected-error {{assigning to 'int *' from incompatible type 'array_ptr<int>'}}
+  p = r;  // expected-error {{assigning to 'int *' from incompatible type '_Array_ptr<int>'}}
           // assignment of checked pointer to unchecked pointer not allowed
 
   // Assignments to array-typed local and global variables are not allowed
@@ -635,7 +635,7 @@ extern void check_call() {
   f3(x, 0);
   f3(y, 0);
   f3(x2d, 0);            // expected-error {{parameter of incompatible type}}
-  f3(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'array_ptr<int>'}}
+  f3(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Array_ptr<int>'}}
 
   // f4(int **p, int y);
   f4(x, 0);              // expected-warning {{incompatible pointer types passing}}
@@ -651,9 +651,9 @@ extern void check_call() {
 
    // f6(ptr<int[10]>, int y);
   f6(x, 0);              // expected-error {{parameter of incompatible type}}
-  f6(y, 0);              // expected-error {{passing 'int checked[10]' to parameter of incompatible type 'ptr<int [10]>'}}
+  f6(y, 0);              // expected-error {{passing 'int checked[10]' to parameter of incompatible type '_Ptr<int [10]>'}}
   f6(x2d, 0);            // OK
-  f6(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'ptr<int [10]>'}}
+  f6(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Ptr<int [10]>'}}
 
    // f7(array_ptr<int[10]>, int y);
   f7(x, 0);              // expected-error {{parameter of incompatible type}}

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -36,14 +36,14 @@ extern void check_subscript_unsafe_ptr(int *p, int y) {
 }
 
 extern void check_subscript_ptr(ptr<int> p, ptr<const int> p_const, int y) {
-   p[0] = y;  // expected-error {{subscript of 'ptr<int>'}}
-   y = p[0];  // expected-error {{subscript of 'ptr<int>'}}
-   0[p] = y;  // expected-error {{subscript of 'ptr<int>'}}
-   y = 0[p];  // expected-error {{subscript of 'ptr<int>'}}
-   p_const[0] = y;  // expected-error {{subscript of 'ptr<const int>'}}
-   y = p_const[0];  // expected-error {{subscript of 'ptr<const int>'}}
-   0[p_const] = y;  // expected-error {{subscript of 'ptr<const int>'}}
-   y = 0[p_const];  // expected-error {{subscript of 'ptr<const int>'}}
+   p[0] = y;  // expected-error {{subscript of '_Ptr<int>'}}
+   y = p[0];  // expected-error {{subscript of '_Ptr<int>'}}
+   0[p] = y;  // expected-error {{subscript of '_Ptr<int>'}}
+   y = 0[p];  // expected-error {{subscript of '_Ptr<int>'}}
+   p_const[0] = y;  // expected-error {{subscript of '_Ptr<const int>'}}
+   y = p_const[0];  // expected-error {{subscript of '_Ptr<const int>'}}
+   0[p_const] = y;  // expected-error {{subscript of '_Ptr<const int>'}}
+   y = 0[p_const];  // expected-error {{subscript of '_Ptr<const int>'}}
 }
 
 extern void check_subscript_array_ptr(array_ptr<int> p, array_ptr<const int> p_const, int y) {
@@ -982,23 +982,23 @@ void check_pointer_arithmetic()
    p_tmp = p - 0;
    p_tmp = 0 - p;  // expected-error {{invalid operands to binary expression}}
 
-   q + 5;  // expected-error {{arithmetic on ptr type}}
-   5 + q;  // expected-error {{arithmetic on ptr type}}
-   q++;    // expected-error {{arithmetic on ptr type}}
-   q--;    // expected-error {{arithmetic on ptr type}}
-   ++q;    // expected-error {{arithmetic on ptr type}}
-   --q;    // expected-error {{arithmetic on ptr type}}
-   q += 1; // expected-error {{arithmetic on ptr type}}
-   q -= 1; // expected-error {{arithmetic on ptr type}}
+   q + 5;  // expected-error {{arithmetic on _Ptr type}}
+   5 + q;  // expected-error {{arithmetic on _Ptr type}}
+   q++;    // expected-error {{arithmetic on _Ptr type}}
+   q--;    // expected-error {{arithmetic on _Ptr type}}
+   ++q;    // expected-error {{arithmetic on _Ptr type}}
+   --q;    // expected-error {{arithmetic on _Ptr type}}
+   q += 1; // expected-error {{arithmetic on _Ptr type}}
+   q -= 1; // expected-error {{arithmetic on _Ptr type}}
 
-   q_void + 5;  // expected-error {{arithmetic on ptr type}}
-   5 + q_void;  // expected-error {{arithmetic on ptr type}}
-   q_void++;    // expected-error {{arithmetic on ptr type}}
-   q_void--;    // expected-error {{arithmetic on ptr type}}
-   ++q_void;    // expected-error {{arithmetic on ptr type}} 
-   --q_void;    // expected-error {{arithmetic on ptr type}}
-   q_void += 1; // expected-error {{arithmetic on ptr type}}
-   q_void -= 1; // expected-error {{arithmetic on ptr type}}
+   q_void + 5;  // expected-error {{arithmetic on _Ptr type}}
+   5 + q_void;  // expected-error {{arithmetic on _Ptr type}}
+   q_void++;    // expected-error {{arithmetic on _Ptr type}}
+   q_void--;    // expected-error {{arithmetic on _Ptr type}}
+   ++q_void;    // expected-error {{arithmetic on _Ptr type}}
+   --q_void;    // expected-error {{arithmetic on _Ptr type}}
+   q_void += 1; // expected-error {{arithmetic on _Ptr type}}
+   q_void -= 1; // expected-error {{arithmetic on _Ptr type}}
 
    r_tmp = r + 5;
    r_tmp = 5 + r;


### PR DESCRIPTION
I updated some clang error messages to use the new type names `_Ptr` and `_Array_ptr` during the code review yesterday.   This caused some of the tests to break.  Update the tests..
