### PR TITLE
Change specification to describe updated Checked C keywords.

### DIFF
--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -13,6 +13,47 @@ proves them redundant) because bounds safety depends upon them.
 Finally, it describes changes to
 undefined behavior needed for bounds safety.
 
+\section{New keywords}
+Some of the extensions use new keywords.   Introducing new keywords
+into a programming language can cause conflicts with identifier names
+in existing programs, if the keywords can appear in places where
+identifiers could also appear.   Fortunately, C provids a
+backward-compatible way to introduce new keywords.  Identifiers that
+begin with an
+underscore followed by a capital letter are reserved for system
+use, as are identifiers that begin with two underscores 
+\cite[Section 7.1.3]{ISO2011}.   
+The following new keywords are 
+introduced:
+\begin{verbatim}
+_Array_ptr  _Checked  _Dynamic_check  _Ptr  _Span  _Where  _Unchecked
+\end{verbatim}
+
+It is desirable to have all lower-case versions of the
+identifiers for readability and ease of typing, of course. The C
+preprocessor is used to provide these. A standard header
+file \keyword{checkedc.h} is provided that has macros
+that map the lower-case versions of keywords to the actual keywords.
+Programs that do not have identifiers that conflict with the
+lower-case versions of tke keywords can include it.
+Note that to allow header files to be included by progrmmers in any order,
+the implementations of other standard header files need to be modified to
+not use identifiers that conflict with these keywords.
+The all lower-case versions of the keywords are:
+\begin{verbatim}
+array_ptr  checked  dynamic_check  ptr  where  span  unchecked
+\end{verbatim}
+
+The pattern of using an identifier reserved for system use
+coupled with a header file has been used to extend C before.  It
+was used to introduce the boolean type for example.  The keyword
+name is \verb+_Bool+.  The standard header file \keyword{stdbool.h}
+has a macro that maps \keyword{bool} to \verb+_Bool+.
+
+Throughout this document, we use the shorter and easier-to-read
+ lower-case versions of the keyword.  We assume implicitly
+ that \keyword{checkedc.h} is included before examples.
+
 \section{New kinds of pointer types}
 Three new checked pointer types are added to C. Each pointer type can be
 used in place of `\texttt{*}':
@@ -53,7 +94,9 @@ The same syntax as C++ template instantiations is used for building
 instances of these types because this syntax is well-known and
 understood.  The new pointer types are added to the syntax for {\it type specifiers} 
 \cite[Section 6.7.2]{ISO2011}. The parameters to these type constructors 
-must be types, which are described syntactically by {\it type names} \cite[Section 6.7.7]{ISO2011}.
+must be types, which are described syntactically by {\it type names} \cite[Section 6.7.7]{ISO2011}.  If Checked C is extended to C++,
+it is intended in C++ that these new types be template types
+that have special meaning.
 
 Checked pointers provide checking that memory accesses are in bounds.  They
 do not provide checking that memory for objects is being managed

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -15,15 +15,12 @@ undefined behavior needed for bounds safety.
 
 \section{New keywords}
 Some of the extensions use new keywords.   Introducing new keywords
-for C can cause conflicts with identifier names
-in existing C programs.  Fortunately, C provides a
-backward-compatible way to introduce new keywords.  Identifiers that
-begin with an
-underscore followed by a capital letter are reserved for system
-use, as are identifiers that begin with two underscores
-\cite[Section 7.1.3]{ISO2011}.
-The following new keywords are
-introduced:
+for C can cause conflicts with identifier names in existing C programs.
+Fortunately, C provides a backward-compatible way to introduce new
+keywords.  Identifiers that begin with an underscore followed by a
+capital letter are reserved for system use, as are identifiers that
+begin with two underscores \cite[Section 7.1.3]{ISO2011}. The following
+new keywords are introduced:
 \begin{verbatim}
 _Array_ptr  _Checked  _Dynamic_check  _Ptr  _Span  _Where  _Unchecked
 \end{verbatim}
@@ -38,14 +35,13 @@ lowercase versions of the keywords can include it.
 Note that to allow header files to be included by programmers in any order,
 the implementations of standard header files need to be modified to
 not use identifiers that conflict with these keywords.
-The all lowercase versions of the keywords are:
+The all-lowercase versions of the keywords are:
 \begin{verbatim}
 array_ptr  checked  dynamic_check  ptr  where  span  unchecked
 \end{verbatim}
 
-The pattern of using an identifier reserved for system use
-coupled with a header file has been used before.  It
-was used to introduce the boolean type for example.  The keyword
+The pattern of using an identifier reserved for system use coupled with
+a header file was used before to introduce the boolean type. The keyword
 name is \verb+_Bool+.  The standard header file \keyword{stdbool.h}
 has a macro that maps \keyword{bool} to \verb+_Bool+.
 
@@ -93,7 +89,8 @@ The same syntax as C++ template instantiations is used for building
 instances of these types because this syntax is well-known and
 understood.  The new pointer types are added to the syntax for {\it type specifiers} 
 \cite[Section 6.7.2]{ISO2011}. The parameters to these type constructors 
-must be types, which are described syntactically by {\it type names} \cite[Section 6.7.7]{ISO2011}.  If Checked C is extended to C++,
+must be types, which are described syntactically by {\it type names}
+\cite[Section 6.7.7]{ISO2011}.  If Checked C is extended to C++,
 in the C++ extension these new types will be template types that have special meaning.
 
 Checked pointers provide checking that memory accesses are in bounds.  They

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -15,44 +15,43 @@ undefined behavior needed for bounds safety.
 
 \section{New keywords}
 Some of the extensions use new keywords.   Introducing new keywords
-into a programming language can cause conflicts with identifier names
-in existing programs, if the keywords can appear in places where
-identifiers could also appear.   Fortunately, C provids a
+for C can cause conflicts with identifier names
+in existing C programs.  Fortunately, C provides a
 backward-compatible way to introduce new keywords.  Identifiers that
 begin with an
 underscore followed by a capital letter are reserved for system
-use, as are identifiers that begin with two underscores 
-\cite[Section 7.1.3]{ISO2011}.   
-The following new keywords are 
+use, as are identifiers that begin with two underscores
+\cite[Section 7.1.3]{ISO2011}.
+The following new keywords are
 introduced:
 \begin{verbatim}
 _Array_ptr  _Checked  _Dynamic_check  _Ptr  _Span  _Where  _Unchecked
 \end{verbatim}
 
-It is desirable to have all lower-case versions of the
-identifiers for readability and ease of typing, of course. The C
+It is desirable to have all-lowercase versions of the
+identifiers for readability and ease of typing. The C
 preprocessor is used to provide these. A standard header
 file \keyword{checkedc.h} is provided that has macros
-that map the lower-case versions of keywords to the actual keywords.
+that map the lowercase versions of keywords to the actual keywords.
 Programs that do not have identifiers that conflict with the
-lower-case versions of tke keywords can include it.
-Note that to allow header files to be included by progrmmers in any order,
-the implementations of other standard header files need to be modified to
+lowercase versions of the keywords can include it.
+Note that to allow header files to be included by programmers in any order,
+the implementations of standard header files need to be modified to
 not use identifiers that conflict with these keywords.
-The all lower-case versions of the keywords are:
+The all lowercase versions of the keywords are:
 \begin{verbatim}
 array_ptr  checked  dynamic_check  ptr  where  span  unchecked
 \end{verbatim}
 
 The pattern of using an identifier reserved for system use
-coupled with a header file has been used to extend C before.  It
+coupled with a header file has been used before.  It
 was used to introduce the boolean type for example.  The keyword
 name is \verb+_Bool+.  The standard header file \keyword{stdbool.h}
 has a macro that maps \keyword{bool} to \verb+_Bool+.
 
 Throughout this document, we use the shorter and easier-to-read
- lower-case versions of the keyword.  We assume implicitly
- that \keyword{checkedc.h} is included before examples.
+lowercase versions of the keywords.  It is assumed
+that \keyword{checkedc.h} is included before examples.
 
 \section{New kinds of pointer types}
 Three new checked pointer types are added to C. Each pointer type can be
@@ -95,8 +94,7 @@ instances of these types because this syntax is well-known and
 understood.  The new pointer types are added to the syntax for {\it type specifiers} 
 \cite[Section 6.7.2]{ISO2011}. The parameters to these type constructors 
 must be types, which are described syntactically by {\it type names} \cite[Section 6.7.7]{ISO2011}.  If Checked C is extended to C++,
-it is intended in C++ that these new types be template types
-that have special meaning.
+in the C++ extension these new types will be template types that have special meaning.
 
 Checked pointers provide checking that memory accesses are in bounds.  They
 do not provide checking that memory for objects is being managed

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -28,7 +28,7 @@ _Array_ptr  _Checked  _Dynamic_check  _Ptr  _Span  _Where  _Unchecked
 It is desirable to have all-lowercase versions of the
 identifiers for readability and ease of typing. The C
 preprocessor is used to provide these. A standard header
-file \keyword{checkedc.h} is provided that has macros
+file \keyword{stdcheckedc.h} is provided that has macros
 that map the lowercase versions of keywords to the actual keywords.
 Programs that do not have identifiers that conflict with the
 lowercase versions of the keywords can include it.

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -169,33 +169,6 @@ preserves the control and efficiency of C. The bounds declarations will
 be checked statically for correctness using rules described in 
 Chapter~\ref{chapter:checking-bounds}.
 
-\subsection{Contextual keywords}
-Bounds expressions can be used in new syntactic contexts only:
-after a \verb+:+ in a declaration or after an identifier and
- a \verb+:+ in \keyword{where} clauses.  The keywords that
- occur in bounds expressions are keywords only when they
- occur in those specific contexts.   Otherwise, they are identifiers.
- These kinds of keywords are called contextual keywords.
- Specifically, the keywords that start bounds expressions:
-\begin{verbatim}
-bounds count  
-\end{verbatim}
-are keywords only when they occur after a\verb+:+
-in a declaraton or after an identifier and a \verb+:+
-in a keyword{where} clause.
-The keywords \keyword{any} and \keyword{none} are 
-keywords only when they follow the keyword \keyword{bounds}
-and a \verb+(+. 
-There is no syntactic ambiguity about whether a contextual
-keyword or an identifier is expected, so there is no need to have
-keywords that begin with an underscore followed by a capital letter.
-
-The contextual keywords are easy to handle in the parsing phase
-of a C compiler.  A compiler can use a grammar that allows
-identifers to occur where the contextual keywords are expected.
-The compiler can check that an identifier is one of the allowed
-contextual keywords while building an abtract syntax tree.
-
 \subsection{Bounds declarations at variable declarations}
 \label{section:variable-declarations}
 
@@ -598,6 +571,31 @@ statements:\\
 \>\var{expression\textsubscript{opt} where-clause\textsubscript{opt}}\texttt{;}
 \end{tabbing}
 
+The names used in bounds expressions (\texttt{any},
+\texttt{bounds}, \texttt{count}, and \texttt{none}) are identifiers.
+They are not keywords.  They can still be used for variables names,
+avoiding backward-compatibility problems.    The grammar for
+bounds expressions is:
+\begin{tabbing}
+\var{bounds}\=\var{-exp:} \\
+\> \var{identifier}\texttt{(}\var{non-modifying-exp}\texttt{)} \\
+\> \var{identifier}\texttt{(}\var{non-modifying-exp}\texttt{,}
+    \var{non-modifying-exp} \texttt{)}
+\end{tabbing}
+
+After parsing, the following rules are applied to bounds
+expressions:
+\begin{itemize}
+\item If the first grammar clause was parsed,
+\begin{itemize}
+\item If \var{identifier} is \texttt{bounds}, the \var{non-modifying-exp}
+must be the identifier \texttt{any} or the identifier \texttt{none}.
+\item Otherwise \var{identifier} must be \texttt{count}.
+\end{itemize}
+\item If the second grammar clause was parsed, \var{identifier} must be
+\texttt{bounds}.
+\end{itemize}
+
 \section{Operations allowed in non-modifying expressions}
 \label{section:non-modifying-expressions}
 
@@ -784,12 +782,12 @@ aligned to its bounds for type \var{T}:
 \> \relalignval{\var{constant-exp}} 
 \end{tabbing}
 
-\texttt{rel\_align} is a contextual keyword.
 This clause is only added to bounds pairs because (by definition) count
 expressions always describe pointers that are relatively aligned to
-their bounds. The optional relative alignment clause specifies a
+their bounds.  \texttt{rel\_align} and \texttt{rel\_align\_value} are
+identifiers.  The optional clause specifies a
 relative alignment type \var{T} or the required relative alignment in
-bytes.  Given 
+bytes.  Given
 \boundsdecl{\var{x}}{\boundsrel{\var{e1}}{\var{e2}}{\var{T}}},
 \texttt{((\arrayptrchar) \var{x} - (\arrayptrchar) \var{e1}) \%
         \sizeof{\var{T}} == 0} and
@@ -935,7 +933,7 @@ added:
 \boundsbytecount{\var{non-modifying-exp}}
 \end{quote}
 
-\texttt{byte\_count} is a contextual keyword.
+\texttt{byte\_count} is the identifier \texttt{byte\_count}.
 The bounds declaration \boundsdecl{\var{x}}{\boundsbytecount{\var{e1}}}
 describes the number of bytes that are accessible beginning at \var{x}. 
 Only memory that is at or above \var{x} and below \texttt{(\arrayptrchar)}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -169,6 +169,33 @@ preserves the control and efficiency of C. The bounds declarations will
 be checked statically for correctness using rules described in 
 Chapter~\ref{chapter:checking-bounds}.
 
+\subsection{Contextual keywords}
+Bounds expressions can be used in new syntactic contexts only:
+after a \verb+:+ in a declaration or after an identifier and
+ a \verb+:+ in \keyword{where} clauses.  The keywords that
+ occur in bounds expressions are keywords only when they
+ occur in those specific contexts.   Otherwise, they are identifiers.
+ These kinds of keywords are called contextual keywords.
+ Specifically, the keywords that start bounds expressions:
+\begin{verbatim}
+bounds count  
+\end{verbatim}
+are keywords only when they occur after a\verb+:+
+in a declaraton or after an identifier and a \verb+:+
+in a keyword{where} clause.
+The keywords \keyword{any} and \keyword{none} are 
+keywords only when they follow the keyword \keyword{bounds}
+and a \verb+(+. 
+There is no syntactic ambiguity about whether a contextual
+keyword or an identifier is expected, so there is no need to have
+keywords that begin with an underscore followed by a capital letter.
+
+The contextual keywords are easy to handle in the parsing phase
+of a C compiler.  A compiler can use a grammar that allows
+identifers to occur where the contextual keywords are expected.
+The compiler can check that an identifier is one of the allowed
+contextual keywords while building an abtract syntax tree.
+
 \subsection{Bounds declarations at variable declarations}
 \label{section:variable-declarations}
 
@@ -757,11 +784,12 @@ aligned to its bounds for type \var{T}:
 \> \relalignval{\var{constant-exp}} 
 \end{tabbing}
 
+\texttt{rel\_align} is a contextual keyword.
 This clause is only added to bounds pairs because (by definition) count
 expressions always describe pointers that are relatively aligned to
 their bounds. The optional relative alignment clause specifies a
 relative alignment type \var{T} or the required relative alignment in
-bytes. Given 
+bytes.  Given 
 \boundsdecl{\var{x}}{\boundsrel{\var{e1}}{\var{e2}}{\var{T}}},
 \texttt{((\arrayptrchar) \var{x} - (\arrayptrchar) \var{e1}) \%
         \sizeof{\var{T}} == 0} and
@@ -907,6 +935,7 @@ added:
 \boundsbytecount{\var{non-modifying-exp}}
 \end{quote}
 
+\texttt{byte\_count} is a contextual keyword.
 The bounds declaration \boundsdecl{\var{x}}{\boundsbytecount{\var{e1}}}
 describes the number of bytes that are accessible beginning at \var{x}. 
 Only memory that is at or above \var{x} and below \texttt{(\arrayptrchar)}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -573,7 +573,7 @@ statements:\\
 
 The names used in bounds expressions (\texttt{any},
 \texttt{bounds}, \texttt{count}, and \texttt{none}) are identifiers.
-They are not keywords.  They can still be used for variables names,
+They are not keywords.  They can still be used for variable names,
 avoiding backward-compatibility problems.    The grammar for
 bounds expressions is:
 \begin{tabbing}


### PR DESCRIPTION
This change addresses issue #53.  To avoid backward-compatiblity problems when using the
Checked C extension with existing C programs, we are changing the keywords for the
extension to start with an underscore followed by a capital letter.  

The updated keywords are:

``
_Array_ptr  _Checked  _Dynamic_check  _Ptr  _Span  _Where  _Unchecked 
``

This change adds a description of these keywords to the specification.  We use a header file 
that provides all-lowercase versions of the keywords.  The text and examples in the
specification continue to use the all-lowercase versions because that is the way extension is
intended to be used.

This change also clarifies that the syntax for bounds expressions uses specific identifiers,
not keywords.   This cuts down on the number of new keywords that need to be introduced.
The places where the specific identifiers occur in bounds expressions are not places where 
general-purpose identifiers can also appear.  This means there is no need to turn the specific
identifiers into keywords to disambiguate a possible overlap during parsing.  This technique
has been used in C++ and C# to avoid introducing new keywords for names that have special 
meaning only in specific syntactic contexts.
