### PR TITLE
Extend function types with bounds information

### DIFF
--- a/spec/bounds_safety/design-alternatives.tex
+++ b/spec/bounds_safety/design-alternatives.tex
@@ -459,6 +459,34 @@ This makes it more likely that programming errors involving bounds
 declarations are detected only at runtime.   We did not pursue
 this approach further for this reason.
 
+\section{Function pointer casts}
+
+The rules in Section~\ref{section:pointer-casting} for casting between function
+pointers require that the bounds declarations on parameters and return values be
+identical after conversions to canonical forms.   It is possible to have
+more general rules around function pointer casts, at least from a checking
+perspective.
+
+For example, a function that expects an \arrayptr\ with 5 elements can
+always be used in place of one that expects an \arrayptr\ with 10 elements.
+This implies that a function pointer that expects an \arrayptr\ with 5
+elements can be cast to a function pointer that expects an \arrayptr\ with
+10 elements.  Similarly, a function that returns an \arrayptr\ with 10 elements
+can always be used in place of a function that returns an \arrayptr\ with 5
+elements.
+
+More generally, a function with weaker preconditions can be used in place
+of one with stronger preconditions.  A function with stronger post-conditions
+can be used in place of a function with weaker post-conditions.
+
+We chose not to generalize the rules for function pointer casts until we have
+evidence from real-world experience that the generalization is needed.   It is
+likely that we will to need to add support for weaker preconditions and stronger
+post-conditions for \keyword{where} clauses on casts to function pointer types,
+to avoid surprising programmers.  It is unclear whether this would be useful in
+practice for bounds declarations on pointer types, or only of theoretical
+interest.
+
 \section{Null pointers and bounds expressions}
 
 \newcommand{\objectbounds}[2]{\texttt{object\_bounds(#1, #2)}}

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -126,10 +126,9 @@ to any existing C typing rules that apply to the cast.
 \item If \var{D} and \var{S} are compatible types or \var{D} and \var{S} are unchecked
 pointer types, checking succeeds.
 
-\item Otherwise, if \var{D} is \ptrvoid\ or \uncheckedptrvoid\ and \var{S} is a \ptr\ type, 
-checking succceeds.\footnote{This rule follows from the next rule, but it is easier to understand 
-stated as a separate rule.}
-
+\item Otherwise, if \var{D} is \ptrvoid\ or \uncheckedptrvoid\ and \var{S} is a \ptr\ type,
+checking succceeds.\footnote{This rule is implied logically by other rules.   We present
+it separately so that there is a simple rule for casts to void pointers.}
 \item Otherwise, if \var{D} is not a function pointer type and \var{D} is
 \begin{itemize}
 \item \ptrT: the bounds of \var{e} are computed using the rules
@@ -155,15 +154,15 @@ type \spanptrT\ with the value of \var{e} and \bounds{\var{lb}}{\var{ub}} will b
 \begin{itemize}
 \item \ptrT, the checking succeeds. This handles the case where \var{T}
 is an incomplete type.
-\item Otherwise, the same rules are followed as for \ptrT.
+\item Otherwise, the rules for \ptrT\ are followed.
 \end{itemize}
 \end{itemize}
 
 \item Otherwise, if \var{D} is a function pointer type,
 \begin{itemize}
-\item If \var{S} is a pointer to a function type, \var{D} is \ptrT,
-\var{S} is \uncheckedptrinst{U}, \var{T} and \var{U} are compatible types, 
-and \var{e} is a function name, checking succeeds.
+\item Function names with unchecked function pointer types can be cast to have corresponding checked
+pointer types.  If \var{e} is a function name, \var{D} is \ptrT, \var{S} is \uncheckedptrinst{U},
+and \var{T} and \var{U} are compatible types, checking succeeds.
 \item Otherwise, checking fails with a compile-time error.
 \end{itemize}
 \end{itemize}
@@ -302,15 +301,15 @@ void f(void) {
 C allows implicit conversions at assignments, function call arguments,
 and conditional expressions.  The purpose of
 implicit conversions is to make programs shorter and easier to
-read.  Implicit conversions describe when a expression of type
-\var{S} is allowed where an expression of type \var{ST} is expected.
+read.  Implicit conversions describe when an expression of type
+\var{S} is allowed where an expression of type \var{T} is expected.
 They allow additional programs to typecheck.
-This section defines implicit conversions that are allowed for checked 
+This section defines implicit conversions that are allowed for checked
 pointer types.
 
 An implicit conversion may allow typechecking to succeed, but
 checking of bounds declarations may still fail.  Implicit
-conversions are treated as though they are explicit C cast 
+conversions are treated as though they are explicit C cast
 operations during the checking of bounds declarations.
 
 \subsection{From unchecked pointers to checked pointers}
@@ -459,19 +458,10 @@ void f(void) {
 \section{Bounds-safe interfaces to existing unchecked functions and variables}
 \label{section:function-bounds-safe-interfaces}
 
-The new pointer types capture specific properties of pointers. We would
-like to update existing C code to use these new pointer types. However,
-this is not possible when backward compatibility requirements exist. 
-For C runtime function or operating system (OS) APIs, it is possible
-to modify the header files that declare them. It is impractical, however,
-to require  all {\em uses} of these functions or APIs be updated.   Code written by
-3\textsuperscript{rd} 
-parties may use these APIs and an existing shipping OS cannot reasonably require all
-3\textsuperscript{rd} parties update their existing code to use the new
-types.
-
-Consider what would happen if the signature for memcpy were updated to
-use \arrayptr. The function
+The new pointer types capture specific properties of pointers. We would like to update
+existing C code to use the new pointer types. This would be problematic for library and operating
+system APIs that have backward  compatibility constraints, though.   Consider what would happen
+if the signature for \texttt{memcpy} were updated to use \arrayptr. The function
 
 \begin{verbatim}
 void *memcpy(void *dest, const void *src, size_t count);
@@ -483,21 +473,15 @@ becomes
 void *memcpy(array_ptr<void> dest, array_ptr<const void> src, size_t count);
 \end{verbatim}
 
-This, of course, breaks every piece of existing code that uses \texttt{memcpy}.
-The code will no longer compile. C does not have method overloading, so
-we cannot simply define multiple overloaded versions of \texttt{memcpy}. That
-would also duplicate code and potentially increase program sizes.
-The reverse problem also exists: suppose the signature for \texttt{memcpy} is not
-updated. Then every ``checked'' method that calls memcpy would need to cast
+This would break existing code that uses \texttt{memcpy}.  The code would no longer type check.
+C does not have function overloading, so we cannot define multiple overloaded versions of
+\texttt{memcpy}.  The reverse problem also exists: suppose the signature for \texttt{memcpy} is
+not updated. Then every ``checked'' method that calls \texttt{memcpy} would need to cast
 the arguments to unchecked pointer types.
 
-Given that we may not be able to change the pointer types of existing
-APIs, we need to adopt an approach that supports backwards
-compatibility, enables new checked code to be written easily, and maintains
-the checking of new code.
-
-We address this by:
-
+Given that it is problematic to change the types of existing APIs, we need to take approach
+that supports backward compatibility, enables new checked code to be written easily, and
+maintains the checking of new code.  We address this by:
 \begin{enumerate}
 \item
   Allowing programmers to declare bounds-safe interfaces to code and
@@ -618,31 +602,21 @@ interface.  For example, an expression will not be
 coerced implicitly from \ptrinst{\var{S}} to \uncheckedptrvoid\ to
 \uncheckedptrinst{\var{T}}, where \var{S} and \var{T} are different types.
 
-\subsection{Compatibility of types}
+\subsection{Type compatibility}
 
-C allows variables or functions be declared with types that are missing information.
-This information can be filled in by other declarations.  The types that
-are missing information are said to be ``compatible'' with more complete
-versions of the types: they can be used interchangeably.   This avoids the
-problem of multiple definitions of variables or functions with different types.
+C allows variables or functions to be declared with types that are missing information.
+There can be other declarations of the variables or functions with types that are more complete
+and fill in the missing information.  The types that are missing information are said to be
+``compatible'' with the more complete versions of the types.  Multiple declarations of
+a variable or function are required to have compatible types, not identical types.
 
-This notion of compatibility extends to bounds-safe interfaces naturally.
-Two function types with bounds declarations on parameters or for a return value are 
-compatible if:
+This notion of compability extends to bounds-safe interfaces naturally.  We extend the
+definition of compatibility of function types in Section~\ref{section:function-types} as follows:
 \begin{itemize}
-\item For parameters
-\begin{itemize}
-\item If corresponding parameters have compatible unchecked pointer types, and one parameter
-has a bounds declaration and other parameter does not have a bounds declaration, or
-\item If corresponding parameters both have bounds declarations, and the
-bounds declarations are syntactically equal or equal after being
-placed into a canonical form.
-\end{itemize}
-
-This is assuming that parameter variables are renamed so that parameter
-variables in corresponding argument positions have the same name.
-
-\item For return values with unchecked pointer types, similar rules apply.
+\item Given corresponding parameters with compatible unchecked pointer types,
+one parameter may have a bounds declaration and one parameter may omit the bounds declaration.
+\item Given return values with compatible unchecked pointer types, one
+return value may have a bounds declaration and one return value may omit the bounds declaration.
 \end{itemize}
 
 The following are examples of declarations of functions with compatible types:
@@ -655,11 +629,12 @@ int g(int *a : count(len), int len, int *b);  // decl 2
 int g(int *a, int len, int *b : count(len));  // decl 3
 int g(int *a : count(len), int len, int *b : count(len));  // decl 4
 \end{verbatim}
-The example of \texttt{g} is particularly interesting.  The only version
+The declarations of \texttt{g} are particularly interesting. They are all
+compatible declarations.  The only version
 that could be used in a checked scope is declaration 4.   For declarations 2 and 3,
 where bounds information is missing for a parameter, the argument passed to \texttt{g}
 for that parameter cannot have an \arrayptr\ type.  The typing rules prevent arguments
-with checked type from being used with parameters of \texttt{g} that are missing 
+with checked type from being used with parameters of \texttt{g} that are missing
 bounds information.
 
 \subsection{Checking bounds declarations}

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -479,7 +479,7 @@ C does not have function overloading, so we cannot define multiple overloaded ve
 not updated. Then every ``checked'' method that calls \texttt{memcpy} would need to cast
 the arguments to unchecked pointer types.
 
-Given that it is problematic to change the types of existing APIs, we need to take approach
+Given that it is problematic to change the types of existing APIs, we need an approach
 that supports backward compatibility, enables new checked code to be written easily, and
 maintains the checking of new code.  We address this by:
 \begin{enumerate}

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -122,8 +122,15 @@ For C cast operators, the checking is only static.
 Here are the rules for cast operators of the form \texttt{(\var{D}) \var{e}},
 where \var{e} has source type \var{S}.  The rules are applied in addition
 to any existing C typing rules that apply to the cast.
+\begin{itemize}
+\item If \var{D} and \var{S} are compatible types or \var{D} and \var{S} are unchecked
+pointer types, checking succeeds.
 
-If \var{D} is not \ptrvoid\ or \uncheckedptrvoid\ and \var{D} is
+\item Otherwise, if \var{D} is \ptrvoid\ or \uncheckedptrvoid\ and \var{S} is a \ptr\ type, 
+checking succceeds.\footnote{This rule follows from the next rule, but it is easier to understand 
+stated as a separate rule.}
+
+\item Otherwise, if \var{D} is not a function pointer type and \var{D} is
 \begin{itemize}
 \item \ptrT: the bounds of \var{e} are computed using the rules
 in Section~\ref{section:checking-nested-assignment-expressions}.
@@ -133,42 +140,31 @@ error.
 \item Otherwise, if the bounds are \boundsany, checking 
 succeeds.
 \item Otherwise, the bounds must be \bounds{\var{lb}}{\var{ub}} (or convertible
-to that form).  It must be statically provable that \texttt{\var{e} >= \var{lb}}
-and that {\texttt{((char *) \var{ub}) - ((char *) \var{e}) >= sizeof(\var{T})}}.    
+to that form).  It must be provable statically that \texttt{\var{e} >= \var{lb}}
+and that {\texttt{((char *) \var{ub}) - ((char *) \var{e}) >= sizeof(\var{T})}}.
+If \texttt{sizeof(\var{T})} is not defined because \var{T} is \void, \texttt{1} is
+used instead.
 \end{itemize}
 \item \arrayptrT: No new rules are needed.   The rules in
 Chapter~\ref{chapter:checking-bounds} already cover this case.
-\item \spanptrT: It must be statically provable that \var{e}
+\item \spanptrT: It must be provable statically that \var{e}
 and \bounds{\var{lb}}{\var{ub}} meet the relative alignment requirements of
 the destination \spanptr\ type.  At runtime, a new value of
 type \spanptrT\ with the value of \var{e} and \bounds{\var{lb}}{\var{ub}} will be created.
 \item \texttt{\var{T} *}: If the source type \var{S} is
 \begin{itemize}
-\item An unchecked pointer type (\texttt{*}), checking succeeds.
 \item \ptrT, the checking succeeds. This handles the case where \var{T}
 is an incomplete type.
 \item Otherwise, the same rules are followed as for \ptrT.
 \end{itemize}
 \end{itemize}
 
-If \var{D} is \ptrvoid\ or \uncheckedptrvoid\ and \var{S} is:
+\item Otherwise, if \var{D} is a function pointer type,
 \begin{itemize}
-\item A \ptr\ type, static checking always succeeds.
-\item An \arrayptr\ or \spanptr\ type: The bounds of \var{e} are computed:
-\begin{itemize}
-\item If the resulting bounds are \boundsnone, checking fails with a compile-time
-error.
-\item Otherwise, if the result bounds are \boundsany, checking 
-succeeds.
-\item Otherwise, the result must be \bounds{\var{lb}}{\var{ub}} (or convertible
-to that form).   It must be statically provable that \texttt{\var{e} >= \var{lb}}
-and that {\texttt{((char *) \var{ub}) - ((char *) e) >= 1}}.   
-\end{itemize}
-\item An unchecked pointer type:
-\begin{itemize}
-\item If \var{D} is \ptrvoid, the prior rule for an \arrayptr\ or \spanptr\ type is
-applied.
-\item If \var{D} is \uncheckedptrvoid, checking always succeeds.
+\item If \var{S} is a pointer to a function type, \var{D} is \ptrT,
+\var{S} is \uncheckedptrinst{U}, \var{T} and \var{U} are compatible types, 
+and \var{e} is a function name, checking succeeds.
+\item Otherwise, checking fails with a compile-time error.
 \end{itemize}
 \end{itemize}
 
@@ -306,13 +302,16 @@ void f(void) {
 C allows implicit conversions at assignments, function call arguments,
 and conditional expressions.  The purpose of
 implicit conversions is to make programs shorter and easier to
-read.  This section defines implicit conversions that are
-allowed for checked pointer types.
+read.  Implicit conversions describe when a expression of type
+\var{S} is allowed where an expression of type \var{ST} is expected.
+They allow additional programs to typecheck.
+This section defines implicit conversions that are allowed for checked 
+pointer types.
 
-The rules for checking bounds declarations are applied separately after 
-typechecking to check the integrity of bounds information.  During the 
-application of these rules, the implicit conversions are treated as
-though they were explicit C cast operations.
+An implicit conversion may allow typechecking to succeed, but
+checking of bounds declarations may still fail.  Implicit
+conversions are treated as though they are explicit C cast 
+operations during the checking of bounds declarations.
 
 \subsection{From unchecked pointers to checked pointers}
 An expression with an unchecked pointer type can be converted implicitly to an
@@ -341,10 +340,6 @@ and:
 \item \var{E} is assignment compatible with \var{T}.
 \end{itemize}
 \end{itemize}
-The definition of assignment compatibility is more
-complicated when referent types are function types or
-pointer types. {\em Discussion of a richer forms of assignment compatibility
-is deferred for now}.
 C allows implicit conversions between \uncheckedptrvoid\ and other pointer
 types. For now, implicit conversions from \uncheckedptrvoid\ to checked pointer
 types are allowed. This may be revised later when a design
@@ -464,15 +459,14 @@ void f(void) {
 \section{Bounds-safe interfaces to existing unchecked functions and variables}
 \label{section:function-bounds-safe-interfaces}
 
-The new pointer types capture specific properties of pointers. One would
+The new pointer types capture specific properties of pointers. We would
 like to update existing C code to use these new pointer types. However,
-this will not be possible when backward compatibility requirements
-exist. Consider C runtime functions or operating system (OS) APIs. 
-It may be feasible to modify the header files for runtime functions or OS APIs. 
-It may be
-impossible to require all uses of these functions or APIs be updated.
-Code written by 3\textsuperscript{rd} parties may use these APIs and it
-is not reasonable for an existing shipping OS to require all
+this is not possible when backward compatibility requirements exist. 
+For C runtime function or operating system (OS) APIs, it is possible
+to modify the header files that declare them. It is impractical, however,
+to require  all {\em uses} of these functions or APIs be updated.   Code written by
+3\textsuperscript{rd} 
+parties may use these APIs and an existing shipping OS cannot reasonably require all
 3\textsuperscript{rd} parties update their existing code to use the new
 types.
 
@@ -624,6 +618,49 @@ interface.  For example, an expression will not be
 coerced implicitly from \ptrinst{\var{S}} to \uncheckedptrvoid\ to
 \uncheckedptrinst{\var{T}}, where \var{S} and \var{T} are different types.
 
+\subsection{Compatibility of types}
+
+C allows variables or functions be declared with types that are missing information.
+This information can be filled in by other declarations.  The types that
+are missing information are said to be ``compatible'' with more complete
+versions of the types: they can be used interchangeably.   This avoids the
+problem of multiple definitions of variables or functions with different types.
+
+This notion of compatibility extends to bounds-safe interfaces naturally.
+Two function types with bounds declarations on parameters or for a return value are 
+compatible if:
+\begin{itemize}
+\item For parameters
+\begin{itemize}
+\item If corresponding parameters have compatible unchecked pointer types, and one parameter
+has a bounds declaration and other parameter does not have a bounds declaration, or
+\item If corresponding parameters both have bounds declarations, and the
+bounds declarations are syntactically equal or equal after being
+placed into a canonical form.
+\end{itemize}
+
+This is assuming that parameter variables are renamed so that parameter
+variables in corresponding argument positions have the same name.
+
+\item For return values with unchecked pointer types, similar rules apply.
+\end{itemize}
+
+The following are examples of declarations of functions with compatible types:
+\begin{verbatim}
+int f(int *);
+int f(int * : count(5));
+
+int g(int *a, int len, int *b);               // decl 1
+int g(int *a : count(len), int len, int *b);  // decl 2
+int g(int *a, int len, int *b : count(len));  // decl 3
+int g(int *a : count(len), int len, int *b : count(len));  // decl 4
+\end{verbatim}
+The example of \texttt{g} is particularly interesting.  The only version
+that could be used in a checked scope is declaration 4.   For declarations 2 and 3,
+where bounds information is missing for a parameter, the argument passed to \texttt{g}
+for that parameter cannot have an \arrayptr\ type.  The typing rules prevent arguments
+with checked type from being used with parameters of \texttt{g} that are missing 
+bounds information.
 
 \subsection{Checking bounds declarations}
 \label{section:checking-bounds-interfaces}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -867,7 +867,7 @@ no way to update the hidden variable to make the bounds declaration be valid.
 Here is a simple example:
 \begin{verbatim}
 /* function that will fail checking */
-void bad(int i) 
+void bad(int i)
 {
     array_ptr<int> x : count(i) = malloc ((sizeof(int) * i);
     {
@@ -1056,10 +1056,11 @@ However, \texttt{calloc} also zeros the allocated memory.  For the sake of effic
 new allocation functions that compute sizes but do not zero memory may be needed.
 
 \section{Function types and function pointer types}
+\label{section:function-types}
 
 Function types can be declared to have parameters and return values that have bounds
-declarations, just like functions. 
-The bounds declarations become part of the function types.  Here are simple examples of function pointer types with bounds declarations:
+declarations, just like functions.  The bounds declarations become part of the function types.
+Here are simple examples of function pointer types with bounds declarations:
 \begin{verbatim}
 // Function that takes a pointer to a 5 element array and returns an integer.
 int (array_ptr<int> arr : count(5))
@@ -1069,13 +1070,13 @@ ptr<int (array_ptr<int> arr : count(i), int i)>
 int (*) (array_ptr<int> arr : count(i), int i)
 \end{verbatim}
 Functions that take pointers to functions and arrays of function pointers can
-be declared also.  A typedef for the function type in the following example
+be declared also.  A typedef for the function type is used in the following example
 to keep the syntax understandable:
 \begin{verbatim}
-typedef int fn(array_ptr<int> arr : count(5));  
+typedef int fn(array_ptr<int> arr : count(5));
 
 // Takes g and arg and calls g with arg.
-int apply(ptr<fn> g, array_ptr<int> arg : count(5));  
+int apply(ptr<fn> g, array_ptr<int> arg : count(5));
 
 // Checked array of 10 function pointers
 ptr<fn> dispatch_table checked[10];
@@ -1086,11 +1087,10 @@ bounds declarations.  Two function types are compatible if
 \begin{itemize}
 \item They are compatible types if all bounds declarations are removed from the type, and
 \item If either type contains a bounds declaration, both types have parameter lists, and
-\item They have bounds declarations on the same parameters, and
-\item They either both have a bounds declaration for their return values or
-both do not have a bounds declaration for their return values, and
+\item They have bounds declarations on corresponding parameters, and
+\item They either both have or both do not have a bounds declaration for their return values, and
 \item The bounds declarations for corresponding parameters and for return values with
-checked types are equivalent. 
+checked types are equivalent.
 Parameter variables should be renamed so that the parameter variables
 in corresponding argument positions have the same name.  The new names should be chosen
 to be different than other variables that are in scope.
@@ -1098,9 +1098,8 @@ to be different than other variables that are in scope.
 For each pair of bounds declarations for corresponding
 parameters or the return values, the bounds declarations are equivalent if
 \begin{itemize}
-\item The bounds expressions for the bounds declarations are syntactically equal or,
-more generally, they are syntactically equal after being placed into
-a canonical form following the rules in Section~\ref{section:canonicalization}, and
+\item The bounds expressions for the bounds declarations are syntactically equal
+after being placed into a canonical form following the rules in Section~\ref{section:canonicalization}, and
 \item  For any non-parameter variable \var{x} to which both expressions refer, the variable is
 declared in the same scope.
 \end{itemize}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -841,26 +841,6 @@ the expressions may be fully re-evaluated at every bounds check involving the
 bounds expression. More complicated bounds expressions are allowed
 because programmers might find them useful.
 
-
-\subsection{Lexical hiding of variables}
-
-A nested lexical scope is not allowed to hide a variable used in a
-bounds declaration within the extent of the bounds declaration. This
-prevents programs from accidentally invalidating the bounds declaration:
-
-\begin{verbatim}
-/* illegal function */
-void bad(int i) 
-{
-    array_ptr<int> x : count(i) = malloc ((sizeof(int) * i);
-    {
-        int x = 5;     // hide x
-        i = INT_MAX;   // subvert bounds
-    }
-    x[random()] = 0xbad;
-}
-\end{verbatim}
-
 \subsection{Storage class-related requirements}
 
 Local variables with static storage class or thread storage class can
@@ -877,6 +857,28 @@ bounds declarations that use variables with external linkage ends at
 function calls, unless the variables with external linkage are declared
 \texttt{const}. This is because the function calls may modify the
 variables with external linkage.
+
+\subsection{Lexical hiding of variables}
+
+A nested lexical scope can hide a variable used in a bounds declaration
+within the extent of the bounds declaration. This will limit the ability
+to update the {\it other} variables used in the bounds declaration.  There will be
+no way to update the hidden variable to make the bounds declaration be valid.
+Here is a simple example:
+\begin{verbatim}
+/* function that will fail checking */
+void bad(int i) 
+{
+    array_ptr<int> x : count(i) = malloc ((sizeof(int) * i);
+    {
+        int x = 5;     // hide x
+        i = INT_MAX;   // illegal: the bounds declaration for array_ptr<int> x
+                       // would no longer be valid;
+    }
+}
+\end{verbatim}
+When compilers insert bounds checks, they need to use the appropriately-scoped
+variables, even if some of the variables are hidden.
 
 \subsection{Variables at external scope}
 \label{section:external-scope-variables}
@@ -1053,6 +1055,70 @@ void *signed_calloc(signed_size_t nobj, size_t size);
 However, \texttt{calloc} also zeros the allocated memory.  For the sake of efficiency,
 new allocation functions that compute sizes but do not zero memory may be needed.
 
+\section{Function types and function pointer types}
+
+Function types can be declared to have parameters and return values that have bounds
+declarations, just like functions. 
+The bounds declarations become part of the function types.  Here are simple examples of function pointer types with bounds declarations:
+\begin{verbatim}
+// Function that takes a pointer to a 5 element array and returns an integer.
+int (array_ptr<int> arr : count(5))
+// checked function pointer
+ptr<int (array_ptr<int> arr : count(i), int i)>
+// unchecked function pointer
+int (*) (array_ptr<int> arr : count(i), int i)
+\end{verbatim}
+Functions that take pointers to functions and arrays of function pointers can
+be declared also.  A typedef for the function type in the following example
+to keep the syntax understandable:
+\begin{verbatim}
+typedef int fn(array_ptr<int> arr : count(5));  
+
+// Takes g and arg and calls g with arg.
+int apply(ptr<fn> g, array_ptr<int> arg : count(5));  
+
+// Checked array of 10 function pointers
+ptr<fn> dispatch_table checked[10];
+\end{verbatim}
+
+Compatibility of function types is extended to take into account
+bounds declarations.  Two function types are compatible if
+\begin{itemize}
+\item They are compatible types if all bounds declarations are removed from the type, and
+\item If either type contains a bounds declaration, both types have parameter lists, and
+\item They have bounds declarations on the same parameters, and
+\item They either both have a bounds declaration for their return values or
+both do not have a bounds declaration for their return values, and
+\item The bounds declarations for corresponding parameters and for return values with
+checked types are equivalent. 
+Parameter variables should be renamed so that the parameter variables
+in corresponding argument positions have the same name.  The new names should be chosen
+to be different than other variables that are in scope.
+
+For each pair of bounds declarations for corresponding
+parameters or the return values, the bounds declarations are equivalent if
+\begin{itemize}
+\item The bounds expressions for the bounds declarations are syntactically equal or,
+more generally, they are syntactically equal after being placed into
+a canonical form following the rules in Section~\ref{section:canonicalization}, and
+\item  For any non-parameter variable \var{x} to which both expressions refer, the variable is
+declared in the same scope.
+\end{itemize}
+\end{itemize}
+
+Canonical forms place semantically equivalent but syntactically distinct
+expressions into the same form.  This allows things like commutativity and constant
+folding to be taken into account:
+\begin{verbatim}
+// These function types are equivalent taking into account commutativity.
+int (array_ptr<int> arr : count(i + j), int i, int j)
+int (array_ptr<int> arr : count(j + i), int i, int j)
+
+// These function types are equivalent after constant-folding.
+int (array_ptr<int> arr : count(5))
+int (array_ptr<int> arr : count(2 + 3))
+int (array_ptr<int> arr : count(4 + 1))
+\end{verbatim}
 
 \section{Bounds declarations for results of casts between \arrayptr\ types}
 \label{section:pointer-cast-results}


### PR DESCRIPTION
This changes updates the Checked C specification to describe how function types are extended with bounds information.  This addresses issue #69.
-  It adds a section to Chapter 3 (bounds for variables) that describes how function types and function pointer types include bounds information.   The section includes a description of how type compatibility changes for function types.
- It updates the rules for casts in Chapter 5 (interoperation)  to include function pointers.
- It adds a section to bound-safe interfaces in Chapter 5 that describes how function types with bounds-safe interfaces are compatible with function types without bounds information.   This is crucial for allowing redeclarations of existing library functions with bounds information.

For now, we have simple rules for function pointer casts.  We require that bounds declarations on parameters and return values be syntactically identical (after canonicalization).  We do not allow weaker preconditions or stronger post-conditions for function pointer casts, even though we could.  This would make the system more complex and it is not clear that more general rules are needed in practice.  Add a section to the design alternatives chapter that discusses this decision.

There are a few other changes folded into this change:
- Revamp the rules around lexical hiding of variables.   We drop the prohibition on lexical hiding of variables used in bounds declarations.  It could cause backward-compatibility issues and was unnecessarily restrictive.  We now allow lexical hiding of variables used in bounds declarations.  We point out that it may make it impossible to update other variables used in a bounds declaration.  There may be no way to do updates that make the bounds declaration be valid.
- Simplify the static checking rules for C-style casts.  The rules were fairly long and adding rules for function only made them even longer.  I compensated for this by reworking the rules to be simpler and shorter. 
- Shorten the motivation section for bounds-safe interfaces.    The text was longer than it needed to be.


