### PR TITLE
Rename some sections.

### DIFF
--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1,6 +1,6 @@
 % !Tex root = checkedc.tex
 
-\chapter{Checking validity of bounds for variables}
+\chapter{Checking validity of bounds declarations for variables}
 \label{chapter:checking-bounds}
 
 This chapter describes basic rules for determining the validity of

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -350,7 +350,7 @@ array_ptr<char> alloc(size_t size) : count(size);
 
 
 
-\subsection{Bounds declarations at expression statements}
+\subsection{Bounds declarations at statements}
 \label{section:statement-declarations}
 
 Programmers may wish to delay initializing variables or may wish to
@@ -1295,7 +1295,7 @@ array_ptr<char> p : count(8) = a;
 array_ptr<int> r : count(2) = (array_ptr<int>) p;
 \end{verbatim}
 
-\section{Extent of dataflow-sensitive bounds declarations}
+\section{Extent of bounds declarations at statements}
 \label{section:extent-of-declarations}
 
 Variables that have bounds declared for them at expression statements


### PR DESCRIPTION
Update the title of Chapter 4 to be clearer.  The terminology
"check bounds" is ambiguous and could be misconstrued to be about
runtime bounds checks.  The chapter is really about checking bounds
declarations.

Update the title of "Extent of dataflow-sensitive bounds declarations"
to be "Extent of bounds declared at statements".  The terminology "dataflow"
is specific to compilers, so avoid it.