### PR TITLE
Test misplacement of return bounds expressions.

### DIFF
--- a/tests/parsing/interop_types.c
+++ b/tests/parsing/interop_types.c
@@ -14,36 +14,36 @@
 //
 
 // first parameter has interop type annotation
-extern void f1(int *p : type(ptr<int>), int y) {
+extern void f1(int *p : itype(ptr<int>), int y) {
    *p = y;
 }
 
-extern void f2(int *p : type(array_ptr<int>), int y) {
+extern void f2(int *p : itype(array_ptr<int>), int y) {
 }
 
-extern void f3(int **p : type(ptr<ptr<int>>), int y) {
+extern void f3(int **p : itype(ptr<ptr<int>>), int y) {
   **p = y;
 }
 
-extern void f4(int **p : type(array_ptr<ptr<int>>), int y) {
+extern void f4(int **p : itype(array_ptr<ptr<int>>), int y) {
 }
 
 // Second parameter has interop type annotation
-extern void g1(int y, int *p : type(ptr<int>)) {
+extern void g1(int y, int *p : itype(ptr<int>)) {
    *p = y;
 }
 
-extern void g2(int y, int *p : type(array_ptr<int>)) {
+extern void g2(int y, int *p : itype(array_ptr<int>)) {
 }
 
-extern void g3(int y, int **p : type(ptr<ptr<int>>)) {
+extern void g3(int y, int **p : itype(ptr<ptr<int>>)) {
    y = **p;
 }
 
-extern void g4(int y, int **p : type(ptr<array_ptr<int>>)) {
+extern void g4(int y, int **p : itype(ptr<array_ptr<int>>)) {
 }
 
-extern void g5(int y, int **p : type(array_ptr<ptr<int>>)) {
+extern void g5(int y, int **p : itype(array_ptr<ptr<int>>)) {
 }
 
 //
@@ -51,20 +51,20 @@ extern void g5(int y, int **p : type(array_ptr<ptr<int>>)) {
 // interop type annotation.
 //
 
-extern int *h1(int y, ptr<int> p) : type(ptr<int>) {
+extern int *h1(int y, ptr<int> p) : itype(ptr<int>) {
    *p = y;
    return 0;
 }
 
-extern int *h2 (int y, const ptr<int> p) : type(array_ptr<int>) {
+extern int *h2 (int y, const ptr<int> p) : itype(array_ptr<int>) {
    return 0;
 }
 
-extern int **h3() : type(ptr<ptr<int>>) {
+extern int **h3() : itype(ptr<ptr<int>>) {
    return 0;
 }
 
-extern int **h4() : type(array_ptr<ptr<int>>) {
+extern int **h4() : itype(array_ptr<ptr<int>>) {
    return 0;
 }
 
@@ -72,42 +72,42 @@ extern int **h4() : type(array_ptr<ptr<int>>) {
 // Global variables with interop type annotations
 //
 
-int *a1 : type(ptr<int>) = 0;
-int *a2 : type(array_ptr<int>) = 0;
-int **a3 : type(ptr<ptr<int>>) = 0;
-int **a4 : type(ptr<array_ptr<int>>) = 0;
-int **a5 : type(array_ptr<ptr<int>>) = 0;
-int **a6 : type(array_ptr<array_ptr<int>>) = 0;
-int ***a7 : type(ptr<ptr<ptr<int>>>) = 0;
+int *a1 : itype(ptr<int>) = 0;
+int *a2 : itype(array_ptr<int>) = 0;
+int **a3 : itype(ptr<ptr<int>>) = 0;
+int **a4 : itype(ptr<array_ptr<int>>) = 0;
+int **a5 : itype(array_ptr<ptr<int>>) = 0;
+int **a6 : itype(array_ptr<array_ptr<int>>) = 0;
+int ***a7 : itype(ptr<ptr<ptr<int>>>) = 0;
 
 //
 // Structure members with interop pointer type annotations
 //
 
 struct S1 {
-  float *data1 : type(ptr<float>);
-  float *data2 : type(array_ptr<float>);
-  float **data3 : type(ptr<ptr<float>>);
-  float **data4 : type(ptr<array_ptr<float>>);
-  float **data5 : type(array_ptr<ptr<float>>);
-  float ***data6 : type(ptr<ptr<ptr<float>>>);
+  float *data1 : itype(ptr<float>);
+  float *data2 : itype(array_ptr<float>);
+  float **data3 : itype(ptr<ptr<float>>);
+  float **data4 : itype(ptr<array_ptr<float>>);
+  float **data5 : itype(array_ptr<ptr<float>>);
+  float ***data6 : itype(ptr<ptr<ptr<float>>>);
 };
 
 ///
 /// The interop type can have modifiers
 ///
-extern void f10(const int * const x : type(const ptr<const int>)) {
+extern void f10(const int * const x : itype(const ptr<const int>)) {
 }
 
-extern void f11(const int *x : type(ptr<const int>)) {
+extern void f11(const int *x : itype(ptr<const int>)) {
 }
 
-extern const int *f12() : type(ptr<const int>) {
+extern const int *f12() : itype(ptr<const int>) {
   return 0;
 }
 
-const int *a10 : type(ptr<const int>) = 0;
-int *const a11 : type(const ptr<int>) = 0;
+const int *a10 : itype(ptr<const int>) = 0;
+int *const a11 : itype(const ptr<int>) = 0;
 
 ///
 /// Typedef'ed names can be used as interop types
@@ -116,8 +116,8 @@ int *const a11 : type(const ptr<int>) = 0;
 typedef ptr<int> pint;
 typedef ptr<const int> pcint;
 
-extern void f20(int *x : type(pint)) {
+extern void f20(int *x : itype(pint)) {
 }
 
-extern void f21(const int *x : type(pcint)) {
+extern void f21(const int *x : itype(pcint)) {
 }

--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -240,3 +240,22 @@ extern array_ptr<int> f30(int len, array_ptr<int> arr : count(len)) : bounds()) 
 extern array_ptr<int> f31(int len) : count() { // expected-error {{expected expression}}
   return 5;  // expected-error {{incompatible result type}}
 }
+
+// Misplace a return bounds expression for a function with a complex
+// declarator.
+
+// f32 is a function that returns a pointer to an array of 10 integers.  The
+// return bounds expression must be part of the function declarator and
+// should not follow the array declarator.
+int(*(f32(int arg[10][10])))[10] : count(10); // expected-error {{unexpected bounds expression after declarator}} expected-note {{if this is a return bounds declaration for 'f32', place it after the ')'}}
+
+int(*(f32(int arg[10][10])))[10] : count(10) { // expected-error {{unexpected bounds expression after declarator}} expected-note {{if this is a return bounds declaration for 'f32', place it after the ')'}}
+  return arg;
+}
+
+// A return bounds expression cannot follow a parenthesized function declarator
+int *(f33(int i)) : count(10); // expected-error {{unexpected bounds expression after declarator}} expected-note {{if this is a return bounds declaration for 'f33', place it after the ')'}}
+
+int *(f33(int i)) : count(10) { // expected-error {{unexpected bounds expression after declarator}} expected-note {{if this is a return bounds declaration for 'f33', place it after the ')'}}
+  return 0;
+}

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -393,12 +393,12 @@ void g27(array_ptr<void> ap : byte_count(10 * sizeof(int))) {
 }
 
 // Check that type qualifiers on pointer referent values work as expected.
-const int *const_v1 : itype(ptr<int>) = 0;
+const int *const_v1 : itype(ptr<const int>) = 0;
 const int *const_v2 : count(10) = 0;
 const int *const_v3 : byte_count(10 * sizeof(int)) = 0;
 const int *const_v4 : bounds(v4, v4 + 10) = 0;
 
-int *const v1_const : itype(ptr<int>) = 0;
+int *const v1_const : itype(const ptr<int>) = 0;
 int *const v2_const : count(10) = 0;
 int *const v3_const : byte_count(10 * sizeof(int)) = 0;
 int *const v4_const : bounds(v4, v4 + 10) = 0;
@@ -498,7 +498,7 @@ void g44(ptr<struct S1_void> p, ptr<void> p1, array_ptr<void> p2 : byte_count(10
 // Check that type qualifiers work as expected.
 
 struct S2 {
-  const int *pint : itype(ptr<int>);
+  const int *pint : itype(ptr<const int>);
   const int *arr1 : count(10);
   const int *arr2 : byte_count(10 * sizeof(int));
   const int *arr3 : bounds(arr3, arr3 + 10);
@@ -521,7 +521,7 @@ void g46(ptr<struct S1> p, ptr<const int> p1, array_ptr<const int> p2 : count(10
 }
 
 struct S3 {
-  int *const pint : itype(ptr<int>);
+  int *const pint : itype(const ptr<int>);
   int *const arr1 : count(10);
   int *const arr2 : byte_count(10 * sizeof(int));
   int *const arr3 : bounds(arr3, arr3 + 10);


### PR DESCRIPTION
Add tests of misplaced return bounds expressions in complex declarators.
The tests also check the resulting error messages from the clang Checked C
implementation.  These tests are for Checked C clang repo issue 66.

This also fixes some cases where const type qualifiers were omitted in a
bound-safe interface t ype annotations.