### PR TITLE
Improve error messages for return bounds declarations for incorrect types.

### DIFF
--- a/tests/parsing/interop_types.c
+++ b/tests/parsing/interop_types.c
@@ -14,36 +14,36 @@
 //
 
 // first parameter has interop type annotation
-extern void f1(int *p : type(ptr<int>), int y) {
+extern void f1(int *p : itype(ptr<int>), int y) {
    *p = y;
 }
 
-extern void f2(int *p : type(array_ptr<int>), int y) {
+extern void f2(int *p : itype(array_ptr<int>), int y) {
 }
 
-extern void f3(int **p : type(ptr<ptr<int>>), int y) {
+extern void f3(int **p : itype(ptr<ptr<int>>), int y) {
   **p = y;
 }
 
-extern void f4(int **p : type(array_ptr<ptr<int>>), int y) {
+extern void f4(int **p : itype(array_ptr<ptr<int>>), int y) {
 }
 
 // Second parameter has interop type annotation
-extern void g1(int y, int *p : type(ptr<int>)) {
+extern void g1(int y, int *p : itype(ptr<int>)) {
    *p = y;
 }
 
-extern void g2(int y, int *p : type(array_ptr<int>)) {
+extern void g2(int y, int *p : itype(array_ptr<int>)) {
 }
 
-extern void g3(int y, int **p : type(ptr<ptr<int>>)) {
+extern void g3(int y, int **p : itype(ptr<ptr<int>>)) {
    y = **p;
 }
 
-extern void g4(int y, int **p : type(ptr<array_ptr<int>>)) {
+extern void g4(int y, int **p : itype(ptr<array_ptr<int>>)) {
 }
 
-extern void g5(int y, int **p : type(array_ptr<ptr<int>>)) {
+extern void g5(int y, int **p : itype(array_ptr<ptr<int>>)) {
 }
 
 //
@@ -51,20 +51,20 @@ extern void g5(int y, int **p : type(array_ptr<ptr<int>>)) {
 // interop type annotation.
 //
 
-extern int *h1(int y, ptr<int> p) : type(ptr<int>) {
+extern int *h1(int y, ptr<int> p) : itype(ptr<int>) {
    *p = y;
    return 0;
 }
 
-extern int *h2 (int y, const ptr<int> p) : type(array_ptr<int>) {
+extern int *h2 (int y, const ptr<int> p) : itype(array_ptr<int>) {
    return 0;
 }
 
-extern int **h3() : type(ptr<ptr<int>>) {
+extern int **h3() : itype(ptr<ptr<int>>) {
    return 0;
 }
 
-extern int **h4() : type(array_ptr<ptr<int>>) {
+extern int **h4() : itype(array_ptr<ptr<int>>) {
    return 0;
 }
 
@@ -72,42 +72,42 @@ extern int **h4() : type(array_ptr<ptr<int>>) {
 // Global variables with interop type annotations
 //
 
-int *a1 : type(ptr<int>) = 0;
-int *a2 : type(array_ptr<int>) = 0;
-int **a3 : type(ptr<ptr<int>>) = 0;
-int **a4 : type(ptr<array_ptr<int>>) = 0;
-int **a5 : type(array_ptr<ptr<int>>) = 0;
-int **a6 : type(array_ptr<array_ptr<int>>) = 0;
-int ***a7 : type(ptr<ptr<ptr<int>>>) = 0;
+int *a1 : itype(ptr<int>) = 0;
+int *a2 : itype(array_ptr<int>) = 0;
+int **a3 : itype(ptr<ptr<int>>) = 0;
+int **a4 : itype(ptr<array_ptr<int>>) = 0;
+int **a5 : itype(array_ptr<ptr<int>>) = 0;
+int **a6 : itype(array_ptr<array_ptr<int>>) = 0;
+int ***a7 : itype(ptr<ptr<ptr<int>>>) = 0;
 
 //
 // Structure members with interop pointer type annotations
 //
 
 struct S1 {
-  float *data1 : type(ptr<float>);
-  float *data2 : type(array_ptr<float>);
-  float **data3 : type(ptr<ptr<float>>);
-  float **data4 : type(ptr<array_ptr<float>>);
-  float **data5 : type(array_ptr<ptr<float>>);
-  float ***data6 : type(ptr<ptr<ptr<float>>>);
+  float *data1 : itype(ptr<float>);
+  float *data2 : itype(array_ptr<float>);
+  float **data3 : itype(ptr<ptr<float>>);
+  float **data4 : itype(ptr<array_ptr<float>>);
+  float **data5 : itype(array_ptr<ptr<float>>);
+  float ***data6 : itype(ptr<ptr<ptr<float>>>);
 };
 
 ///
 /// The interop type can have modifiers
 ///
-extern void f10(const int * const x : type(const ptr<const int>)) {
+extern void f10(const int * const x : itype(const ptr<const int>)) {
 }
 
-extern void f11(const int *x : type(ptr<const int>)) {
+extern void f11(const int *x : itype(ptr<const int>)) {
 }
 
-extern const int *f12() : type(ptr<const int>) {
+extern const int *f12() : itype(ptr<const int>) {
   return 0;
 }
 
-const int *a10 : type(ptr<const int>) = 0;
-int *const a11 : type(const ptr<int>) = 0;
+const int *a10 : itype(ptr<const int>) = 0;
+int *const a11 : itype(const ptr<int>) = 0;
 
 ///
 /// Typedef'ed names can be used as interop types
@@ -116,8 +116,8 @@ int *const a11 : type(const ptr<int>) = 0;
 typedef ptr<int> pint;
 typedef ptr<const int> pcint;
 
-extern void f20(int *x : type(pint)) {
+extern void f20(int *x : itype(pint)) {
 }
 
-extern void f21(const int *x : type(pcint)) {
+extern void f21(const int *x : itype(pcint)) {
 }

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -811,39 +811,39 @@ extern enum E1 fn28() : bounds(s1, s1 + 5);
 //
 
 // count
-char fn41() : count(5);         // expected-error {{expected 'fn41' to have a pointer or array return type}}
-_Bool fn42() : count(5);        // expected-error {{expected 'fn42' to have a pointer or array return type}}
-short int fn43() : count(5);    // expected-error {{expected 'fn43' to have a pointer or array return type}}
-int fn44() : count(5);          // expected-error {{expected 'fn44' to have a pointer or array return type}}
-long int fn45() : count(5);     // expected-error {{expected 'fn45' to have a pointer or array return type}}
-unsigned short int fn46() : count(5); // expected-error {{expected 'fn46' to have a pointer or array return type}}
-unsigned int fn47() : count(5);       // expected-error {{expected 'fn47' to have a pointer or array return type}}
-unsigned long int fn48() : count(5);  // expected-error {{expected 'fn48' to have a pointer or array return type}}
+char fn41() : count(5);         // expected-error {{expected 'fn41' to have a pointer return type}}
+_Bool fn42() : count(5);        // expected-error {{expected 'fn42' to have a pointer return type}}
+short int fn43() : count(5);    // expected-error {{expected 'fn43' to have a pointer return type}}
+int fn44() : count(5);          // expected-error {{expected 'fn44' to have a pointer return type}}
+long int fn45() : count(5);     // expected-error {{expected 'fn45' to have a pointer return type}}
+unsigned short int fn46() : count(5); // expected-error {{expected 'fn46' to have a pointer return type}}
+unsigned int fn47() : count(5);       // expected-error {{expected 'fn47' to have a pointer return type}}
+unsigned long int fn48() : count(5);  // expected-error {{expected 'fn48' to have a pointer return type}}
 
-float fn49() : count(5);        // expected-error {{expected 'fn49' to have a pointer or array return type}}
-double fn50() : count(5);       // expected-error {{expected 'fn50' to have a pointer or array return type}}
-struct S1 fn51() : count(5);    // expected-error {{expected 'fn51' to have a pointer or array return type}}
-union U1 fn52() : count(5);     // expected-error {{expected 'fn52' to have a pointer or array return type}}
-enum E1 fn53() : count(5);      // expected-error {{expected 'fn53' to have a pointer or array return type}}
+float fn49() : count(5);        // expected-error {{expected 'fn49' to have a pointer return type}}
+double fn50() : count(5);       // expected-error {{expected 'fn50' to have a pointer return type}}
+struct S1 fn51() : count(5);    // expected-error {{expected 'fn51' to have a pointer return type}}
+union U1 fn52() : count(5);     // expected-error {{expected 'fn52' to have a pointer return type}}
+enum E1 fn53() : count(5);      // expected-error {{expected 'fn53' to have a pointer return type}}
 ptr<int> fn54() : count(1);     // expected-error {{bounds declaration not allowed because 'fn54' has a _Ptr return type}}
 array_ptr<void> fn55() : count(1);     // expected-error {{expected 'fn55' to have a non-void pointer return type}}
 void (*fn56(void) : count(1))(int);    // expected-error {{bounds declaration not allowed because 'fn56' has a function pointer return type}}
 ptr<void(int)> fn57(void) : count(1); // expected-error {{bounds declaration not allowed because 'fn57' has a _Ptr return type}}
 
 // byte_count
-float fn60() : byte_count(8);     // expected-error {{expected 'fn60' to have a pointer, array, or integer return type}}
-double fn61() : byte_count(8);    // expected-error {{expected 'fn61' to have a pointer, array, or integer return type}}
-struct S1 fn62() : byte_count(8); // expected-error {{expected 'fn62' to have a pointer, array, or integer return type}}
-union U1 fn63() : byte_count(8);  // expected-error {{expected 'fn63' to have a pointer, array, or integer return type}}
+float fn60() : byte_count(8);     // expected-error {{expected 'fn60' to have a pointer or integer return type}}
+double fn61() : byte_count(8);    // expected-error {{expected 'fn61' to have a pointer or integer return type}}
+struct S1 fn62() : byte_count(8); // expected-error {{expected 'fn62' to have a pointer or integer return type}}
+union U1 fn63() : byte_count(8);  // expected-error {{expected 'fn63' to have a pointer or integer return type}}
 ptr<int> fn64() : byte_count(sizeof(int)); // expected-error {{bounds declaration not allowed because 'fn64' has a _Ptr return type}}
 void (*fn65(void) : byte_count(1))(int);   // expected-error {{bounds declaration not allowed because 'fn65' has a function pointer return type}}
 ptr<void(int)> fn66(void) : byte_count(1); // expected-error {{bounds declaration not allowed because 'fn66' has a _Ptr return type}}
 
 // bounds
-float fn70() : bounds(s1, s1 + 1);      // expected-error {{expected 'fn70' to have a pointer, array, or integer return type}}
-double fn71() : bounds(s1, s1 + 1);     // expected-error {{expected 'fn71' to have a pointer, array, or integer return type}}
-struct S1 fn72() : bounds(s1, s1 + 1);  // expected-error {{expected 'fn72' to have a pointer, array, or integer return type}}
-union U1 fn73() : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' to have a pointer, array, or integer return type}}
+float fn70() : bounds(s1, s1 + 1);      // expected-error {{expected 'fn70' to have a pointer or integer return type}}
+double fn71() : bounds(s1, s1 + 1);     // expected-error {{expected 'fn71' to have a pointer or integer return type}}
+struct S1 fn72() : bounds(s1, s1 + 1);  // expected-error {{expected 'fn72' to have a pointer or integer return type}}
+union U1 fn73() : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' to have a pointer or integer return type}}
 ptr<int> fn74() : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a _Ptr return type}}
 void (*fn75(void) : bounds(s1, s1 + 1))(int);  // expected-error {{bounds declaration not allowed because 'fn75' has a function pointer return type}}
 ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'fn76' has a _Ptr return type}}


### PR DESCRIPTION
Return bounds declarations are only allowed for functions with return types that are integer or pointer types.   The clang error messages for this situation suggested an array type as a possibility.   Functions cannot return arrays, so we've update the clang error message.  Update the corresponding Checked C tests too.
