### PR TITLE
Improve the ordering of material in Chapter 3.

### DIFF
--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -144,7 +144,7 @@ valid. This implies that any access to memory where \var{ev} \texttt{!=
 0 \&\&} \var{lbv} \texttt{<=} \var{ev} \texttt{\&\&} \var{ev}
 \texttt{<} \var{ubv} will be within the bounds of \var{obj}.
 
-In this section, to simplify the description, it is assumed that none of
+In this chapter, to simplify the description, it is assumed that none of
 the \arrayptr\ variables that have bounds declarations have
 their addresses taken. It is also assumed that the values of variables
 whose addresses are taken are not used in bounds declarations. It is
@@ -158,7 +158,7 @@ design to avoid these restrictions.  It covers pointers to data with
 \arrayptr\ values,  pointers to variables used in bounds, and bounds 
 that use pointers.
 
-\subsection{Using bounds declarations}
+\section{Using bounds declarations}
 
 Bounds declarations may be added to declarations and statements using
 \keyword{where} clauses. They also may be placed inline at a declaration
@@ -305,6 +305,51 @@ void AES_cbc_encrypt(array_ptr<const unsigned char> in : count(len),
                      const int enc);
 \end{verbatim}
 
+\subsection{Bounds declarations for return values}
+
+Bounds may be declared for the value returned by a function. The
+parameter list can be followed by either \texttt{:} \var{bounds-exp} or
+a \keyword{where} clause. The special variable \keyword{return\_value} can
+be used to refer to the return value. The parameters are considered in
+scope for the bounds declaration or \keyword{where} clause. Any parameters
+occurring in the return bounds declaration or \keyword{where} clause may
+not be modified by the body of the function.
+
+The following example show the \texttt{find} function from
+Section~\ref{section:variable-declarations} modified
+to return a pointer to the element instead of the index:
+
+\begin{verbatim}
+array_ptr<int> find(int key, array_ptr<int> a : count(len), int len)
+ : bounds(a, a + len)
+{
+    for (int i = 0; i < len; i++) {
+         if (a[i] == key) { // a[i] is bounds checked.  The checking
+                            // ensures that i is between 0 and len.
+             return &a[i];
+         }
+    }
+    return NULL;
+}
+\end{verbatim}
+
+This also can be written as:
+
+\begin{verbatim}
+array_ptr<int> find(int key, array_ptr<int> a : count(len), int len)
+  where return_value : bounds(a, a + len)
+{
+   ...
+}
+\end{verbatim}
+Here is the declaration of a function that allocates memory:
+
+\begin{verbatim}
+array_ptr<char> alloc(size_t size) : count(size);
+\end{verbatim}
+
+
+
 \subsection{Bounds declarations at expression statements}
 \label{section:statement-declarations}
 
@@ -381,48 +426,6 @@ int sum(array_ptr<int> start : bounds(start, end), array_ptr<int> end)
 }
 \end{verbatim}
 
-\subsubsection{Bounds declarations for return values}
-
-Bounds may be declared for the value returned by a function. The
-parameter list can be followed by either \texttt{:} \var{bounds-exp} or
-a \keyword{where} clause. The special variable \keyword{return\_value} can
-be used to refer to the return value. The parameters are considered in
-scope for the bounds declaration or \keyword{where} clause. Any parameters
-occurring in the return bounds declaration or \keyword{where} clause may
-not be modified by the body of the function.
-
-The following example show the \texttt{find} function from
-Section~\ref{section:variable-declarations} modified
-to return a pointer to the element instead of the index:
-
-\begin{verbatim}
-array_ptr<int> find(int key, array_ptr<int> a : count(len), int len)
- : bounds(a, a + len)
-{
-    for (int i = 0; i < len; i++) {
-         if (a[i] == key) { // a[i] is bounds checked.  The checking
-                            // ensures that i is between 0 and len.
-             return &a[i];
-         }
-    }
-    return NULL;
-}
-\end{verbatim}
-
-This also can be written as:
-
-\begin{verbatim}
-array_ptr<int> find(int key, array_ptr<int> a : count(len), int len)
-  where return_value : bounds(a, a + len)
-{
-   ...
-}
-\end{verbatim}
-Here is the declaration of a function that allocates memory:
-
-\begin{verbatim}
-array_ptr<char> alloc(size_t size) : count(size);
-\end{verbatim}
 
 \subsection{Invariant bounds declarations}
 \label{section:invariant-bounds-declarations}
@@ -436,101 +439,63 @@ Because externally-scoped \arrayptr\ variables can have bounds declared
 for them only at their definitions, by definition their bounds are
 always invariants.
 
-\subsection{Lexical hiding of variables}
+\subsection{Byte counts for pointers to void}
+\label{section:pointers-to-void}
 
-A nested lexical scope is not allowed to hide a variable used in a
-bounds declaration within the extent of the bounds declaration. This
-prevents programs from accidentally invalidating the bounds declaration:
+The definition of count expressions poses a problem for
+\arrayptrvoid. \texttt{Void} is an
+incomplete type and has no defined size, which means that count
+expressions are ill-defined for
+\arrayptrvoid. To address this, a
+variant of count expressions where counts are given in terms of bytes is
+added:
 
-\begin{verbatim}
-/* illegal function */
-void bad(int i) 
-{
-    array_ptr<int> x : count(i) = malloc ((sizeof(int) * i);
-    {
-        int x = 5;     // hide x
-        i = INT_MAX;   // subvert bounds
-    }
-    x[random()] = 0xbad;
-}
-\end{verbatim}
+\var{bounds-exp:}
 
-\subsection{Storage class-related requirements}
+\begin{quote}
+\ldots{}
 
-Local variables with static storage class or thread storage class can
-have only bounds declarations with bounds expressions that use variables
-with the same storage class as the local variable or variables that are declared
-\texttt{const}. The memory for static variables and thread variables
-persists across exit and reentry from functions and blocks. It follows
-that the bounds information must persist also.
+\boundsbytecount{\var{non-modifying-exp}}
+\end{quote}
 
-Local variables with automatic storage class can have bounds
-declarations with bounds expressions that use variables with automatic,
-static, or thread storage class. However, the extent of local variable
-bounds declarations that use variables with external linkage ends at
-function calls, unless the variables with external linkage are declared
-\texttt{const}. This is because the function calls may modify the
-variables with external linkage.
+\texttt{byte\_count} is the identifier \texttt{byte\_count}.
+The bounds declaration \boundsdecl{\var{x}}{\boundsbytecount{\var{e1}}}
+describes the number of bytes that are accessible beginning at \var{x}. 
+Only memory that is at or above \var{x} and below \texttt{(\arrayptrchar)}
+\var{x} \texttt{+} \var{e1} can be accessed through \var{x}. The type
+of \var{e1} must be an integral type.  The usual C integer conversions are
+applied to \var{e1}.  This bounds declaration is a synonym for 
+\boundsdecl{\var{x}}
+           {\boundsrel{(\arrayptrchar) \var{x}}
+                      {(\arrayptrchar) \var{x} \texttt{+} \var{e1}}
+                      {\texttt{char}}}
 
-\section{Variables at external scope}
-\label{section:external-scope-variables}
-
-If there are multiple declarations of a variable with external scope in
-a translation unit, the bounds declaration and/or \keyword{where} clauses for the
-variable must be identical at all the declarations. This prevents the
-specification of different bounds for global variables in the same
-compilation unit. Any variables with external scope that have bounds
-declarations and/or \keyword{where} clauses must have the same bounds declaration
-and where clauses in all translation units.
-
-All places in a program that may write to a variable with external scope
-also must have the same view of the bounds declarations involving that
-variable. This allows static checking to ensure that bounds declarations
-remain valid.
-
-To see what can go wrong without this requirement, consider the
-following example:
+The standard C library functions for \texttt{malloc}, \texttt{memcmp}, and
+\texttt{memcpy} will be
+given bounds-safe interfaces to avoid breaking existing code as
+described in Section~\ref{section:function-bounds-safe-interfaces}. 
+However, if they were to return checked pointer
+types, their bounds declarations would be:
 
 \begin{verbatim}
-extern int size;
+array_ptr<void> malloc(size_t num) : byte_count(num);
 
-void update_size(int i)
-{
-    num = i;
-}
+int memcmp(array_ptr<const void> dest : byte_count(num),
+           array_ptr<const void> src : byte_count(num), size_t num);
 
-extern array_ptr<int> ap : count(size);
-
-void go(void)
-{
-    update_size(INT_MAX);
-    ap[100] = 0xbad;
-}
-
-// define size and ap
-int size = 10;
-int arr[10];
-array_ptr<int> ap = arr : count(size);
+array_ptr<void> memcpy(array_ptr<void> dest : byte_count(num),
+                       array_ptr<const void> src : byte_count(num), size_t num) :
+    byte_count(num);
 \end{verbatim}
 
-The checking of bounds declarations does not know at
-\texttt{update\_size} that \texttt{ap} needs to have at least \texttt{i}
-elements when \texttt{size} is updated, allowing a programmer to accidentally
-invalidate bounds declarations.
+The return value of \texttt{memcpy} is \texttt{dest}. The bounds for
+this return value could be described more precisely by:
 
-A simple rule enforces this restriction. Given the initial declaration
-in a translation unit of a variable with external scope that has a
-\keyword{where} clause, there cannot be any function definitions between
-the declaration and the initial declarations of other variables used in
-the bounds declaration for the variable or the optional \keyword{where} clause for the declaration.
-It is possible for the initial declaration of
-a variable with external scope to occur within the body of a function.
-In that case, there cannot be any statements or declarations of
-non-external variables with initializers between the initial declaration
-and the initial declarations of other variables used in the
-bounds declaration for the variable or the optional \keyword{where} clause for
-the declaration.
-
+\begin{verbatim}
+array_ptr<void> memcpy(array_ptr<void> dest : byte_count(num),
+                       array_ptr<void> src : byte_count(num), size_t num) :
+  bounds((<array_ptr<char>) dest, (array_ptr<char>) dest + num) rel_align(char)
+\end{verbatim}
 \section{Syntax changes}
 The grammar from the ``C Programming Language'' \cite{Ritchie1988} is extended to include
 in-line bounds declarations and \keyword{where} clauses for declarations:
@@ -596,7 +561,201 @@ must be the identifier \texttt{any} or the identifier \texttt{none}.
 \texttt{bounds}.
 \end{itemize}
 
-\section{Operations allowed in non-modifying expressions}
+\section{Insertion of bounds checks at pointer dereferences}
+
+\label{section:bounds-checking-indirections}
+
+Given *\var{e1}, where \var{e1} is an expression of type
+\arrayptr, the compiler determines the bounds for \var{e1}
+following the rules in Section~\ref{section:inferring-expression-bounds}.
+Special rules are followed in
+\texttt{bundled} blocks to determine the bounds for \var{e1}. The
+compiler inserts checks before the memory pointed to by \var{e1} is
+read or written that \var{e1} is non-null and that the value of
+\var{e1} is in bounds.
+
+If \boundsinfer{\var{e1}}{\bounds{\var{e2}}{\var{e3}}},
+the compiler inserts a runtime check that \texttt{\var{e2} <= \var{e1} \&\&
+\var{e1} < \var{e3}}. If the runtime check fails, the program
+will be terminated by the runtime system or in, systems that support it,
+a runtime exception will be raised.   If \boundsinfer{\var{e1}}{\boundscount{\var{e2}}},
+this is expanded to \boundsinfer{\var{e1}}{\bounds{\var{e1}}{\var{e1} + \var{e2}}}
+before inserting checks.  Of course a temporary variable would be used to hold the
+value of \var{e1}.
+
+Consider as an example, \verb|z = *x;| where 
+\verb|x : bounds(x, x + c)|. The compiler will produce code of the form
+
+\begin{quote}
+\begin{verbatim}
+dynamic_check(x != null);
+dynamic_check(x <= x && x < x + c);
+z = *t1;
+\end{verbatim}
+\end{quote}
+The condition \texttt{x <= x} is trivially true. The
+condition \texttt{x < x + c} simplifies to \texttt{0
+< c}, that is \texttt{c > 0}, which is what one
+would expect.
+
+Now suppose pointer arithmetic is involved and \texttt{z = *(x + 5)}. The
+bounds of \texttt{x + 5} will be the same as the bounds of \texttt{x}.
+The expression \texttt{x + 5} must point into the same object as
+\texttt{x} for this to be a valid memory access. This means that
+\boundsdecl{\texttt{x + 5}}{\bounds{\texttt{x}}{\texttt{x + c}}}.
+The compiler will produce code of the form:
+
+\begin{quote}
+\begin{verbatim}
+dynamic_check(x != null);
+t1 = x + 5;
+dynamic_check(t1 != null && x <= t1 && t1 < x + c);
+z = *t1;
+\end{verbatim}
+\end{quote}
+
+Array subscripting works as expected. For \texttt{e1[e2]}, the
+compiler computes the bounds of \texttt{e1}. The compiler inserts
+runtime checks that \texttt{e1 + e2} is within this bounds. For example,
+given \verb|x[5]| where \verb|x : bounds(x, x + c)|, the
+compiler inserts runtime checks that \verb|x <= x + 5 < x + c|. 
+The runtime checks simplify to \verb|5 < c|.
+
+\subsection{Evaluation of bounds at bounds checks}
+
+The preceding example raises a subtle point, which is when bounds
+expressions are evaluated. Consider the following code:
+
+\begin{verbatim}
+array_ptr<int> x;
+x = malloc ((sizeof(int) * 5)
+where x : bounds(x, x + 5);
+\end{verbatim}
+
+When is \texttt{x + 5} evaluated?  In this design, 
+the evaluation of a bounds expression in a bounds declaration is
+{\em deferred} until a bounds check uses the bounds expression. 
+This avoids the need for temporary storage to 
+hold the value of \texttt{x + 5}.  The need for temporary storage would
+be particularly problematic when bounds declarations are extended
+to structures.   It also avoids complications when \texttt{x} is
+\texttt{null}. Section~\ref{section:bounds-declarations-alternate-semantics} 
+discusses eager evaluation of bounds expressions at
+bounds declarations in more detail and explains why this was not chosen.
+
+\section{Bundling statements and declarations}
+
+It is common in C code to use multiple statements to update program state.
+This can cause problems when variables in a bounds declaration are updated.
+Invariant bounds declarations must be valid at the end of every statement.
+When updates involve multiple statements, a bounds declaration may be valid only
+after all the updates are done.  In Checked C, statements and declarations can be 
+grouped into bundled blocks.  Bounds declarations are checked only at the end of bundled blocks.
+
+Consider the following example where a function is added to the earler sum
+example that allows a buffer to be reallocated:
+\begin{verbatim}
+// external-scoped variables that hold a buffer and its length
+int buflen = 0;
+array_ptr<int> buf : count(buflen) = NULL;
+
+int sum(void)
+{
+   int result = 0;
+   for (int i = 0; i < buflen; i++) {
+       result += buf[i]; // bounds checked
+   }
+   return result;
+}
+
+/* buggy resize function */
+void resize(int len) 
+{
+    array_ptr<int> tmp : count(len) = malloc(sizeof(int) * len);
+    copy(tmp, buf, buflen);
+    buflen = len;  // fails at compile-time because the bounds are not true
+    buf = tmp;
+}
+\end{verbatim}
+Without bundling, the update to \texttt{buflen} will fail
+compile-time checking because the bounds declaration is not true after the
+assignment.
+
+The updates to \texttt{buflen} and \texttt{buf} can be grouped together,
+so the checker considers them to be one action:
+\begin{verbatim}
+/* correct resize function */
+void resize(int len) 
+{
+    array_ptr<int> tmp : count(len) = malloc(sizeof(int) * len);
+    copy(tmp, buf, buflen);
+    bundle {
+      buflen = len;
+      buf = tmp;
+    }
+}
+\end{verbatim}
+
+The C syntax for is extended with:
+\begin{tabbing}
+\var{statement:}\=\\
+\>\var{bundled-statement}\texttt{;} \\
+\\
+\var{bundled-statement:} \\
+\>\texttt{bundled \{ \var{bundled-item-list\textsubscript{opt}} \}} \\
+\\
+\var{bundled-item-list:}\\
+\> \var{bundled-item} \\
+\> \var{bundled-item-list bundled-item} \\
+\\
+\var{bundled-item:}\\
+\> \var{declaration}\\
+\> \var{expression-statement} 
+\end{tabbing}
+
+There is some subtlety with bundled blocks and function calls. The
+bounds declarations for any static variables must be valid before any
+function call in a bundle. This is because the called function may make
+use of the static variables. It will assume that the bounds declaration
+holds when it uses the static variables. In general, programmers may
+deal with this requirement by using the idiom of storing function call
+results in temporary variables and updating static variables \textit{en
+masse} after the required function calls have been made.
+
+Bundled blocks expose an interesting difference between regular C
+and Checked C programs.  In regular C, 
+\begin{verbatim}
+expr1, expr2;
+\end{verbatim}
+
+is always the same as:
+
+\begin{verbatim}
+expr1;
+expr2;
+\end{verbatim}
+
+In Checked C, however, bounds are checked only at the ends of
+statements.  Thus bounds could be valid after
+\verb+expr1, expr+, but not valid after \verb+expr1+ alone.
+In the resize example, the following suceeds with a bundle
+block:
+\begin{verbatim}
+void resize(int len) 
+{
+    array_ptr<int> tmp = malloc(sizeof(int) * len);
+    copy(tmp, buf, buflen);
+    buflen = len, buf = tmp; // succeeds, surprisingly
+}
+\end{verbatim}
+Bundled blocks are still necessary because new declarations
+cannot be introduced cannot be introduced within a comma
+operators.  They also provide easier-to-read syntax for
+complex updates to variables.
+
+\section{Additional requirements for bounds declarations}
+
+\subsection{Operations allowed in non-modifying expressions}
 \label{section:non-modifying-expressions}
 
 As mentioned earlier, non-modifying expressions are a subset of C
@@ -681,6 +840,219 @@ It is suggested that programmers use simple non-modifying expressions because
 the expressions may be fully re-evaluated at every bounds check involving the
 bounds expression. More complicated bounds expressions are allowed
 because programmers might find them useful.
+
+
+\subsection{Lexical hiding of variables}
+
+A nested lexical scope is not allowed to hide a variable used in a
+bounds declaration within the extent of the bounds declaration. This
+prevents programs from accidentally invalidating the bounds declaration:
+
+\begin{verbatim}
+/* illegal function */
+void bad(int i) 
+{
+    array_ptr<int> x : count(i) = malloc ((sizeof(int) * i);
+    {
+        int x = 5;     // hide x
+        i = INT_MAX;   // subvert bounds
+    }
+    x[random()] = 0xbad;
+}
+\end{verbatim}
+
+\subsection{Storage class-related requirements}
+
+Local variables with static storage class or thread storage class can
+have only bounds declarations with bounds expressions that use variables
+with the same storage class as the local variable or variables that are declared
+\texttt{const}. The memory for static variables and thread variables
+persists across exit and reentry from functions and blocks. It follows
+that the bounds information must persist also.
+
+Local variables with automatic storage class can have bounds
+declarations with bounds expressions that use variables with automatic,
+static, or thread storage class. However, the extent of local variable
+bounds declarations that use variables with external linkage ends at
+function calls, unless the variables with external linkage are declared
+\texttt{const}. This is because the function calls may modify the
+variables with external linkage.
+
+\subsection{Variables at external scope}
+\label{section:external-scope-variables}
+
+If there are multiple declarations of a variable with external scope in
+a translation unit, the bounds declaration and/or \keyword{where} clauses for the
+variable must be identical at all the declarations. This prevents the
+specification of different bounds for global variables in the same
+compilation unit. Any variables with external scope that have bounds
+declarations and/or \keyword{where} clauses must have the same bounds declaration
+and where clauses in all translation units.
+
+All places in a program that may write to a variable with external scope
+also must have the same view of the bounds declarations involving that
+variable. This allows static checking to ensure that bounds declarations
+remain valid.
+
+To see what can go wrong without this requirement, consider the
+following example:
+
+\begin{verbatim}
+extern int size;
+
+void update_size(int i)
+{
+    num = i;
+}
+
+extern array_ptr<int> ap : count(size);
+
+void go(void)
+{
+    update_size(INT_MAX);
+    ap[100] = 0xbad;
+}
+
+// define size and ap
+int size = 10;
+int arr[10];
+array_ptr<int> ap = arr : count(size);
+\end{verbatim}
+
+The checking of bounds declarations does not know at
+\texttt{update\_size} that \texttt{ap} needs to have at least \texttt{i}
+elements when \texttt{size} is updated, allowing a programmer to accidentally
+invalidate bounds declarations.
+
+A simple rule enforces this restriction. Given the initial declaration
+in a translation unit of a variable with external scope that has a
+\keyword{where} clause, there cannot be any function definitions between
+the declaration and the initial declarations of other variables used in
+the bounds declaration for the variable or the optional \keyword{where} clause for the declaration.
+It is possible for the initial declaration of
+a variable with external scope to occur within the body of a function.
+In that case, there cannot be any statements or declarations of
+non-external variables with initializers between the initial declaration
+and the initial declarations of other variables used in the
+bounds declaration for the variable or the optional \keyword{where} clause for
+the declaration.
+
+\section{Size computations and integer overflow or wraparound}
+\label{section:integer-overflow-informal}
+
+When objects are allocated dynamically in C, programmers have to compute
+the amount of memory to allocate for the objects. It is well-known 
+that integer overflow or wraparound in these computations can lead to buffer
+overruns \cite{Howard2003,Mitre2015-128,Mitre2015-190,Mitre2015-680,Dietz2015}.
+ In Checked C, the explicit size computations are not enough
+to imply that the bounds for a newly-allocated object are valid.
+Additional side conditions that deal with integer overflow or wraparound
+are needed.
+
+This section informally examines why and the additional conditions that
+are needed. We start by looking at an allocation using malloc with an
+old-style \texttt{char *} return type and a bounds declaration:
+
+\begin{verbatim}
+extern char *malloc(size_t s) : count(s);
+\end{verbatim}
+
+An array of type T is allocated with:
+
+\begin{verbatim}
+array_ptr<T> p : count(e1) = (arrayptr<T>) malloc(sizeof(T) * e1);
+\end{verbatim}
+
+The size computation in the count expression differs subtly from the
+explicit computation on the right-hand side. In the count expression,
+arithmetic with overflow checking is used, while the explicit
+computation does not have overflow checking. Intuitively, this leads to
+a mismatch when overflow or wraparound can happen, which causes static
+checking to fail.
+
+We expand the count expression to integer arithmetic to make its size
+computation clear. \texttt{count(e1)} expands to \bounds{p}{p + e1}. 
+Following the rules in Section~\ref{section:pointers-as-integers},
+the expansion of \texttt{p +
+e1} from pointer arithmetic to integer arithmetic depends on the type of
+\texttt{e1}.
+
+\begin{itemize}
+\item
+  If \texttt{e1} is an unsigned integer, \texttt{p + e1} expands to
+  \texttt{p +\textsubscript{ovf} sizeof(T) *\textsubscript{ovf} e1}
+\item
+  If \texttt{e1} is a signed integer, \texttt{p + e1} expands to
+  \texttt{p +\textsubscript{ovf} ((signed\_size\_t) sizeof(T))
+  *\textsubscript{ovf} e1}.
+\end{itemize}
+
+The number of bytes added to \texttt{p} is the size computation of the
+count expression. We can compare the size computations and see when the
+values differ. We add casts for any implicit conversions that would
+occur in the \texttt{malloc} size computation also:
+
+\begin{longtable}[c]{lp{1.75in}p{1.75in}p{1in}}
+\toprule
+Type of e1 & Count size computation & \texttt{malloc} size computation &
+Values differ?\tabularnewline
+\midrule
+\endhead
+Unsigned integer & \texttt{sizeof(T) *\textsubscript{ovf} e1} &
+\texttt{sizeof(T) * e1} & On overflow\tabularnewline
+Signed integer & \texttt{((signed\_size\_t) sizeof(T))
+*\textsubscript{ovf} e1} & \texttt{sizeof(T) * (size\_t) e1} & On
+overflow or when \texttt{e1 <} 0.\tabularnewline
+\bottomrule
+\end{longtable}
+
+For correctness, we want the count size computation and the
+\texttt{malloc} size computations to produce identical values. This
+implies that malloc did allocate the number of bytes expected by the
+count size computation. We add conditions on \texttt{e1} to do this:
+
+\begin{longtable}[c]{ll}
+\toprule
+Type of e1 & Restrictions\tabularnewline
+\midrule
+\endhead
+Unsigned integer & \texttt{e1 <= UINT\_MAX/sizeof(T)}\tabularnewline
+Signed integer & \texttt{e1 >= 0 and e1 <= INT\_MAX/sizeof(T)}\tabularnewline
+\bottomrule
+\end{longtable}
+
+This has an interesting implication for any function that allocates an
+array of \var{T}. If the count of elements is constant, of course these
+conditions are trivial. If the count is non-constant, the function
+must do the following checks:
+
+\begin{itemize}
+\item
+  If the count is a signed integer, the function must check that the
+  count \textgreater{}= 0 before trying to allocate the array.
+\item
+  If the size of \var{T} is larger than 1 byte, the function must check that the
+  count is less than the upper bound as well.
+\end{itemize}
+
+When retrofitting existing code to use checked pointers, the code may be
+unprepared for overflow or wraparound to happen during allocation. This
+suggests that uses of \texttt{malloc} should be replaced by slightly
+higher-level functions that takes the element count and the size of
+elements and handle overflow. C already has a function that is suitable
+for unsigned integer counts:
+
+\begin{verbatim}
+void *calloc(size_t nobj, size_t size);
+\end{verbatim}
+
+A signed version is needed too:
+\begin{verbatim}
+void *signed_calloc(signed_size_t nobj, size_t size);
+\end{verbatim}
+However, \texttt{calloc} also zeros the allocated memory.  For the sake of efficiency,
+new allocation functions that compute sizes but do not zero memory may be needed.
+
 
 \section{Bounds declarations for results of casts between \arrayptr\ types}
 \label{section:pointer-cast-results}
@@ -797,6 +1169,15 @@ specified, \sizeof{\var{T}} is replaced by the
 constant expression.  The relative alignment clause \relalign{\var{type}}
 is just short-hand for \relalignval{\texttt{sizeof(\var{type})}}.
 
+\subsection{Effect on bounds checks}
+
+If the default relative alignment has been overridden and
+\boundsdecl{\var{e1}}{\boundsrel{\var{e2}}{\var{e3}}{\var{T}}}, the compiler checks whether
+\texttt{sizeof(referent-type(\var{e1}))} is a common factor of \texttt{sizeof(\var{T})}. 
+If it is, it inserts the same
+runtime check as before. Otherwise, it inserts a runtime check that
+\texttt{\var{e2} <= \var{e1} \&\& \var{e1} + sizeof(\var{T}) - 1 < \var{e3}}
+
 \subsection{Examples of uses of bounds declarations that specify relative alignment}
 
 Here are examples of the use of relative alignment clauses in
@@ -912,64 +1293,6 @@ bytes of characters can be converted easily a pointer to 2 integers:
 char a[] = "0123456";
 array_ptr<char> p : count(8) = a;
 array_ptr<int> r : count(2) = (array_ptr<int>) p;
-\end{verbatim}
-
-\section{Pointers to void}
-\label{section:pointers-to-void}
-
-The definition of count expressions poses a problem for
-\arrayptrvoid. \texttt{Void} is an
-incomplete type and has no defined size, which means that count
-expressions are ill-defined for
-\arrayptrvoid. To address this, a
-variant of count expressions where counts are given in terms of bytes is
-added:
-
-\var{bounds-exp:}
-
-\begin{quote}
-\ldots{}
-
-\boundsbytecount{\var{non-modifying-exp}}
-\end{quote}
-
-\texttt{byte\_count} is the identifier \texttt{byte\_count}.
-The bounds declaration \boundsdecl{\var{x}}{\boundsbytecount{\var{e1}}}
-describes the number of bytes that are accessible beginning at \var{x}. 
-Only memory that is at or above \var{x} and below \texttt{(\arrayptrchar)}
-\var{x} \texttt{+} \var{e1} can be accessed through \var{x}. The type
-of \var{e1} must be an integral type.  The usual C integer conversions are
-applied to \var{e1}.  This bounds declaration is a synonym for 
-\boundsdecl{\var{x}}
-           {\boundsrel{(\arrayptrchar) \var{x}}
-                      {(\arrayptrchar) \var{x} \texttt{+} \var{e1}}
-                      {\texttt{char}}}
-
-The standard C library functions for \texttt{malloc}, \texttt{memcmp}, and
-\texttt{memcpy} will be
-given bounds-safe interfaces to avoid breaking existing code as
-described in Section~\ref{section:function-bounds-safe-interfaces}. 
-However, if they were to return checked pointer
-types, their bounds declarations would be:
-
-\begin{verbatim}
-array_ptr<void> malloc(size_t num) : byte_count(num);
-
-int memcmp(array_ptr<const void> dest : byte_count(num),
-           array_ptr<const void> src : byte_count(num), size_t num);
-
-array_ptr<void> memcpy(array_ptr<void> dest : byte_count(num),
-                       array_ptr<const void> src : byte_count(num), size_t num) :
-    byte_count(num);
-\end{verbatim}
-
-The return value of \texttt{memcpy} is \texttt{dest}. The bounds for
-this return value could be described more precisely by:
-
-\begin{verbatim}
-array_ptr<void> memcpy(array_ptr<void> dest : byte_count(num),
-                       array_ptr<void> src : byte_count(num), size_t num) :
-  bounds((<array_ptr<char>) dest, (array_ptr<char>) dest + num) rel_align(char)
 \end{verbatim}
 
 \section{Extent of dataflow-sensitive bounds declarations}
@@ -1318,306 +1641,3 @@ int compare(array_ptr<int> x : bounds(x, x_end),
 }
 \end{verbatim}
 
-\section{Bundling statements and declarations}
-
-Invariant bounds declarations must be valid at the end of every
-statement. The effect of the statement must preserve the validity of the
-bounds declarations. This is too restrictive when multiple statements
-are used to update variables involved in a bounds declaration.
-
-For example, suppose a function was added to the earlier sum example
-that allowed for the buffer to be reallocated:
-\begin{verbatim}
-// external-scoped variables that hold a buffer and its length
-int buflen = 0;
-array_ptr<int> buf : count(buflen) = NULL;
-
-int sum(void)
-{
-   int result = 0;
-   for (int i = 0; i < buflen; i++) {
-       result += buf[i]; // bounds checked
-   }
-   return result;
-}
-
-/* buggy resize function */
-void resize(int len) 
-{
-    array_ptr<int> tmp : count(len) = malloc(sizeof(int) * len);
-    copy(tmp, buf, buflen);
-    buflen = len;  // fails at compile-time because the bounds are not true
-    buf = tmp;
-}
-\end{verbatim}
-In this example, the update to \texttt{buflen} fails compile-time
-checking because the bounds declaration is not true after the
-assignment. If the two updates are combined into one statement, though,
-the checking would succeed.
-
-\begin{verbatim}
-void resize(int len) 
-{
-    array_ptr<int> tmp = malloc(sizeof(int) * len);
-    copy(tmp, buf, buflen);
-    buflen = len, buf = tmp; // succeeds, surprisingly
-}
-\end{verbatim}
-
-This is an interesting difference between regular C, where
-
-\begin{verbatim}
-expr1, expr2;
-\end{verbatim}
-
-is always the same as:
-
-\begin{verbatim}
-expr1;
-expr2;
-\end{verbatim}
-
-To allow invariant bounds to be checked after several statements or
-initializing declarations, we introduce the notion of a bundled block.
-Assignment statements and declarations can be grouped together using a
-bundled block. Bounds declarations must be valid only at the end of the
-block:
-
-\begin{verbatim}
-if (cond  && clen > 1) {
-    bundle {
-        c++;
-        clen = clen - 1;
-    }
-}
-\end{verbatim}
-
-There is some subtlety with bundled blocks and function calls. The
-bounds declarations for any static variables must be valid before any
-function call in a bundle. This is because the called function may make
-use of the static variables. It will assume that the bounds declaration
-holds when it uses the static variables. In general, programmers may
-deal with this requirement by using the idiom of storing function call
-results in temporary variables and updating static variables \textit{en
-masse} after the required function calls have been made.
-
-The C syntax for is extended with:
-\begin{tabbing}
-\var{statement:}\=\\
-\>\var{bundled-statement}\texttt{;} \\
-\\
-\var{bundled-statement:} \\
-\>\texttt{bundled \{ \var{bundled-item-list\textsubscript{opt}} \}} \\
-\\
-\var{bundled-item-list:}\\
-\> \var{bundled-item} \\
-\> \var{bundled-item-list bundled-item} \\
-\\
-\var{bundled-item:}\\
-\> \var{declaration}\\
-\> \var{expression-statement} 
-\end{tabbing}
-
-\section{Bounds checks at pointer dereferences}
-\label{section:bounds-checking-indirections}
-
-Given *\var{e1}, where \var{e1} is an expression of type
-\arrayptr, the compiler determines the bounds for \var{e1}
-following the rules in Section~\ref{section:inferring-expression-bounds}.
-Special rules are followed in
-\texttt{bundled} blocks to determine the bounds for \var{e1}. The
-compiler inserts checks before the memory pointed to by \var{e1} is
-read or written that \var{e1} is non-null and that the value of
-\var{e1} is in bounds.
-
-If \boundsinfer{\var{e1}}{\bounds{\var{e2}}{\var{e3}}},
-the compiler inserts a runtime check that \texttt{\var{e2} <= \var{e1} \&\&
-\var{e1} < \var{e3}}. If the runtime check fails, the program
-will be terminated by the runtime system or in, systems that support it,
-a runtime exception will be raised.   If \boundsinfer{\var{e1}}{\boundscount{\var{e2}}},
-this is expanded to \boundsinfer{\var{e1}}{\bounds{\var{e1}}{\var{e1} + \var{e2}}}
-before inserting checks.  Of course a temporary variable would be used to hold the
-value of \var{e1}.
-
-If the default relative alignment has been overridden and
-\boundsdecl{\var{e1}}{\boundsrel{\var{e2}}{\var{e3}}{\var{T}}}, the compiler checks whether
-\texttt{sizeof(referent-type(\var{e1}))} is a common factor of \texttt{sizeof(\var{T})}. 
-If it is, it inserts the same
-runtime check as before. Otherwise, it inserts a runtime check that
-\texttt{\var{e2} <= \var{e1} \&\& \var{e1} + sizeof(\var{T}) - 1 < \var{e3}}
-
-Consider as an example, \verb|z = *x;| where 
-\verb|x : bounds(x, x + c)|. The compiler will produce code of the form
-
-\begin{quote}
-\begin{verbatim}
-dynamic_check(x != null);
-dynamic_check(x <= x && x < x + c);
-z = *t1;
-\end{verbatim}
-\end{quote}
-The condition \texttt{x <= x} is trivially true. The
-condition \texttt{x < x + c} simplifies to \texttt{0
-< c}, that is \texttt{c > 0}, which is what one
-would expect.
-
-Now suppose pointer arithmetic is involved and \texttt{z = *(x + 5)}. The
-bounds of \texttt{x + 5} will be the same as the bounds of \texttt{x}.
-The expression \texttt{x + 5} must point into the same object as
-\texttt{x} for this to be a valid memory access. This means that
-\boundsdecl{\texttt{x + 5}}{\bounds{\texttt{x}}{\texttt{x + c}}}.
-The compiler will produce code of the form:
-
-\begin{quote}
-\begin{verbatim}
-dynamic_check(x != null);
-t1 = x + 5;
-dynamic_check(t1 != null && x <= t1 && t1 < x + c);
-z = *t1;
-\end{verbatim}
-\end{quote}
-
-Array subscripting works as expected. For \texttt{e1[e2]}, the
-compiler computes the bounds of \texttt{e1}. The compiler inserts
-runtime checks that \texttt{e1 + e2} is within this bounds. For example,
-given \verb|x[5]| where \verb|x : bounds(x, x + c)|, the
-compiler inserts runtime checks that \verb|x <= x + 5 < x + c|. 
-The runtime checks simplify to \verb|5 < c|.
-
-\subsection{Evaluation of bounds at bounds checks}
-
-The preceding example raises a subtle point, which is when bounds
-expressions are evaluated. Consider the following code:
-
-\begin{verbatim}
-array_ptr<int> x;
-x = malloc ((sizeof(int) * 5)
-where x : bounds(x, x + 5);
-\end{verbatim}
-
-When is \texttt{x + 5} evaluated?  In this design, 
-the evaluation of a bounds expression in a bounds declaration is
-{\em deferred} until a bounds check uses the bounds expression. 
-This avoids the need for temporary storage to 
-hold the value of \texttt{x + 5}.  The need for temporary storage would
-be particularly problematic when bounds declarations are extended
-to structures.   It also avoids complications when \texttt{x} is
-\texttt{null}. Section~\ref{section:bounds-declarations-alternate-semantics} 
-discusses eager evaluation of bounds expressions at
-bounds declarations in more detail and explains why this was not chosen.
-
-\section{Size computations and integer overflow or wraparound}
-\label{section:integer-overflow-informal}
-
-When objects are allocated dynamically in C, programmers have to compute
-the amount of memory to allocate for the objects. It is well-known 
-that integer overflow or wraparound in these computations can lead to buffer
-overruns \cite{Howard2003,Mitre2015-128,Mitre2015-190,Mitre2015-680,Dietz2015}.
- In Checked C, the explicit size computations are not enough
-to imply that the bounds for a newly-allocated object are valid.
-Additional side conditions that deal with integer overflow or wraparound
-are needed.
-
-This section informally examines why and the additional conditions that
-are needed. We start by looking at an allocation using malloc with an
-old-style \texttt{char *} return type and a bounds declaration:
-
-\begin{verbatim}
-extern char *malloc(size_t s) : count(s);
-\end{verbatim}
-
-An array of type T is allocated with:
-
-\begin{verbatim}
-array_ptr<T> p : count(e1) = (arrayptr<T>) malloc(sizeof(T) * e1);
-\end{verbatim}
-
-The size computation in the count expression differs subtly from the
-explicit computation on the right-hand side. In the count expression,
-arithmetic with overflow checking is used, while the explicit
-computation does not have overflow checking. Intuitively, this leads to
-a mismatch when overflow or wraparound can happen, which causes static
-checking to fail.
-
-We expand the count expression to integer arithmetic to make its size
-computation clear. \texttt{count(e1)} expands to \bounds{p}{p + e1}. 
-Following the rules in Section~\ref{section:pointers-as-integers},
-the expansion of \texttt{p +
-e1} from pointer arithmetic to integer arithmetic depends on the type of
-\texttt{e1}.
-
-\begin{itemize}
-\item
-  If \texttt{e1} is an unsigned integer, \texttt{p + e1} expands to
-  \texttt{p +\textsubscript{ovf} sizeof(T) *\textsubscript{ovf} e1}
-\item
-  If \texttt{e1} is a signed integer, \texttt{p + e1} expands to
-  \texttt{p +\textsubscript{ovf} ((signed\_size\_t) sizeof(T))
-  *\textsubscript{ovf} e1}.
-\end{itemize}
-
-The number of bytes added to \texttt{p} is the size computation of the
-count expression. We can compare the size computations and see when the
-values differ. We add casts for any implicit conversions that would
-occur in the \texttt{malloc} size computation also:
-
-\begin{longtable}[c]{lp{1.75in}p{1.75in}p{1in}}
-\toprule
-Type of e1 & Count size computation & \texttt{malloc} size computation &
-Values differ?\tabularnewline
-\midrule
-\endhead
-Unsigned integer & \texttt{sizeof(T) *\textsubscript{ovf} e1} &
-\texttt{sizeof(T) * e1} & On overflow\tabularnewline
-Signed integer & \texttt{((signed\_size\_t) sizeof(T))
-*\textsubscript{ovf} e1} & \texttt{sizeof(T) * (size\_t) e1} & On
-overflow or when \texttt{e1 <} 0.\tabularnewline
-\bottomrule
-\end{longtable}
-
-For correctness, we want the count size computation and the
-\texttt{malloc} size computations to produce identical values. This
-implies that malloc did allocate the number of bytes expected by the
-count size computation. We add conditions on \texttt{e1} to do this:
-
-\begin{longtable}[c]{ll}
-\toprule
-Type of e1 & Restrictions\tabularnewline
-\midrule
-\endhead
-Unsigned integer & \texttt{e1 <= UINT\_MAX/sizeof(T)}\tabularnewline
-Signed integer & \texttt{e1 >= 0 and e1 <= INT\_MAX/sizeof(T)}\tabularnewline
-\bottomrule
-\end{longtable}
-
-This has an interesting implication for any function that allocates an
-array of \var{T}. If the count of elements is constant, of course these
-conditions are trivial. If the count is non-constant, the function
-must do the following checks:
-
-\begin{itemize}
-\item
-  If the count is a signed integer, the function must check that the
-  count \textgreater{}= 0 before trying to allocate the array.
-\item
-  If the size of \var{T} is larger than 1 byte, the function must check that the
-  count is less than the upper bound as well.
-\end{itemize}
-
-When retrofitting existing code to use checked pointers, the code may be
-unprepared for overflow or wraparound to happen during allocation. This
-suggests that uses of \texttt{malloc} should be replaced by slightly
-higher-level functions that takes the element count and the size of
-elements and handle overflow. C already has a function that is suitable
-for unsigned integer counts:
-
-\begin{verbatim}
-void *calloc(size_t nobj, size_t size);
-\end{verbatim}
-
-A signed version is needed too:
-\begin{verbatim}
-void *signed_calloc(signed_size_t nobj, size_t size);
-\end{verbatim}
-However, \texttt{calloc} also zeros the allocated memory.  For the sake of efficiency,
-new allocation functions that compute sizes but do not zero memory may be needed.


### PR DESCRIPTION
Rearrange the order in which material is presented in Chapter 3 (bounds for variables) to flow more logically.

- Present the important concepts that programmers will need to know in earlier
  sections.
- Move the more advanced technical material to later sections.  This includes
  additional requirements on bounds declarations that programmers may need
  to rarely consult.  It also includes support for non-relatively
  aligned pointers and detailed technical descriptions of concepts such
  as flow-sensitive bounds declarations.
- Update the description of bundled blocks to be more succinct and
  direct.  Discuss the somewhat esoteric differences between e1, e2 and
  e1; e2 in Checked C at the end of the section.