### PR TITLE
Test redeclarations of no-prototype functions with checked types.

### DIFF
--- a/tests/parsing/checked_array_types.c
+++ b/tests/parsing/checked_array_types.c
@@ -165,7 +165,7 @@ typedef int incomplete_checked_array_ty checked[];
 // Operators that take types
 //
 
-void parse_operators_with_types() {
+void parse_operators_with_types(void) {
     int s1 = sizeof(int checked[10]);
     int s3 = sizeof(ptr<int checked[5]>);
     int s4 = sizeof(array_ptr<int checked[5]>);

--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -91,7 +91,7 @@ extern void f4(array_ptr<int> arr : count(len), int len) {
 }
 
 // Checked array declarations
-extern void f5() {
+extern void f5(void) {
   int arr1 checked[5] : count(5);
   int arr2 checked[5]: count(2 + 3);
   int arr3 checked[6] : count(5);

--- a/tests/parsing/interop_types.c
+++ b/tests/parsing/interop_types.c
@@ -82,11 +82,11 @@ extern int *h2 (int y, const ptr<int> p) : itype(array_ptr<int>) {
    return 0;
 }
 
-extern int **h3() : itype(ptr<ptr<int>>) {
+extern int **h3(void) : itype(ptr<ptr<int>>) {
    return 0;
 }
 
-extern int **h4() : itype(array_ptr<ptr<int>>) {
+extern int **h4(void) : itype(array_ptr<ptr<int>>) {
    return 0;
 }
 
@@ -133,7 +133,7 @@ extern void f32(const int a[10] : itype(const int checked[10])) {
 extern void f33(const int *x : itype(ptr<const int>)) {
 }
 
-extern const int *f34() : itype(ptr<const int>) {
+extern const int *f34(void) : itype(ptr<const int>) {
   return 0;
 }
 

--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -133,14 +133,14 @@ struct S15 {
 
 // Members that are pointers to functions that have bounds declarations on
 // return values
-extern void S16() {
+extern void S16(void) {
   // Checked pointer to a function that returns an array_ptr to 5 integers.
-  ptr<array_ptr<int>() : count(5)> p1;
+  ptr<array_ptr<int>(void) : count(5)> p1;
   // Checked pointer to a function that returns an array_ptr to n integers,
   // where n is n argument.
   ptr<array_ptr<int>(int n) : count(n)> p2;
   // Use 'byte_count; instead of 'count'
-  ptr<array_ptr<int>() : byte_count(5 * sizeof(int))> q1;
+  ptr<array_ptr<int>(void) : byte_count(5 * sizeof(int))> q1;
   ptr<int(int arg) : byte_count(5 * sizeof(int))> q2;
   ptr<int(int n, int arg) : byte_count(n * sizeof(int))> q3;
   // Use 'bounds' instead of 'count'.
@@ -260,7 +260,7 @@ struct S29 {
 };
 
 
-int f1() {
+int f1(void) {
   int buffer checked[100];
   struct S30 {
      int len;
@@ -268,7 +268,7 @@ int f1() {
   };
 }
 
-int f2() {
+int f2(void) {
   const int bounds = 4;
   struct S31 {
     // This should be parsed as an incorrect bounds expression+-
@@ -276,7 +276,7 @@ int f2() {
   };
 }
 
-int f3() {
+int f3(void) {
   enum E {
     bounds = 4
   };

--- a/tests/parsing/parameter_bounds.c
+++ b/tests/parsing/parameter_bounds.c
@@ -172,7 +172,7 @@ extern void f32(int len,
 }
 
 // Pointers to functions that have bounds declarations on parameters.
-extern void f33() {
+extern void f33(void) {
   // Checked pointer to a function that takes an array_ptr to 5 integers.
   ptr<int(array_ptr<int> : count(5))> p1 = 0;
   ptr<int(array_ptr<int> arg : count(5))> p2 = 0;

--- a/tests/parsing/pointer_types.c
+++ b/tests/parsing/pointer_types.c
@@ -212,7 +212,7 @@ typedef array_ptr<ptr<int>> t_array_ptr_ptr_int;
 // Operators that take types
 //
 
-void parse_operators_with_types() {
+void parse_operators_with_types(void) {
     int s1 = sizeof(ptr<int>);
     int s2 = sizeof(array_ptr<int>);
     int s3 = sizeof(ptr<int[5]>);

--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -21,7 +21,7 @@ extern array_ptr<int> f6(array_ptr<int> arr : bounds(arr, arr + 5))
 extern array_ptr<int> f7(int start,
                          array_ptr<int> arr : bounds(arr - start, arr - start + 5))
                       : bounds(arr - start, arr - start + 5);
-extern array_ptr<char> f8() : bounds(none);
+extern array_ptr<char> f8(void) : bounds(none);
 // count, bounds, and none are contextual keywords.  They are treated as keyword
 // only when they immediately follow a ':';
 extern array_ptr<char> f9(int count) : count(count);
@@ -65,7 +65,7 @@ extern array_ptr<int> f7(int start,
    return arr;
 }
 
-extern array_ptr<char> f8() : bounds(none) {
+extern array_ptr<char> f8(void) : bounds(none) {
   return 0;
 }
 
@@ -176,14 +176,14 @@ extern array_ptr<ptr<array_ptr<int>(int len) : count(len)>> f23(int len)
 }
 
 // Pointers to functions that have bounds declarations on return values
-extern void f24() {
+extern void f24(void) {
   // Checked pointer to a function that returns an array_ptr to 5 integers.
-  ptr<array_ptr<int>() : count(5)> p1 = 0;
+  ptr<array_ptr<int>(void) : count(5)> p1 = 0;
   // Checked pointer to a function that returns an array_ptr to n integers,
   // where n is n argument.
   ptr<array_ptr<int>(int n) : count(n)> p2 = 0;
   // Use 'byte_count; instead of 'count'
-  ptr<array_ptr<int>() : byte_count(5 * sizeof(int))> q1 = 0;
+  ptr<array_ptr<int>(void) : byte_count(5 * sizeof(int))> q1 = 0;
   ptr<int(int arg) : byte_count(5 * sizeof(int))> q2 = 0;
   ptr<int(int n, int arg) : byte_count(n * sizeof(int))> q3 = 0;
   // Use 'bounds' instead of 'count'.
@@ -209,10 +209,10 @@ static func1 *func1_ptr1;
 static func2 *func2_ptr1;
 func1 *func1_ptr2;
 
-extern void f25() : 6 + 6 { // expected-error {{expected bounds expression}}
+extern void f25(void) : 6 + 6 { // expected-error {{expected bounds expression}}
 }
 
-extern array_ptr<char> f26() : count(len) { // expected-error {{use of undeclared identifier 'len'}}
+extern array_ptr<char> f26(void) : count(len) { // expected-error {{use of undeclared identifier 'len'}}
   return 0;
 }
 

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -780,70 +780,70 @@ struct s8 {
 //
 
 // count
-array_ptr<int> fn1() : count(5) { return 0; }
-int *fn2() : count(5) { return 0; }
+array_ptr<int> fn1(void) : count(5) { return 0; }
+int *fn2(void) : count(5) { return 0; }
 
 // byte_count
-extern array_ptr<int> fn4() : byte_count(5 * sizeof(int));
-extern array_ptr<void> fn5() : byte_count(5 * sizeof(int));
-extern int *fn6() : byte_count(5 * sizeof(int));
+extern array_ptr<int> fn4(void) : byte_count(5 * sizeof(int));
+extern array_ptr<void> fn5(void) : byte_count(5 * sizeof(int));
+extern int *fn6(void) : byte_count(5 * sizeof(int));
 
 // bounds
-array_ptr<int> fn10() : bounds(s1, s1 + 5) { return 0; }
-array_ptr<void> fn11() : bounds(s1, s1 + 5) { return 0; }
-int *fn12() : bounds(s1, s1 + 5) { return 0; }
+array_ptr<int> fn10(void) : bounds(s1, s1 + 5) { return 0; }
+array_ptr<void> fn11(void) : bounds(s1, s1 + 5) { return 0; }
+int *fn12(void) : bounds(s1, s1 + 5) { return 0; }
 
 // Test valid rEturn bounds declarations for integer-typed values
-short int fn20() : byte_count(5 * sizeof(int)) { return (short int) s1; }
-int fn21() : byte_count(5 * sizeof(int)) { return (short int)s1; }
-long int fn22() : byte_count(5 * sizeof(int)) { return (short int)s1; }
-unsigned long int fn23() : byte_count(5 * sizeof(int)) { return (short int)s1; }
-enum E1 fn24() : byte_count(8) { return (short int)s1; }
+short int fn20(void) : byte_count(5 * sizeof(int)) { return (short int) s1; }
+int fn21(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
+long int fn22(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
+unsigned long int fn23(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
+enum E1 fn24(void) : byte_count(8) { return (short int)s1; }
 
 // bounds
-extern int fn25() : bounds(s1, s1 + 5);
-extern long int fn26() : bounds(s1, s1 + 5);
-extern unsigned long int fn27 : bounds(s1, s1 + 5);
-extern enum E1 fn28() : bounds(s1, s1 + 5);
+extern int fn25(void) : bounds(s1, s1 + 5);
+extern long int fn26(void) : bounds(s1, s1 + 5);
+extern unsigned long int fn27(void) : bounds(s1, s1 + 5);
+extern enum E1 fn28(void) : bounds(s1, s1 + 5);
 
 //
 // Test invalid return bounds declarations
 //
 
 // count
-char fn41() : count(5);         // expected-error {{expected 'fn41' to have a pointer return type}}
-_Bool fn42() : count(5);        // expected-error {{expected 'fn42' to have a pointer return type}}
-short int fn43() : count(5);    // expected-error {{expected 'fn43' to have a pointer return type}}
-int fn44() : count(5);          // expected-error {{expected 'fn44' to have a pointer return type}}
-long int fn45() : count(5);     // expected-error {{expected 'fn45' to have a pointer return type}}
-unsigned short int fn46() : count(5); // expected-error {{expected 'fn46' to have a pointer return type}}
-unsigned int fn47() : count(5);       // expected-error {{expected 'fn47' to have a pointer return type}}
-unsigned long int fn48() : count(5);  // expected-error {{expected 'fn48' to have a pointer return type}}
+char fn41(void) : count(5);         // expected-error {{expected 'fn41' to have a pointer return type}}
+_Bool fn42(void) : count(5);        // expected-error {{expected 'fn42' to have a pointer return type}}
+short int fn43(void) : count(5);    // expected-error {{expected 'fn43' to have a pointer return type}}
+int fn44(void) : count(5);          // expected-error {{expected 'fn44' to have a pointer return type}}
+long int fn45(void) : count(5);     // expected-error {{expected 'fn45' to have a pointer return type}}
+unsigned short int fn46(void) : count(5); // expected-error {{expected 'fn46' to have a pointer return type}}
+unsigned int fn47(void) : count(5);       // expected-error {{expected 'fn47' to have a pointer return type}}
+unsigned long int fn48(void) : count(5);  // expected-error {{expected 'fn48' to have a pointer return type}}
 
-float fn49() : count(5);        // expected-error {{expected 'fn49' to have a pointer return type}}
-double fn50() : count(5);       // expected-error {{expected 'fn50' to have a pointer return type}}
-struct S1 fn51() : count(5);    // expected-error {{expected 'fn51' to have a pointer return type}}
-union U1 fn52() : count(5);     // expected-error {{expected 'fn52' to have a pointer return type}}
-enum E1 fn53() : count(5);      // expected-error {{expected 'fn53' to have a pointer return type}}
-ptr<int> fn54() : count(1);     // expected-error {{bounds declaration not allowed because 'fn54' has a _Ptr return type}}
-array_ptr<void> fn55() : count(1);     // expected-error {{expected 'fn55' to have a non-void pointer return type}}
+float fn49(void) : count(5);        // expected-error {{expected 'fn49' to have a pointer return type}}
+double fn50(void) : count(5);       // expected-error {{expected 'fn50' to have a pointer return type}}
+struct S1 fn51(void) : count(5);    // expected-error {{expected 'fn51' to have a pointer return type}}
+union U1 fn52(void) : count(5);     // expected-error {{expected 'fn52' to have a pointer return type}}
+enum E1 fn53(void) : count(5);      // expected-error {{expected 'fn53' to have a pointer return type}}
+ptr<int> fn54(void) : count(1);     // expected-error {{bounds declaration not allowed because 'fn54' has a _Ptr return type}}
+array_ptr<void> fn55(void) : count(1);     // expected-error {{expected 'fn55' to have a non-void pointer return type}}
 void (*fn56(void) : count(1))(int);    // expected-error {{bounds declaration not allowed because 'fn56' has a function pointer return type}}
 ptr<void(int)> fn57(void) : count(1); // expected-error {{bounds declaration not allowed because 'fn57' has a _Ptr return type}}
 
 // byte_count
-float fn60() : byte_count(8);     // expected-error {{expected 'fn60' to have a pointer or integer return type}}
-double fn61() : byte_count(8);    // expected-error {{expected 'fn61' to have a pointer or integer return type}}
-struct S1 fn62() : byte_count(8); // expected-error {{expected 'fn62' to have a pointer or integer return type}}
-union U1 fn63() : byte_count(8);  // expected-error {{expected 'fn63' to have a pointer or integer return type}}
-ptr<int> fn64() : byte_count(sizeof(int)); // expected-error {{bounds declaration not allowed because 'fn64' has a _Ptr return type}}
+float fn60(void) : byte_count(8);     // expected-error {{expected 'fn60' to have a pointer or integer return type}}
+double fn61(void) : byte_count(8);    // expected-error {{expected 'fn61' to have a pointer or integer return type}}
+struct S1 fn62(void) : byte_count(8); // expected-error {{expected 'fn62' to have a pointer or integer return type}}
+union U1 fn63(void) : byte_count(8);  // expected-error {{expected 'fn63' to have a pointer or integer return type}}
+ptr<int> fn64(void) : byte_count(sizeof(int)); // expected-error {{bounds declaration not allowed because 'fn64' has a _Ptr return type}}
 void (*fn65(void) : byte_count(1))(int);   // expected-error {{bounds declaration not allowed because 'fn65' has a function pointer return type}}
 ptr<void(int)> fn66(void) : byte_count(1); // expected-error {{bounds declaration not allowed because 'fn66' has a _Ptr return type}}
 
 // bounds
-float fn70() : bounds(s1, s1 + 1);      // expected-error {{expected 'fn70' to have a pointer or integer return type}}
-double fn71() : bounds(s1, s1 + 1);     // expected-error {{expected 'fn71' to have a pointer or integer return type}}
-struct S1 fn72() : bounds(s1, s1 + 1);  // expected-error {{expected 'fn72' to have a pointer or integer return type}}
-union U1 fn73() : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' to have a pointer or integer return type}}
-ptr<int> fn74() : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a _Ptr return type}}
+float fn70(void) : bounds(s1, s1 + 1);      // expected-error {{expected 'fn70' to have a pointer or integer return type}}
+double fn71(void) : bounds(s1, s1 + 1);     // expected-error {{expected 'fn71' to have a pointer or integer return type}}
+struct S1 fn72(void) : bounds(s1, s1 + 1);  // expected-error {{expected 'fn72' to have a pointer or integer return type}}
+union U1 fn73(void) : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' to have a pointer or integer return type}}
+ptr<int> fn74(void) : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a _Ptr return type}}
 void (*fn75(void) : bounds(s1, s1 + 1))(int);  // expected-error {{bounds declaration not allowed because 'fn75' has a function pointer return type}}
 ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'fn76' has a _Ptr return type}}

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -137,7 +137,7 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
 }
 
 // Test that dimensions in multi-dimensional arrays are either all checked or unchecked arrays.
-extern void check_dimensions1() {
+extern void check_dimensions1(void) {
   int t1 checked[10][5]checked[5];     // multiple checked modifiers are allowed
   int t2 checked[10][5][5]checked[5];
 
@@ -448,7 +448,7 @@ extern void check_condexpr_2d(int val) {
 
 // Test conditional expressions where arms have different kinds of
 // array types and const/volatile modifiers.
-extern void check_condexpr_cv()
+extern void check_condexpr_cv(void)
 {
   int val = 0;
   int p[5];
@@ -612,7 +612,7 @@ extern void g3(int y, int p checked[10]) {
   *p = y;
 }
 
-extern void check_call() {
+extern void check_call(void) {
   int x[10];
   int y checked[10];
   int x2d[10][10];
@@ -707,7 +707,7 @@ extern void check_call() {
 
 }
 
-extern void check_call_void() {
+extern void check_call_void(void) {
   int val = 0;
   int p[10];
   int r checked[10];
@@ -749,7 +749,7 @@ extern void check_call_void() {
   f3(u, 0);           // expected-error {{incompatible type}}
 }
 
-void check_call_cv() {
+void check_call_cv(void) {
   int val = 0;
   int p[10];
   const int p_const[10] = { 0, 1, 2, 3, 4,5, 6, 7, 8, 9};
@@ -780,38 +780,38 @@ void check_call_cv() {
 // try to return an array type. This is not allowed by the C standard.
 //
 
-extern unchecked_arr_type h1() {  // expected-error {{function cannot return array type}}
+extern unchecked_arr_type h1(void) {  // expected-error {{function cannot return array type}}
   return 0;
 }
 
-extern checked_arr_type h2() {    // expected-error {{function cannot return array type}}
+extern checked_arr_type h2(void) {    // expected-error {{function cannot return array type}}
   return 0;
 }
 
 int global[10];
 int checked_global checked[10];
 
-int *h3() {
+int *h3(void) {
   return global;
 }
 
-ptr<int> h4() {
+ptr<int> h4(void) {
   return global;
 }
 
-array_ptr<int> h5() {
+array_ptr<int> h5(void) {
   return global;
 }
 
-int *h6() {
+int *h6(void) {
   return checked_global; // expected-error {{incompatible result type}}
 }
 
-ptr<int> h7() {
+ptr<int> h7(void) {
   return checked_global; // expected-error {{incompatible result type}}
 }
 
-array_ptr<int> h8() {
+array_ptr<int> h8(void) {
   return checked_global;
 }
 
@@ -892,7 +892,7 @@ array_ptr<int checked[10]> h27(int arr checked[10][10]) {
 }
 
 
-void check_pointer_arithmetic() {
+void check_pointer_arithmetic(void) {
   int p[5];
   int r checked[5];
 
@@ -973,7 +973,7 @@ void check_pointer_difference(int flag) {
   count = checked_a_float - r_int;  // expected-error {{not pointers to compatible types}}
 }
 
-void check_pointer_relational_compare() {
+void check_pointer_relational_compare(void) {
   int result;
 
   int val_int[5];
@@ -1029,7 +1029,7 @@ void check_pointer_relational_compare() {
   result = r_int <= checked_val_float; // expected-warning {{comparison of distinct pointer types}}
 }
 
-void check_pointer_equality_compare() {
+void check_pointer_equality_compare(void) {
   int result;
 
   int val_int[5];
@@ -1085,7 +1085,7 @@ void check_pointer_equality_compare() {
   result = r_int == checked_val_float; // expected-warning {{comparison of distinct pointer types}}
 }
 
-void check_logical_operators() {
+void check_logical_operators(void) {
   int p[5];
   int r checked[5];
 
@@ -1111,7 +1111,7 @@ void check_logical_operators() {
   b = p && r;
 }
 
-void check_cast_operator() {
+void check_cast_operator(void) {
   int x = 0;
   int arr checked[5];
 
@@ -1142,7 +1142,7 @@ void check_cast_operator() {
 
 // spot check operators that aren't supposed to be used with array types:
 //   *, /, %, <<, >>, |, &, ^, ~, unary -, and unary +
-void check_illegal_operators() {
+void check_illegal_operators(void) {
   int p[5];
   int r checked[5];
 

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -142,7 +142,7 @@ void g2_complete_array_param(int ap checked[10]) {
   f4_incomplete_arr(ap, 10);
 }
 
-void g2_complete_array_arg() {
+void g2_complete_array_arg(void) {
   int arr checked[10];
 
   f1_complete_arr(arr);
@@ -199,7 +199,7 @@ void g2_complete_md_array_param(int ap checked[10][10]) {
   f4_incomplete_md_arr(ap, 10);
 }
 
-void g2_complete_md_array_arg() {
+void g2_complete_md_array_arg(void) {
   int arr checked[10][10];
 
   f1_complete_md_arr(arr);

--- a/tests/typechecking/interop_type_annotations.c
+++ b/tests/typechecking/interop_type_annotations.c
@@ -397,80 +397,80 @@ void f283(ptr<int> ((*f)(int[10])) : itype(ptr<int *(int[10])>)) { // expected-e
 // Types that cannot appear in bounds-safe interface type annotations.
 //
 
-int *r1() : itype(int) {      // expected-error {{must be a pointer type}}
+int *r1(void) : itype(int) {      // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r2() : itype(_Bool) {     // expected-error {{must be a pointer type}}
+int *r2(void) : itype(_Bool) {     // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r3() : itype(char) {      // expected-error {{must be a pointer type}}
+int *r3(void) : itype(char) {      // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r4() : itype(short int) { // expected-error {{must be a pointer type}}
+int *r4(void) : itype(short int) { // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r5() : itype(int) {       // expected-error {{must be a pointer type}}
+int *r5(void) : itype(int) {       // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r6() : itype(long int) {  // expected-error {{must be a pointer type}}
+int *r6(void) : itype(long int) {  // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r7() : itype(float) {     // expected-error {{must be a pointer type}}
+int *r7(void) : itype(float) {     // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r8() : itype(double) {    // expected-error {{must be a pointer type}}
+int *r8(void) : itype(double) {    // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r9() : itype(void) {      // expected-error {{must be a pointer type}}
+int *r9(void) : itype(void) {      // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r10() : itype(struct S) { // expected-error {{must be a pointer type}}
+int *r10(void) : itype(struct S) { // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r11() : itype(union U) {  // expected-error {{must be a pointer type}}
+int *r11(void) : itype(union U) {  // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r12() : itype(int (int)) { // expected-error {{must be a pointer type}}
+int *r12(void) : itype(int (int)) { // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r13() : itype(t1) {      // expected-error {{must be a pointer type}}
+int *r13(void) : itype(t1) {      // expected-error {{must be a pointer type}}
   return 0;
 }
 
-int *r14() : itype(t2) {      // expected-error {{must be a pointer type}}
+int *r14(void) : itype(t2) {      // expected-error {{must be a pointer type}}
   return 0;
 }
 
 
-int *r30() : itype(int *) {   // expected-error {{must be a checked type}}
+int *r30(void) : itype(int *) {   // expected-error {{must be a checked type}}
   return 0;
 }
 
-int *r31a() : itype(int[]) {   // expected-error {{array type not allowed}}
+int *r31a(void) : itype(int[]) {   // expected-error {{array type not allowed}}
   return 0;
 }
 
-int *r31b() : itype(int checked[]) {   // expected-error {{array type not allowed}}
+int *r31b(void) : itype(int checked[]) {   // expected-error {{array type not allowed}}
   return 0;
 }
 
-int *r31c() : itype(int[10]) {   // expected-error {{array type not allowed}}
+int *r31c(void) : itype(int[10]) {   // expected-error {{array type not allowed}}
   return 0;
 }
 
-int *r31d() : itype(int checked[10]) {   // expected-error {{array type not allowed}}
+int *r31d(void) : itype(int checked[10]) {   // expected-error {{array type not allowed}}
   return 0;
 }
 
@@ -484,56 +484,56 @@ int(*(r31f(int arg[10][10]) : itype(int checked[10][10])))[10] { // expected-err
   return arg;
 }
 
-// Return types that cannot have interfce types
+// Return types that cannot have interface types
 
-int r1a() : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
+int r1a(void) : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-_Bool r2a() : itype(ptr<int>) {  // expected-error {{interface type only allowed for a pointer return type}}
+_Bool r2a(void) : itype(ptr<int>) {  // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-char r3a() : itype(ptr<int>) {   // expected-error {{interface type only allowed for a pointer return type}}
+char r3a(void) : itype(ptr<int>) {   // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-short int r4a() : itype(ptr<int>) { // expected-error {{interface type only allowed for a pointer return type}}
+short int r4a(void) : itype(ptr<int>) { // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-long int r6a() : itype(ptr<int>) {   // expected-error {{interface type only allowed for a pointer return type}}
+long int r6a(void) : itype(ptr<int>) {   // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-float r7a() : itype(ptr<int>) {      // expected-error {{interface type only allowed for a pointer return type}}
+float r7a(void) : itype(ptr<int>) {      // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-double r8a() : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
+double r8a(void) : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-void r9a() : itype(ptr<int>) {      // expected-error {{interface type only allowed for a pointer return type}}
+void r9a(void) : itype(ptr<int>) {      // expected-error {{interface type only allowed for a pointer return type}}
 }
 
-struct S r10a() : itype(ptr<int>) { // expected-error {{interface type only allowed for a pointer return type}}
+struct S r10a(void) : itype(ptr<int>) { // expected-error {{interface type only allowed for a pointer return type}}
   struct S v;
   v.a = 0;
   return v;
 }
 
-union U r11a() : itype(ptr<int>) {  // expected-error {{interface type only allowed for a pointer return type}}
+union U r11a(void) : itype(ptr<int>) {  // expected-error {{interface type only allowed for a pointer return type}}
   union U v;
   v.a = 0;
   return v;
 }
 
-t1 r13a() : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
+t1 r13a(void) : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 
-t2 r14a() : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
+t2 r14a(void) : itype(ptr<int>) {    // expected-error {{interface type only allowed for a pointer return type}}
   return 0;
 }
 //
@@ -541,98 +541,98 @@ t2 r14a() : itype(ptr<int>) {    // expected-error {{interface type only allowed
 // 
 
 // Single pointer
-int *r32() : itype(ptr<int>) {
+int *r32(void) : itype(ptr<int>) {
   return 0;
 }
 
-int *r33() : itype(array_ptr<int>) {
+int *r33(void) : itype(array_ptr<int>) {
   return 0;
 }
 
 // Two levels of pointers
 
-int **r50() : itype(ptr<ptr<int>>) {
+int **r50(void) : itype(ptr<ptr<int>>) {
   return 0;
 }
 
-int **r51() : itype(ptr<array_ptr<int>>) {
+int **r51(void) : itype(ptr<array_ptr<int>>) {
   return 0;
 }
 
-int **r52() : itype(array_ptr<ptr<int>>) {
+int **r52(void) : itype(array_ptr<ptr<int>>) {
   return 0;
 }
 
-int **r53() : itype(array_ptr<array_ptr<int>>) {
+int **r53(void) : itype(array_ptr<array_ptr<int>>) {
   return 0;
 }
 
-int **r54() : itype(ptr<int *>) {
+int **r54(void) : itype(ptr<int *>) {
   return 0;
 }
 
-int **r55() : itype(array_ptr<int *>) {
+int **r55(void) : itype(array_ptr<int *>) {
   return 0;
 }
 
-ptr<int> *r59() : itype(ptr<ptr<int>>) {
+ptr<int> *r59(void) : itype(ptr<ptr<int>>) {
   return 0;
 }
 
 // Function pointers
 
-int (*r80() : itype(ptr<int(int *, int *)>))(int *,int *) {
+int (*r80(void) : itype(ptr<int(int *, int *)>))(int *,int *) {
   return 0;
 }
 
-int (*r81() : itype(ptr<int(ptr<int>, ptr<int>)>))(int *, int *) {
+int (*r81(void) : itype(ptr<int(ptr<int>, ptr<int>)>))(int *, int *) {
   return 0;
 }
 
-int (*r82() : itype(ptr<int(int checked[10], int checked[10])>))(int *, int *) {
+int (*r82(void) : itype(ptr<int(int checked[10], int checked[10])>))(int *, int *) {
   return 0;
 }
 
 // Spot check uses of type qualifiers.  They must be identical for the declared type
 // and the bounds-safe interface type.
 
-const int *r200() : itype(ptr<const int>) {
+const int *r200(void) : itype(ptr<const int>) {
   return 0;
 }
 
-volatile int *r201() : itype(ptr<volatile int>) {
+volatile int *r201(void) : itype(ptr<volatile int>) {
   return 0;
 }
 
-const volatile int *r202() : itype(ptr<const volatile int>) {
+const volatile int *r202(void) : itype(ptr<const volatile int>) {
   return 0;
 }
 
-const int *r203() : itype(array_ptr<const int>) {
+const int *r203(void) : itype(array_ptr<const int>) {
   return 0;
 }
 
-volatile int *r204() : itype(array_ptr<volatile int>) {
+volatile int *r204(void) : itype(array_ptr<volatile int>) {
   return 0;
 }
 
-const volatile int *r205() : itype(array_ptr<const volatile int>) {
+const volatile int *r205(void) : itype(array_ptr<const volatile int>) {
   return 0;
 }
 
-int * const r206() : itype(const ptr<int>) {
+int * const r206(void) : itype(const ptr<int>) {
   return 0;
 }
 
-int * volatile r207() : itype(volatile ptr<int>) {
+int * volatile r207(void) : itype(volatile ptr<int>) {
   return 0;
 }
 
-int * restrict r208() : itype(restrict ptr<int>) {
+int * restrict r208(void) : itype(restrict ptr<int>) {
   return 0;
 }
 
-int * const r209() : itype(const array_ptr<int>) {
+int * const r209(void) : itype(const array_ptr<int>) {
   return 0;
 }
 
@@ -643,63 +643,63 @@ int * const r209() : itype(const array_ptr<int>) {
 // Incompatible pointee or element types.
 
 // Pointer types
-float **r250() : itype(ptr<int *>) {   // expected-error {{mismatch between interface type '_Ptr<int *>' and declared type 'float **'}}
+float **r250(void) : itype(ptr<int *>) {   // expected-error {{mismatch between interface type '_Ptr<int *>' and declared type 'float **'}}
 }
 
-float **r251() : itype(ptr<ptr<int>>) {   // expected-error {{mismatch between interface type '_Ptr<_Ptr<int>>' and declared type 'float **'}}
+float **r251(void) : itype(ptr<ptr<int>>) {   // expected-error {{mismatch between interface type '_Ptr<_Ptr<int>>' and declared type 'float **'}}
 }
 
 // Array types
 
 // Returns pointer to array of 10 integers.
-int (*r254() : itype(ptr<int checked[]>))[10] {  // expected-error {{mismatch between interface type}}
+int (*r254(void) : itype(ptr<int checked[]>))[10] {  // expected-error {{mismatch between interface type}}
 }
 
 // Returns pointer to array of integers with unknown
 // size.
-int (*r255() : itype(ptr<int checked[10]>))[]{  // expected-error {{mismatch between interface type}}
+int (*r255(void) : itype(ptr<int checked[10]>))[]{  // expected-error {{mismatch between interface type}}
 }
 
 // Differing number of parameters for function pointer.
 // Note that the function declarator has to be parenthesized so that
 // the interface type declaration is not parsed as the interface type for
 // the return type of the function declarator.
-int (*r256() : itype(ptr<int(int, float)>))(int, float, char) { // expected-error {{mismatch between interface type}}
+int (*r256(void) : itype(ptr<int(int, float)>))(int, float, char) { // expected-error {{mismatch between interface type}}
 }
 
 // Differing parameter types for function pointer.
 // See the earlier comment for r256 about why the function declarator is
 // parenthesized.
-int (*r257() : itype(ptr<int(int, float, double)>))(int, float, char) { // expected-error {{mismatch between interface type}}
+int (*r257(void) : itype(ptr<int(int, float, double)>))(int, float, char) { // expected-error {{mismatch between interface type}}
 }
 
 // Differing return types for function pointer
 // See the earlier comment for r256 about why the function declarator is
 // parenthesized.
-int (*r258() : itype(ptr<float (int, float, char)>))(int, float, char) { // expected-error {{mismatch between interface type}}
+int (*r258(void) : itype(ptr<float (int, float, char)>))(int, float, char) { // expected-error {{mismatch between interface type}}
 }
 
 // No special treatement for void pointers
-void *r259() : itype(ptr<int>) { // expected-error {{mismatch between interface type}}
+void *r259(void) : itype(ptr<int>) { // expected-error {{mismatch between interface type}}
 }
 
-int *r260() : itype(ptr<void>) { // expected-error {{mismatch between interface type}}
+int *r260(void) : itype(ptr<void>) { // expected-error {{mismatch between interface type}}
 }
 
 // Annotation type loses checking.
 
-ptr<int> *r280() : itype(ptr<int *>) { //expected-error {{type '_Ptr<int *>' loses checking of declared type '_Ptr<int> *'}}
+ptr<int> *r280(void) : itype(ptr<int *>) { //expected-error {{type '_Ptr<int *>' loses checking of declared type '_Ptr<int> *'}}
 }
 
 // Declared return type is an unchecked pointer to a checked 2-d array, but
 // the interop type is a checked pointer to an unchecked 2-d array.
-int (*r281() : itype(ptr<int[10][10]>))checked[10][10] { // expected-error {{loses checking of declared type}}
+int (*r281(void) : itype(ptr<int[10][10]>))checked[10][10] { // expected-error {{loses checking of declared type}}
 }
 
 // Declared return type is an unchecked pointer to a checked 1-d array, but
 // the interop type is a checked pointer to an unchecked 1-d array.
 
-int (*r282() : itype(ptr<int[10]>)) checked[10] { // expected-error {{loses checking of declared type}}
+int (*r282(void) : itype(ptr<int[10]>)) checked[10] { // expected-error {{loses checking of declared type}}
 }
 
 //-------------------------------------------------------------

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -1,0 +1,207 @@
+// Feature tests of typechecking no prototype functions.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+
+#include "../../include/stdchecked.h"
+
+struct S1 {
+  ptr<int> m1;
+};
+
+struct S2 {
+  array_ptr<int> m1;
+};
+
+struct S3 {
+  ptr<int> (*m1)();
+};
+
+struct S4 {
+  int (*m1)(ptr<int>);
+};
+
+struct S5 {
+  struct S1 m1;
+  int m2;
+};
+
+struct S6 {
+  int m1;
+  ptr<int> m2;
+};
+
+struct S7 {
+  int m1 checked[10];
+};
+
+struct S8 {
+  int base;
+  int m1 checked[];
+};
+
+union U1 {
+  ptr<int> m1;
+  int *m2;
+};
+
+union U2 {
+  array_ptr<int> m1;
+  array_ptr<char> m2;
+};
+
+union U3 {
+  ptr<int>(*m1)();
+  int *(*m2)();
+};
+
+union U4 {
+  int(*m1)(ptr<int>);
+  int(*m2)(int *);
+};
+
+union U5 {
+  struct S1 m1;
+  struct S1 m2;
+};
+
+union U6 {
+  int *m1;
+  ptr<int> m2;
+};
+
+union U7 {
+  int m1 checked[10];
+  int m2[10];
+};
+
+//
+// No prototype functions cannot return checked values or checked values
+// embedded in objects.
+//
+
+extern ptr<int> f1();      // expected-error {{function without prototype cannot return a checked value}}
+extern array_ptr<int> f2();// expected-error {{function without prototype cannot return a checked value}}
+extern struct S1 f3();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S2 f4();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S3 f5();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S4 f6();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S5 f7();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S6 f8();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S7 f9();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S8 f10();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U1 f11();      // expected-error {{function without prototype cannot return a checked value}}
+extern union U2 f12();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U3 f13();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U4 f14();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U5 f15();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U6 f16();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U7 f17();     // expected-error {{function without prototype cannot return a checked value}}
+
+// No prototype functions that return function pointers
+
+// Returns an unchecked pointer to a function with a checked argument (ptr<int>)
+extern int (*f18())(ptr<int>);  // expected-error {{function without prototype cannot return a checked value}}
+
+// Returns an unchecked pointer to a no-prototype function returning a checked
+// value (ptr<int>)
+extern ptr<int> (*f19())(); // expected-error {{function without prototype cannot return a checked value}}
+// Returns a checked pointer to a function with a checked argument (ptr<int>)
+extern ptr<int (ptr<int>)> f20(); // expected-error {{function without prototype cannot return a checked value}}
+
+// Returns a checked pointer to a no-prototype function returning a checked
+// value (ptr<int>)
+// This unexpectedly produces a syntax error
+// extern ptr<ptr<int> ()> f21();
+
+// No prototype functions can return unchecked pointers to checked values
+// or checked values embedded in objects.  They cannot return unchecked
+// pointers to function types that take or return checked values.
+
+extern ptr<int> *f30();
+extern array_ptr<int> *f31();
+extern struct S1 *f32();
+extern struct S2 *f33();
+extern struct S3 *f34();
+extern struct S4 *f36();
+extern struct S5 *f37();
+extern struct S6 *f38();
+
+//
+// No prototype functions cannot have return bounds declarations.  They can
+// declare bounds-safe interfaces.
+//
+
+extern array_ptr<int> f50() : count(5); // expected-error {{cannot return a checked value}} expected-error {{cannot have a return bounds}}
+extern int f51() : byte_count(10);      // expected-error {{cannot have a return bounds}}
+extern int *f52() : byte_count(10);
+extern int *f53() : itype(ptr<int>);
+
+// No prototype functions cannot be redeclared to take arguments that are
+// checked values or objects with checked values embedded within them.
+
+extern void f60(); 
+extern void f60(ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f61();
+extern void f61(array_ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f62();
+extern void f62(struct S1); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}} 
+
+extern void f63();
+extern void f63(struct S2); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f64();
+extern void f64(struct S3); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f65();
+extern void f65(struct S4); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f66();
+extern void f66(struct S5); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f67();
+extern void f67(struct S6); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f68();
+extern void f68(struct S7); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f69();
+extern void f69(struct S8); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f70();
+extern void f70(union U1); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f71();
+extern void f71(union U2); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f72();
+extern void f72(union U3); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f73();
+extern void f73(union U4); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f74();
+extern void f74(union U5); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f75();
+extern void f75(union U6); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f76();
+extern void f76(union U7); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f80();
+extern void f80(int checked[]); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+// Function type arguments.
+extern void f81();
+extern void f81(ptr<int> f()); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f82();
+extern void f82(int f(ptr<int>)); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+
+extern void f83(int f());
+extern void f84(int f(ptr<int>));
+

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
 #include "../../include/stdchecked.h"
 
@@ -15,7 +15,7 @@ struct S2 {
 };
 
 struct S3 {
-  ptr<int> (*m1)();
+  ptr<int> (*m1)(void);
 };
 
 struct S4 {
@@ -41,6 +41,12 @@ struct S8 {
   int m1 checked[];
 };
 
+struct S9 {
+  int len;
+  // bound declaration on an integer-typed member.
+  int p : bounds((char *) p, (char *) p + len);
+};
+
 union U1 {
   ptr<int> m1;
   int *m2;
@@ -52,7 +58,7 @@ union U2 {
 };
 
 union U3 {
-  ptr<int>(*m1)();
+  ptr<int>(*m1)(void);
   int *(*m2)();
 };
 
@@ -91,24 +97,25 @@ extern struct S5 f7();     // expected-error {{function without prototype cannot
 extern struct S6 f8();     // expected-error {{function without prototype cannot return a checked value}}
 extern struct S7 f9();     // expected-error {{function without prototype cannot return a checked value}}
 extern struct S8 f10();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U1 f11();      // expected-error {{function without prototype cannot return a checked value}}
-extern union U2 f12();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U3 f13();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U4 f14();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U5 f15();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U6 f16();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U7 f17();     // expected-error {{function without prototype cannot return a checked value}}
+extern struct S9 f11();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U1 f12();      // expected-error {{function without prototype cannot return a checked value}}
+extern union U2 f13();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U3 f14();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U4 f15();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U5 f16();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U6 f17();     // expected-error {{function without prototype cannot return a checked value}}
+extern union U7 f18();     // expected-error {{function without prototype cannot return a checked value}}
 
 // No prototype functions that return function pointers
 
 // Returns an unchecked pointer to a function with a checked argument (ptr<int>)
-extern int (*f18())(ptr<int>);  // expected-error {{function without prototype cannot return a checked value}}
+extern int (*f19())(ptr<int>);  // expected-error {{function without prototype cannot return a checked value}}
 
 // Returns an unchecked pointer to a no-prototype function returning a checked
 // value (ptr<int>)
-extern ptr<int> (*f19())(); // expected-error {{function without prototype cannot return a checked value}}
+extern ptr<int> (*f20(void))(); // expected-error {{function without prototype cannot return a checked value}}
 // Returns a checked pointer to a function with a checked argument (ptr<int>)
-extern ptr<int (ptr<int>)> f20(); // expected-error {{function without prototype cannot return a checked value}}
+extern ptr<int (ptr<int>)> f21(); // expected-error {{function without prototype cannot return a checked value}}
 
 // Returns a checked pointer to a no-prototype function returning a checked
 // value (ptr<int>)
@@ -127,6 +134,9 @@ extern struct S3 *f34();
 extern struct S4 *f36();
 extern struct S5 *f37();
 extern struct S6 *f38();
+extern struct S7 *f39();
+extern struct S8 *f40();
+extern struct S9 *f41();
 
 //
 // No prototype functions cannot have return bounds declarations.  They can
@@ -142,66 +152,117 @@ extern int *f53() : itype(ptr<int>);
 // checked values or objects with checked values embedded within them.
 
 extern void f60(); 
-extern void f60(ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f60(ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f61();
-extern void f61(array_ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f61(array_ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f62();
-extern void f62(struct S1); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}} 
+extern void f62(struct S1); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}} 
 
 extern void f63();
-extern void f63(struct S2); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f63(struct S2); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f64();
-extern void f64(struct S3); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f64(struct S3); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f65();
-extern void f65(struct S4); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f65(struct S4); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f66();
-extern void f66(struct S5); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f66(struct S5); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f67();
-extern void f67(struct S6); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f67(struct S6); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f68();
-extern void f68(struct S7); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f68(struct S7); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f69();
-extern void f69(struct S8); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f69(struct S8); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f70();
-extern void f70(union U1); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f70(struct S9); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f71();
-extern void f71(union U2); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f71(union U1); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f72();
-extern void f72(union U3); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f72(union U2); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f73();
-extern void f73(union U4); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f73(union U3); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f74();
-extern void f74(union U5); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f74(union U4); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f75();
-extern void f75(union U6); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f75(union U5); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f76();
-extern void f76(union U7); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f76(union U6); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+
+extern void f77();
+extern void f77(union U7); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+
 
 extern void f80();
-extern void f80(int checked[]); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f80(int checked[]); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 // Function type arguments.
+
 extern void f81();
-extern void f81(ptr<int> f()); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f81(ptr<int> f(void)); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f82();
-extern void f82(int f(ptr<int>)); // expected-error {{redeclaring a no-prototype function with checked argument not allowed}}
+extern void f82(int f(ptr<int>)); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
 
 extern void f83(int f());
-extern void f84(int f(ptr<int>));
+extern void f83(int f(ptr<int>));  // expected-error {{conflicting types for 'f83'}}
 
+extern void f84(int f(ptr<int>));  
+extern void f84(int f());   // expected-error {{conflicting types for 'f84'}}
+
+// No prototype functions cannot be redeclared to take arguments that have
+// bounds declarations.
+extern void f85();
+extern void f85(int p : bounds((char *)p, (char *)p + len), int len); // expected-error {{redeclaring a no-prototype function with an argument bounds is not allowed}}
+
+//
+// Redeclaring a function with a checked argument as a no prototype function is not allowed.
+//
+
+extern void f90(ptr<int>);
+extern void f90(); // expected-error {{redeclaring function that has a checked argument or argument bounds as a no-prototype function is not allowed}} 
+
+// TODO: Github checkedc-clang issue 20 this is an error, but the Checked C
+// clang implementation isn't catching it yet.  It doesn't detect that
+// the types are incompatible because bounds information is not represented
+// in function types yet..
+extern void f91(int p : bounds((char *)p, (char *)p + len), int len);
+extern void f91();
+
+//
+// Spot-check other attempts at creating no prototype functions that return
+// a checked value.
+//
+
+struct S20 {
+  ptr<int> (*f)(); // expected-error {{function without prototype cannot return a checked value}}
+};
+
+typedef ptr<int> functype(); // expected-error {{function without prototype cannot return a checked value}}
+
+// Check the obscure case of a function being declare as a no-prototype, then
+// being declared to have a prototype with an incomplete type, and then
+// incomplete type being completed.
+
+struct S21;
+extern void f100();
+extern void f100(struct S21);
+struct S21 {
+   ptr<int> m;
+};
+
+extern void f100(struct S21 x) { // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+}

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -87,35 +87,35 @@ union U7 {
 // embedded in objects.
 //
 
-extern ptr<int> f1();      // expected-error {{function without prototype cannot return a checked value}}
-extern array_ptr<int> f2();// expected-error {{function without prototype cannot return a checked value}}
-extern struct S1 f3();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S2 f4();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S3 f5();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S4 f6();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S5 f7();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S6 f8();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S7 f9();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S8 f10();     // expected-error {{function without prototype cannot return a checked value}}
-extern struct S9 f11();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U1 f12();      // expected-error {{function without prototype cannot return a checked value}}
-extern union U2 f13();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U3 f14();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U4 f15();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U5 f16();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U6 f17();     // expected-error {{function without prototype cannot return a checked value}}
-extern union U7 f18();     // expected-error {{function without prototype cannot return a checked value}}
+extern ptr<int> f1();      // expected-error {{function with no prototype cannot have a return type that is a checked type}}
+extern array_ptr<int> f2();// expected-error {{function with no prototype cannot have a return type that is a checked type}}
+extern struct S1 f3();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S2 f4();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S3 f5();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S4 f6();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S5 f7();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S6 f8();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S7 f9();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S8 f10();    // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern struct S9 f11();    // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+extern union U1 f12();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
+extern union U2 f13();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
+extern union U3 f14();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
+extern union U4 f15();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
+extern union U5 f16();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
+extern union U6 f17();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
+extern union U7 f18();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
 
 // No prototype functions that return function pointers
 
 // Returns an unchecked pointer to a function with a checked argument (ptr<int>)
-extern int (*f19())(ptr<int>);  // expected-error {{function without prototype cannot return a checked value}}
+extern int (*f19())(ptr<int>);  // expected-error {{function with no prototype cannot have a return type that is a checked type}}
 
 // Returns an unchecked pointer to a no-prototype function returning a checked
 // value (ptr<int>)
-extern ptr<int> (*f20(void))(); // expected-error {{function without prototype cannot return a checked value}}
+extern ptr<int> (*f20(void))(); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
 // Returns a checked pointer to a function with a checked argument (ptr<int>)
-extern ptr<int (ptr<int>)> f21(); // expected-error {{function without prototype cannot return a checked value}}
+extern ptr<int (ptr<int>)> f21(); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
 
 // Returns a checked pointer to a no-prototype function returning a checked
 // value (ptr<int>)
@@ -143,7 +143,7 @@ extern struct S9 *f41();
 // declare bounds-safe interfaces.
 //
 
-extern array_ptr<int> f50() : count(5); // expected-error {{cannot return a checked value}} expected-error {{cannot have a return bounds}}
+extern array_ptr<int> f50() : count(5); // expected-error {{function with no prototype cannot have a return type that is a checked type}} expected-error {{function with no prototype cannot have a return bounds}}
 extern int f51() : byte_count(10);      // expected-error {{cannot have a return bounds}}
 extern int *f52() : byte_count(10);
 extern int *f53() : itype(ptr<int>);
@@ -152,70 +152,70 @@ extern int *f53() : itype(ptr<int>);
 // checked values or objects with checked values embedded within them.
 
 extern void f60(); 
-extern void f60(ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f60(ptr<int>); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a checked type}}
 
 extern void f61();
-extern void f61(array_ptr<int>); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f61(array_ptr<int>); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a checked type}}
 
 extern void f62();
-extern void f62(struct S1); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}} 
+extern void f62(struct S1); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f63();
-extern void f63(struct S2); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f63(struct S2); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f64();
-extern void f64(struct S3); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f64(struct S3); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f65();
-extern void f65(struct S4); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f65(struct S4); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f66();
-extern void f66(struct S5); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f66(struct S5); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f67();
-extern void f67(struct S6); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f67(struct S6); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f68();
-extern void f68(struct S7); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f68(struct S7); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f69();
-extern void f69(struct S8); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f69(struct S8); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f70();
-extern void f70(struct S9); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f70(struct S9); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
 extern void f71();
-extern void f71(union U1); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f71(union U1); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 extern void f72();
-extern void f72(union U2); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f72(union U2); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 extern void f73();
-extern void f73(union U3); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f73(union U3); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 extern void f74();
-extern void f74(union U4); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f74(union U4); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 extern void f75();
-extern void f75(union U5); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f75(union U5); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 extern void f76();
-extern void f76(union U6); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f76(union U6); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 extern void f77();
-extern void f77(union U7); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f77(union U7); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
 
 extern void f80();
-extern void f80(int checked[]); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f80(int checked[]); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a checked type}}
 
 // Function type arguments.
 
 extern void f81();
-extern void f81(ptr<int> f(void)); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f81(ptr<int> f(void)); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a checked type}}
 
 extern void f82();
-extern void f82(int f(ptr<int>)); // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f82(int f(ptr<int>)); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a checked type}}
 
 extern void f83(int f());
 extern void f83(int f(ptr<int>));  // expected-error {{conflicting types for 'f83'}}
@@ -226,14 +226,14 @@ extern void f84(int f());   // expected-error {{conflicting types for 'f84'}}
 // No prototype functions cannot be redeclared to take arguments that have
 // bounds declarations.
 extern void f85();
-extern void f85(int p : bounds((char *)p, (char *)p + len), int len); // expected-error {{redeclaring a no-prototype function with an argument bounds is not allowed}}
+extern void f85(int p : bounds((char *)p, (char *)p + len), int len); // expected-error {{cannot redeclare a function with no prototype to have an argument bounds}}
 
 //
 // Redeclaring a function with a checked argument as a no prototype function is not allowed.
 //
 
 extern void f90(ptr<int>);
-extern void f90(); // expected-error {{redeclaring function that has a checked argument or argument bounds as a no-prototype function is not allowed}} 
+extern void f90(); // expected-error {{cannot redeclare a function that has a checked argument or argument bounds to have no prototype}}
 
 // TODO: Github checkedc-clang issue 20 this is an error, but the Checked C
 // clang implementation isn't catching it yet.  It doesn't detect that
@@ -248,14 +248,14 @@ extern void f91();
 //
 
 struct S20 {
-  ptr<int> (*f)(); // expected-error {{function without prototype cannot return a checked value}}
+  ptr<int> (*f)(); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
 };
 
-typedef ptr<int> functype(); // expected-error {{function without prototype cannot return a checked value}}
+typedef ptr<int> functype1(); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
 
-// Check the obscure case of a function being declare as a no-prototype, then
+// Check the obscure case of a function being declared as a no-prototype, then
 // being declared to have a prototype with an incomplete type, and then
-// incomplete type being completed.
+// the incomplete type being completed.
 
 struct S21;
 extern void f100();
@@ -264,5 +264,16 @@ struct S21 {
    ptr<int> m;
 };
 
-extern void f100(struct S21 x) { // expected-error {{redeclaring a no-prototype function with checked argument is not allowed}}
+extern void f100(struct S21 x) { // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 }
+
+typedef int functype2(ptr<int>);
+struct S22 {
+  functype2 *m;
+};
+
+extern void f101();
+extern void f101(struct S22); //expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
+
+extern void f102();
+extern void f102(functype2 arg); //expected-error {{cannot redeclare a function with no prototype to have an argument type that is a checked type}}

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -292,7 +292,7 @@ extern void check_assign_void(int val, int *p, ptr<int> q, array_ptr<int> r,
 
 // Test assignments between pointers of different kinds with const/volatile
 // attributes on referent types
-extern void check_assign_cv() {
+extern void check_assign_cv(void) {
     int val = 0;
     const int const_val = 0;
     volatile int volatile_val = 0;
@@ -493,7 +493,7 @@ extern void check_condexpr_void(int val, int *p, ptr<int> q, array_ptr<int> r,
 
 // Test conditional expressions where arms have different kinds of
 // pointer types and const/volatile modifiers.
-extern void check_condexpr_cv()
+extern void check_condexpr_cv(void)
 {
   int val = 0;
   const int const_val = 0;
@@ -710,19 +710,19 @@ extern void g4(int y, _Bool p) {
 // returns a new pointer type
 //
 
-extern int *h1() {
+extern int *h1(void) {
     return 0;
 }
 
-extern ptr<int> h2() {
+extern ptr<int> h2(void) {
    return 0;
 }
 
-extern array_ptr<int> h3() {
+extern array_ptr<int> h3(void) {
    return 0;
 }
 
-extern void check_call() {
+extern void check_call(void) {
     int val = 0;
     float fval = 0.0;
     int *p = 0;
@@ -834,7 +834,7 @@ extern void check_call() {
                                // int = array_ptr<int>
 }
 
-extern void check_call_void() {
+extern void check_call_void(void) {
     int val = 0;
     float fval = 0.0;
     int *p = 0;
@@ -919,7 +919,7 @@ extern void check_call_void() {
     f3_void(0, val);
 }
 
-void check_call_cv() {
+void check_call_cv(void) {
     int val = 0;
     const int const_val = 0;
     int *p = 0;
@@ -954,7 +954,7 @@ void check_call_cv() {
                           // param array_ptr<int> arg array_ptr<const int> not OK
 }
 
-void check_pointer_arithmetic()
+void check_pointer_arithmetic(void)
 {
    int val[5];
    int *p = val;
@@ -1032,7 +1032,7 @@ void check_pointer_arithmetic()
    r + r; // expected-error {{invalid operands}}
 }
 
-void check_pointer_difference()
+void check_pointer_difference(void)
 {
     int count;
     int val_int[5];
@@ -1172,7 +1172,7 @@ void check_pointer_difference()
 							 // array_ptr<void> - array_ptr<int> not OK.
 }
 
-void check_pointer_relational_compare()
+void check_pointer_relational_compare(void)
 {
     int result;
     int val_int[5];
@@ -1337,7 +1337,7 @@ void check_pointer_relational_compare()
     result = 0 < r_void; // 0 < array_ptr<void> OK.
 }
 
-void check_pointer_equality_compare()
+void check_pointer_equality_compare(void)
 {
     int result;
     int val_int[5];
@@ -1509,7 +1509,7 @@ void check_pointer_equality_compare()
                                // array_ptr<float> == array_ptr<int> not OK.
 }
 
-void check_logical_operators()
+void check_logical_operators(void)
 {
     int val[5];
     int *p = val;
@@ -1572,7 +1572,7 @@ void check_logical_operators()
 
 // spot check operators that aren't supposed to be used with pointer types:
 //   *, /, %, <<, >>, |, &, ^, ~, unary -, and unary +
-void check_illegal_operators()
+void check_illegal_operators(void)
 {
     int val[5];
     int *p = val;


### PR DESCRIPTION
Calls to no-prototype functions are not type checked according to the C Specification (Section 6.5.2.2 of the C11 specification).  Because of this, the Checked C extension does not allow no-prototype functions to be redeclared to take or return checked types.   The lack of type checking at calls enables checking of bounds to be bypassed. Section 5.5 of the Checked C extension specification describes the restrictions.  In the terminology of the C Specification, no-prototype function types are incompatible with function types that take arguments or return values that have checked types, contain values with checked types embedded within them, or are recursively pointers to function types that take or return checked types or checked values.

This change adds feature tests that check that redeclarations of no-prototype functions to use checked types are not allowed.  The tests are in  typechecking/no_prototype_functions.c.

It also fixes accidental declarations in existing tests of no-prototype functions.  All these functions actually take no arguments.  In C, a prototype for a function that takes no arguments has to be declared with an
argument list that is the `void` keyword.  For example, `int f(void);` declares a function that takes no arguments and returns an integer.