### PR TITLE
Test redeclarations of functions with bounds declarations.

### DIFF
--- a/include/fenv_checked.h
+++ b/include/fenv_checked.h
@@ -1,0 +1,16 @@
+//--------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in fenv.h that                //
+// take pointer arguments.                                            //
+//                                                                    //
+// These are listed in the same order that they occur in the C11      //
+// specification.                                                     //
+////////////////////////////////////////////////////////////////////////
+
+#include <fenv.h>
+
+int fesetexceptflag(const fexcept_t *flagp : itype(_Ptr<const fexcept_t>),
+                    int excepts);
+int fegetenv(fenv_t *envp : itype(_Ptr<fenv_t>));
+int feholdexcept(fenv_t *envp : itype(_Ptr<fenv_t>));
+int fesetenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
+int feupdateenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in inttypes.h that             //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <inttypes.h>
+
+intmax_t strtoimax(const char * restrict nptr,
+                   char ** restrict endptr : itype(restrict _Ptr<char *>),
+                   int base);
+uintmax_t strtoumax(const char * restrict nptr,
+                    char ** restrict endptr : itype(restrict _Ptr<char *>),
+                    int base);
+
+intmax_t wcstoimax(const wchar_t * restrict nptr,
+                   wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+                   int base);
+uintmax_t wcstoumax(const wchar_t * restrict nptr,
+                    wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+                    int base);

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in math.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <math.h>
+
+double frexp(double value, int *exp : itype(_Ptr<int>));
+float frexpf(float value, int *exp : itype(_Ptr<int>));
+long double frexpl(long double value, int *exp : itype(_Ptr<int>));
+
+double modf(double value, double *iptr : itype(_Ptr<double>));
+float modff(float value, float *iptr : itype(_Ptr<float>));
+long double modfl(long double value,
+                  long double *iptr : itype(_Ptr<long double>));
+
+double remquo(double x, double y, int *quo : itype(_Ptr<int>));
+float remquof(float x, float y, int *quo : itype(_Ptr<int>));
+long double remquol(long double x, long double y, int *quo : itype(_Ptr<int>));
+
+// TODO: strings
+// double nan(const char *t);
+// float nanf(const char *t);
+// long double nanf(const char *t);

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -5,5 +5,8 @@
 
 #include <signal.h>
 
-void (*signal(int sig, void (*func)(int) : itype(_Ptr<void (int)>)))(int) :
-   itype(_Ptr<void (int)>);
+void (*signal(int sig,
+              void ((*func)(int)) :
+                itype(_Ptr<void (int)>) // bound-safe interface for func
+              ) : itype(_Ptr<void (int)>) // bounds-safe interface for signal return
+     )(int);

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -1,0 +1,9 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for a functions in signal.h that             //
+// take pointer arguments.                                             //
+/////////////////////////////////////////////////////////////////////////
+
+#include <signal.h>
+
+void (*signal(int sig, void (*func)(int) : itype(_Ptr<void (int)>)))(int) :
+   itype(_Ptr<void (int)>);

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -1,0 +1,122 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in math.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <stdio.h>
+
+// TODO: handle strings
+// int remove(const char *name);
+// int rename(const char *from, const char *to);
+FILE *tmpfile(void) : itype(_Ptr<FILE>);
+// TODO: handle strings
+// char *tmpnam(char *source);
+int fclose(FILE *stream : itype(_Ptr<FILE>));
+int fflush(FILE *stream : itype(_Ptr<FILE>));
+FILE *fopen(const char * restrict filename,
+            const char * restrict mode) : itype(_Ptr<FILE>);
+FILE *freopen(const char * restrict filename,
+              const char * restrict mode,
+              FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
+  itype(_Ptr<FILE>);
+
+void setbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            char * restrict buf : count(BUFSIZ));
+int setvbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            char * restrict buf : count(size),
+            int mode, size_t size);
+
+//
+// TODO: printing and scanning functions are still mostly
+// unchecked because of the use of varargs.
+// * There may not be enough arguments for the format string.
+// * Any pointer arguments may not meet the requirements of the
+//  format string.
+//
+int fprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            const char * restrict format, ...);
+int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+           const char * restrict format, ...);
+// TODO: handle strings
+// int printf(const char * restrict format, ...);
+// int scanf(const char * restrict format, ...);
+
+// OMITTED INTENTIONALLY:
+// sprintf cannot be made checked.  It is missing the bounds
+// for the output buffer.
+// int sprintf(char * restrict s,
+//            const char * restrict format, ...);
+//
+// TODO: handle strings
+// int sscanf(const char * restrict s,
+//            const char * restrict format, ...);
+int snprintf(char * restrict s : count(n), size_t n,
+             const char * restrict format, ...);
+
+int vfprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+             const char * restrict format,
+             va_list arg);
+int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            const char * restrict format,
+            va_list arg);
+
+// TODO: handle strings
+// int vprintf(const char * restrict format,
+//             va_list arg);
+// int vscanf(const char * restrict format,
+//            va_list arg);
+int vsnprintf(char * restrict s : count(n), size_t n,
+              const char * restrict format,
+              va_list arg);
+// OMITTED INTENTIONALLY:
+// vsprintf cannot be made checked. it is missing the bounds
+// for the output buffer.
+// int vsprintf(char * restrict s,
+//             const char * restrict format,
+//             va_list arg);
+// TODO: handle strings
+// int vsscanf(const char * restrict s,
+//            const char * restrict format,
+//            va_list arg);
+
+int fgetc(FILE *stream : itype(_Ptr<FILE>));
+char *fgets(char * restrict s : count(n), int n,
+            FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
+  bounds(s, s + n);
+int fputs(const char * restrict s,
+          FILE * restrict stream : itype(restrict _Ptr<FILE>));
+int getc(FILE *stream : itype(_Ptr<FILE>));
+int putc(int c, FILE *stream : itype(_Ptr<FILE>));
+// TODO: strings
+// int puts(const char *str);
+int ungetc(int c, FILE *stream : itype(_Ptr<FILE>));
+
+size_t fread(void * restrict ptr : byte_count(size * nmemb),
+             size_t size, size_t nmemb,
+             FILE * restrict stream : itype(restrict _Ptr<FILE>));
+
+size_t fwrite(const void * restrict ptr : byte_count(size * nmemb),
+              size_t size, size_t nmemb,
+              FILE * restrict stream : itype(restrict _Ptr<FILE>));
+
+int fgetpos(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            fpos_t * restrict pos : itype(restrict _Ptr<fpos_t>));
+
+int fseek(FILE *stream : itype(_Ptr<FILE>), long int offset, int whence);
+int fsetpos(FILE *stream : itype(_Ptr<FILE>),
+            const fpos_t *pos :  itype(_Ptr<const fpos_t>));
+
+long int ftell(FILE *stream : itype(_Ptr<FILE>));
+void rewind(FILE *stream : itype(_Ptr<FILE>));
+
+void clearerr(FILE *stream : itype(_Ptr<FILE>));
+int feof(FILE *stream : itype(_Ptr<FILE>));
+int ferror(FILE *stream : itype(_Ptr<FILE>));
+// TODO: strings
+// void perror(const char *s);

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -55,7 +55,7 @@ int atquick_exit(void(*func)(void) : itype(_Ptr<void (void)>));
 // TODO: strings
 // int system(const char *s);
 
-// TODO: compar needs to have a type that has bounds
+// TODO: compar needs to have an itype that has bounds
 // on parameters based on size.  Currently we are requiring that
 // bounds in parameters lists be closed with respect to variables
 // in the parameter list.
@@ -63,18 +63,16 @@ void *bsearch(const void *key : byte_count(size),
               const void *base : byte_count(nmemb * size),
               size_t nmemb, size_t size,
               int(*compar)(const void *, const void *) :
-                 itype(_Ptr<int (const void * : itype(_Ptr<const void>),
-                                 const void * : itype(_Ptr<const void>))>)) :
+                itype(_Ptr<int(_Ptr<const void>, _Ptr<const void>)>)) :
                 byte_count(size);
 
-// TODO: compar needs to have a type that has bounds
+// TODO: compar needs to have an itype that has bounds
 // on parameters based on size.  Currently we are requiring that
 // types be closed.
 void qsort(void *base : byte_count(nmemb * size),
            size_t nmemb, size_t size,
            int(*compar)(const void *, const void *) :
-           itype(_Ptr<int(const void * : itype(_Ptr<const void>),
-                          const void * : itype(_Ptr<const void>))>));
+             itype(_Ptr<int (_Ptr<const void>, _Ptr<const void>)>));
 
 int mblen(const char *s : count(n), size_t n);
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -49,8 +49,8 @@ void *realloc(void *ptr  : itype(_Ptr<void>), size_t size) : byte_count(size);
 // TODO: strings
 // char *getenv(const char *n);
 
-int atexit(void (*func)(void) : itype(_Ptr<void (void)>));
-int atquick_exit(void(*func)(void) : itype(_Ptr<void (void)>));
+int atexit(void ((*func)(void)) : itype(_Ptr<void (void)>));
+int atquick_exit(void ((*func)(void)) : itype(_Ptr<void (void)>));
 
 // TODO: strings
 // int system(const char *s);
@@ -62,7 +62,7 @@ int atquick_exit(void(*func)(void) : itype(_Ptr<void (void)>));
 void *bsearch(const void *key : byte_count(size),
               const void *base : byte_count(nmemb * size),
               size_t nmemb, size_t size,
-              int(*compar)(const void *, const void *) :
+              int ((*compar)(const void *, const void *)) :
                 itype(_Ptr<int(_Ptr<const void>, _Ptr<const void>)>)) :
                 byte_count(size);
 
@@ -71,7 +71,7 @@ void *bsearch(const void *key : byte_count(size),
 // types be closed.
 void qsort(void *base : byte_count(nmemb * size),
            size_t nmemb, size_t size,
-           int(*compar)(const void *, const void *) :
+           int ((*compar)(const void *, const void *)) :
              itype(_Ptr<int (_Ptr<const void>, _Ptr<const void>)>));
 
 int mblen(const char *s : count(n), size_t n);

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -1,0 +1,92 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in stdlib.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+#include <stdlib.h>
+
+// TODO: strings
+// double atof(const char *s);
+// int atoi(const char *s);
+// long int atol(const char *s);
+// long long int atoll(const char *s);
+
+double strtod(const char * restrict nptr,
+              char ** restrict endptr : itype(restrict _Ptr<char *>));
+float strtof(const char * restrict nptr,
+             char ** restrict endptr : itype(restrict _Ptr<char *>));
+long double strtold(const char * restrict nptr,
+                    char ** restrict endptr : itype(restrict _Ptr<char *>));
+
+long int strtol(const char * restrict nptr,
+                char ** restrict endptr : itype(restrict _Ptr<char *>),
+                int base);
+long long int strtoll(const char * restrict nptr,
+                      char ** restrict endptr : itype(restrict _Ptr<char *>),
+                      int base);
+unsigned long int strtoul(const char * restrict nptr,
+                          char ** restrict endptr :
+                            itype(restrict _Ptr<char *>),
+                          int base);
+
+unsigned long long int strtoull(const char * restrict nptr,
+                                char ** restrict endptr:
+                                   itype(restrict _Ptr<char *>),
+                                int base);
+
+// TODO: express alignment constraints once where clauses have been added.
+void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
+void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
+void free(void *ptr : itype(_Ptr<void>));
+void *malloc(size_t size) : byte_count(size);
+void *realloc(void *ptr  : itype(_Ptr<void>), size_t size) : byte_count(size);
+
+// TODO: strings
+// char *getenv(const char *n);
+
+int atexit(void (*func)(void) : itype(_Ptr<void (void)>));
+int atquick_exit(void(*func)(void) : itype(_Ptr<void (void)>));
+
+// TODO: strings
+// int system(const char *s);
+
+// TODO: compar needs to have a type that has bounds
+// on parameters based on size.  Currently we are requiring that
+// bounds in parameters lists be closed with respect to variables
+// in the parameter list.
+void *bsearch(const void *key : byte_count(size),
+              const void *base : byte_count(nmemb * size),
+              size_t nmemb, size_t size,
+              int(*compar)(const void *, const void *) :
+                 itype(_Ptr<int (const void * : itype(_Ptr<const void>),
+                                 const void * : itype(_Ptr<const void>))>)) :
+                byte_count(size);
+
+// TODO: compar needs to have a type that has bounds
+// on parameters based on size.  Currently we are requiring that
+// types be closed.
+void qsort(void *base : byte_count(nmemb * size),
+           size_t nmemb, size_t size,
+           int(*compar)(const void *, const void *) :
+           itype(_Ptr<int(const void * : itype(_Ptr<const void>),
+                          const void * : itype(_Ptr<const void>))>));
+
+int mblen(const char *s : count(n), size_t n);
+
+int mbtowc(wchar_t * restrict output : itype(restrict _Ptr<wchar_t>),
+           const char * restrict input : count(n),
+           size_t n);
+int wctomb(char *s : count(MB_CUR_MAX), wchar_t wc);
+
+size_t mbstowcs(wchar_t * restrict pwcs : count(n),
+                const char * restrict s,
+                size_t n);
+
+size_t wcstombs(char * restrict output : count(n),
+                const wchar_t * restrict pwcs,
+                size_t n);

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -1,0 +1,72 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in string.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+#include <string.h>
+
+void *memcpy(void * restrict dest : byte_count(n),
+             const void * restrict src : byte_count(n),
+             size_t n) : bounds(dest, (char *) dest + n);
+
+void *memmove(void * restrict dest : byte_count(n),
+              const void * restrict src : byte_count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+// TODO: strings
+// char *strcpy(char * restrict dest,
+//              const char * restrict src);
+
+// OMITTED INTENTIONALLY: this cannot be made checked.
+// There is no bound on s1.
+// char *strcpy(char * restrict s1,
+//              const char * restrict s2);
+
+char *strncpy(char * restrict dest : count(n),
+              const char * restrict src : count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+
+// OMITTED INTENTIONALLY: this cannot be made checked.
+// There is no bound on dest.
+// char *strcat(char * restrict dest,
+//              const char * restrict src);
+
+char *strncat(char * restrict dest : count(n),
+              const char * restrict src : count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+
+int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
+           size_t n);
+
+// TODO: strings
+// int strcmp(const char *src1, const char *src2);
+// int strcoll(const char *src1, const char *src2);
+
+int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
+size_t strxfrm(char * restrict dest : count(n),
+               const char * restrict src,
+               size_t n);
+
+void *memchr(const void *s : byte_count(n), int c, size_t n) :
+  bounds(s, (char *) s + n);
+
+// TODO: strings
+// char *strchr(const char *s, int c);
+// size_t strcspn(const char *s1, const char *s2);
+// char *strpbrk(const char *s1, const char *s2);
+// char *strrchr(const char *s, int c);
+// size_t strspn(const char *s1, const char *s2);
+// char *strstr(const char *s1, const char *s2);
+// char *strtok(char * restrict s1,
+//              const char * restrict s2);
+
+void *memset(void *s : byte_count(n), int c, size_t n) :
+  bounds(s, (char *) s + n);
+
+// TODO: strings
+// char *strerror(int errnum);
+// size_t strlen(const char *s);

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in threads.h that              //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+/////////////////////////////////////////////////////////////////////////
+
+#ifdef _CHECKEDC_MOCKUP_THREADS
+// C implementations may not support the C11 threads package or even the
+// macro that says C11 threads are not supported.  This mocks up
+// the types needed by threads so that we can test that the declarations
+// below compile.
+typedef struct __once_flag_struct once_flag;
+typedef struct __cnd_struct cnd_t;
+typedef struct __mtx_struct mtx_t;
+typedef struct __thread_struct thrd_t;
+typedef int (*thrd_start_t)(void *);
+typedef struct __thread_specific_storage_struct tss_t;
+typedef void (tss_dtor_t)(void *);
+struct timespec;
+#else
+#include <threads.h>
+#endif
+
+void call_once(once_flag *flag : itype(_Ptr<once_flag>),
+               void(*fn)(void) : itype(_Ptr<void (void)>));
+
+int cnd_broadcast(cnd_t *condition : itype(_Ptr<cnd_t>));
+void cnd_destroy(cnd_t *condition : itype(_Ptr<cnd_t>));
+void cnd_init(cnd_t *condition : itype(_Ptr<cnd_t>));
+int cnd_signal(cnd_t *condition : itype(_Ptr<cnd_t>));
+int cnd_timedwait(cnd_t *restrict cond : itype(restrict _Ptr<cnd_t>),
+                  mtx_t *restrict mutex: itype(restrict _Ptr<mtx_t>),
+                  const struct timespec *restrict spec :
+                    itype(restrict _Ptr<const struct timespec>));
+int cnd_wait(cnd_t *condition : itype(_Ptr<cnd_t>),
+             mtx_t *mutex : itype(_Ptr<mtx_t>));
+void mtx_destroy(mtx_t *mutex : itype(_Ptr<mtx_t>));
+int mtx_init(mtx_t *mutex : itype(_Ptr<mtx_t>), int type);
+int mtx_lock(mtx_t *mutex : itype(_Ptr<mtx_t>));
+int mtx_timedlock(mtx_t *restrict mutex : itype(restrict _Ptr<mtx_t>),
+                  const struct timespec *restrict ts :
+                    itype(restrict _Ptr<const struct timespec>));
+int mtx_trylock(mtx_t *mtex : itype(_Ptr<mtx_t>));
+int mtx_unlock(mtx_t *mtex : itype(_Ptr<mtx_t>));
+
+int thrd_create(thrd_t *thr : itype(_Ptr<thrd_t>),
+                thrd_start_t func :
+                  itype(_Ptr<int (void * : itype(_Ptr<void>))>),
+                void *arg : itype(_Ptr<void>));
+int thrd_join(thrd_t thr, int *res : itype(_Ptr<int>));
+int thrd_sleep(const struct timespec *duration :
+                 itype(_Ptr<const struct timespec>),
+               struct timespec *remaining : itype(_Ptr<struct timespec>));
+int tss_create(tss_t *key : itype(_Ptr<tss_t>),
+               tss_dtor_t dtor :
+                 itype(_Ptr<void (void * : itype(_Ptr<void>))>));
+// Casting the Ptr<void> returned by tss_get to a specific type will be an
+// unchecked operation.
+void *tss_get(tss_t key) : itype(_Ptr<void>);
+int tss_set(tss_t key, void *value : itype(_Ptr<void>));

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -24,7 +24,7 @@ struct timespec;
 #endif
 
 void call_once(once_flag *flag : itype(_Ptr<once_flag>),
-               void(*fn)(void) : itype(_Ptr<void (void)>));
+               void ((*fn)(void)) : itype(_Ptr<void (void)>));
 
 int cnd_broadcast(cnd_t *condition : itype(_Ptr<cnd_t>));
 void cnd_destroy(cnd_t *condition : itype(_Ptr<cnd_t>));

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in time.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <time.h>
+
+time_t mktime(struct tm *timeptr : itype(_Ptr<struct tm>));
+int timespec_get(struct timespec *ts : itype(_Ptr<struct timespec>),
+                 int base);
+char *asctime(const struct tm *timeptr : itype(_Ptr<const struct tm>));
+char *ctime(const time_t *timer : itype(_Ptr<const time_t>));
+struct tm *gmtime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Ptr<struct tm>);
+struct tm *localtime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Ptr<struct tm>);
+size_t strftime(char * restrict output : count(maxsize),
+                size_t maxsize,
+                const char * restrict format,
+                const struct tm * restrict timeptr :
+                   itype(restrict _Ptr<const struct tm>));
+
+

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -460,38 +460,53 @@ void f(void) {
 
 The new pointer types capture specific properties of pointers. We would like to update
 existing C code to use the new pointer types. This would be problematic for library and operating
-system APIs that have backward  compatibility constraints, though.   Consider what would happen
-if the signature for \texttt{memcpy} were updated to use \arrayptr. The function
+system APIs that have backward  compatibility constraints, however.   Consider what would happen
+if the signature for \texttt{memcpy} were changed to use \arrayptr. The function
 
 \begin{verbatim}
 void *memcpy(void *dest, const void *src, size_t count);
 \end{verbatim}
 
-becomes
+would become
 
 \begin{verbatim}
 void *memcpy(array_ptr<void> dest, array_ptr<const void> src, size_t count);
 \end{verbatim}
 
-This would break existing code that uses \texttt{memcpy}.  The code would no longer type check.
-C does not have function overloading, so we cannot define multiple overloaded versions of
-\texttt{memcpy}.  The reverse problem also exists: suppose the signature for \texttt{memcpy} is
-not updated. Then every ``checked'' method that calls \texttt{memcpy} would need to cast
-the arguments to unchecked pointer types.
+This would break existing code that uses \texttt{memcpy}.  The code would no
+longer type check.  The reverse problem also exists: suppose the signature for
+\texttt{memcpy} is not updated.  Then every checked method that calls
+\texttt{memcpy} would need to cast the arguments to unchecked pointer types.
 
-Given that it is problematic to change the types of existing APIs, we need an approach
-that supports backward compatibility, enables new checked code to be written easily, and
-maintains the checking of new code.  We address this by:
+Given that changing the types of existing APIs is problematic, we take an approach
+that does not change types, yet enables new checked code to be written easily
+and that maintains the checking of the new code.  We allow programmers to
+declare {\em bounds-safe interfaces} that extend existing declarations with
+additional bounds information.  
+
+Bounds-safe interfaces can be 
+specified for declarations of functions, global variables, and
+data structures.  They can also be specified for function types.
+The interfaces describe the expected behavior and the assumptions
+of existing code about bounds. The types remain the same.
+It is assumed but not verified that existing code
+meets the specified interfaces.  A bounds-safe interface allows
+checked code to use existing unchecked code safely with respect
+to bounds, assuming that the interface and existing code are
+correct.
+
+Type checking is modified to insert implicit conversions between
+checked types and unchecked types at bounds-safe interfaces.
+The additional bounds information is used during checking
+of bounds declarations to ensure that checked code is
+using existing declarations properly.  It is also used to insert
+bounds checks in checked code.  This allows new checked code to
+use existing unchecked code, once a bounds-safe interface has
+been added to the existing code.
 \begin{enumerate}
 \item
-  Allowing programmers to declare bounds-safe interfaces to code and
-  data structures that use unchecked pointers. A bounds-safe interface for
-  a function, for example, describes bounds for unchecked pointer
-  parameters.   Type checking is altered to insert implicit conversions
-  between pointer types when needed.
-\item
   In checked scopes, code is limited to using pointer types that are 
-  checked pointer types or unchecked pointer types that have bounds-safe interfaces.
+  checked pointer types or unchecked pointer types with bounds-safe interfaces.
   This makes the code in checked scopes straightforward to understand:
   the unchecked pointer types are regarded as checked pointer types, all memory
   accesses are bounds checked or in bounds, and bounds-safe interfaces are trusted
@@ -499,37 +514,71 @@ maintains the checking of new code.  We address this by:
 \item
   In unchecked scopes, checked and unchecked pointer types can be
   be intermixed within expressions.  When that happens, the bounds-safe
-  interfaces are used during checking of bounds for determining bounds
-  of expressions and the required bounds for expressions. 
+  interfaces are used during checking of bounds declarations to determine
+  bounds of expressions and the required bounds for assignments and function calls. 
   Section~\ref{section:implicit-conversions} already
   explained when implicit conversions from unchecked pointer types to checked pointer
-  types may be inserted.   Implicit conversions of rvalue expressions 
-  from checked pointer types to unchecked pointer types are also inserted when
-  there are bounds-safe interfaces that describe the bounds requirements.
+  types may be inserted.   Implicit conversions of expressions 
+  from checked pointer types to unchecked pointer types are inserted when
+  necessary at bounds-safe interfaces.
 \end{enumerate}
 
-Functions that have parameters with unchecked pointer types or that return
-values with unchecked pointer types can have bounds declared for the unchecked
-pointer parameters or the unchecked pointer return value. Bounds must be
-declared for all parameters with unchecked pointer types and the return
-value, if it has an unchecked pointer type. In the case where a parameter
-has \texttt{ptr} type, this can be declared specially.
+The sections on bounds-safe interfaces are organized as
+follows.  Section~\ref{section:bounds-safe-interface-specifying} describes
+how to specify bounds-safe interfaces.
+Section~\ref{section:bounds-safe-interface-examples}
+has examples that show the use of bounds-safe interfaces.
+Section~\ref{section:bounds-safe-interface-redeclaration} explains
+how existing functions and variables can be redeclared with bounds-safe
+interfaces.  Section~\ref{section:bounds-safe-interface-type-checking}
+and ~\ref{section:checking-bounds-interfaces} cover technical details
+about type checking and checking bounds declarations that are interesting
+to language designers and compiler writers.  Programmers interested
+in using the Checked C extension can skip those sections.
 
+\subsection{Specifying bounds-safe interfaces}
+\label{section:bounds-safe-interface-specifying}
+Bounds-safe interfaces for declarations are specified by adding bounds
+declarations or type annotations to declarations.  They can be added to
+function declarations, function types, globally-scoped variables, and
+declarations of members of structure and union types.
+
+We describe adding bounds declarations first and then  describe adding type
+annotations.  Functions that have parameters with unchecked pointer
+types or that return values with unchecked pointer types can have bounds
+declared for the parameters and return values.  At calls to
+these functions, implicit conversions from checked types to unchecked
+pointer types are inserted for the corresponding argument expressions
+  
 Here is a bounds-safe interface for \texttt{memcpy}:
 \begin{verbatim}
 void *memcpy(void *dest : byte_count(len), const void *src : byte_count(len), 
              size_t len) 
              where return_value : bounds((char *) dest, (char *) dest + count)
 \end{verbatim}
-
 The correctness of bounds information is enforced at compile-time when
-memcpy is passed checked pointer arguments. It is not enforced when memcpy
-is passed unchecked pointer arguments.
+\texttt{memcpy} is passed checked pointer arguments. It is not enforced when 
+\texttt{memcpy} is passed unchecked pointer arguments.
 
-Similarly, for data structures, members with unchecked pointer types can
-have bounds declared. If bounds are declared for one member of a
-structure with an unchecked pointer type, they must be declared for all
-members with unchecked pointer types.
+Variables at external scope with unchecked pointer types can have
+bounds declared for them.   The declarations must follow the 
+rules in Section~\ref{section:external-scope-variables}.
+
+For data structures, members with unchecked pointer types can
+have bounds declared for them.   Implicit conversions from \arrayptr\ 
+type to unchecked pointer type are inserted at assignments to the members.
+
+Bounds-safe interfaces for functions and members must be
+declared on an ``all-or-nothing'' basis.
+For a function, if any parameter (or the return value) has an unchecked pointer
+type and has a bounds declaration or type annotation, all the
+the other parameters (or the return value) that have unchecked
+pointer types must also have bounds declarations or type
+annotations.  Similarly, for a structure or union type,
+if any member with unchecked pointer type
+has a bounds declaration or type annotation, all other members
+that have unchecked pointer types must also have bounds declarations
+or type annotations.
 
 Here are the bounds for a structure that is a counted buffer of
 characters.
@@ -540,69 +589,128 @@ struct S {
 }
 \end{verbatim}
 
-We may have a method that takes a counted buffer of characters and
-counts the number of instances of a specific character. The \texttt{ptr}
-declaration can be used to declare an unchecked pointer to a singleton
-object of a type:
-\begin{verbatim}
-int count_char(S *str where ptr, char arg);
-\end{verbatim}
-
-Variables at external scope with unchecked pointer types may also have
-bounds declared for them.   The declarations must follow the 
-rules in Section~\ref{section:external-scope-variables}.
-
 It is important to understand that the \emph{semantics of unchecked
 pointers does not change in unchecked scopes even when bounds are
 declared for the pointers}. The declared bounds are used  for expressions
 that mix checked and unchecked pointer types. Unchecked pointer dereferences do not
-have bounds checks added to them. A function that declares a bounds-safe 
+have bounds checks added to them. A function that has a bounds-safe
 interface and whose body does not use checked pointer
 types is compiled as though the bounds-safe interface has been
 stripped from its source code.
 
-\subsection{Type checking}
+A type annotation describes an alternate checked type to use in checked code
+in place of an unchecked type. It is used, for example, when a variable with
+an unchecked pointer type should be treated as having
+a \texttt{ptr} type.  Syntactically, it can
+be used in place of the  bounds expression in a bounds declaration.
 
-Bounds-safe interfaces allow unchecked pointer types to be used
-where checked pointer types with assignment compatible referent types are
-expected and {\it vice versa}.
-To handle this, implicit pointer conversions are inserted during type checking.
-Section~\ref{section:implicit-conversions} covered implicit conversions from unchecked pointer types to checked pointer types.
+A type annotation is specified using the following syntax:
 
-Implicit conversions from checked pointer types to unchecked pointer types
-with assignment-compatible referent types are allowed exactly at the uses of functions,
-variables, or members with a  bounds-safe interface.  In this case, assignment
-compatibility is applied in a reverse fashion.  The source referent type must be
-assignment compatible with the destination referent type.  The conversions are done for rvalue expressions by inserting C cast operators to the desired unchecked types.
-They may be done at:
-\begin{itemize}
-\item Function call arguments: If the function being called has a
-      bounds-safe interface for unchecked pointer type arguments, a parameter
-      type has an unchecked pointer type, the corresponding argument expression
-      has a checked pointer type, and the argument referent type is assignment
-      compatible with the parameter referent type, then the argument expression
-      will be converted implicitly to the unchecked pointer type.
-\item Assignments to a variable with external scope: if the variable being
-     assigned to has an unchecked pointer type and a bounds-safe interface, the
-     right-hand side expression has a checked pointer type, and the right-hand
-     side expression referent type is assignment compatible with the referent
-     type of the variable, then the right-hand side expression will be converted
-     implicitly to the unchecked pointer type.
-\item
-   Member assignments: a similar conversion is done for member assignments.
-\end{itemize}
+\begin{tabbing}
+\var{type-}\=\var{annotation:} \\
+\>\texttt{itype (} \var{type name} \texttt{)}\\
+\\
+The syntax for inline bounds specifiers is extended to include
+type annotations:\\
+\\
+\var{inline-bounds-specifier:}\\
+\> \var{\ldots{}}\\
+\>\texttt{:} \var{type-annotation}
+\end{tabbing}
+The keyword \texttt{itype} is short for bounds-safe  interface type.
 
-Implicit conversions at bounds-safe interfaces are allowed from checked pointer types to
-\uncheckedptrvoid.  This rule is likely to change in the future.  There is not a  design for
-checking type-safety of casts yet and the design will amost certainly affect 
-\uncheckedptrvoid\ casts.
+A type annotation can be used to declare that an unchecked
+pointer to a structure should be treated as a \verb+ptr+ in
+checked code. Here is a declaration for a function
+\verb+count_char+ that takes
+an unchecked pointer to the struct \texttt{S} defined earlier,
+with a type annotation. \verb+count_char+ counts the number
+of occurrences of \verb+arg+ in \verb+S+. Checked code must pass a
+value that is a valid \verb+ptr+ to \verb+count_char+:
+\begin{verbatim}
+int count_char(S *str : itype(ptr<S>), char arg);
+\end{verbatim}
 
-Only one implicit pointer conversion is allowed for an expression at a bounds-safe
-interface.  For example, an expression will not be
-coerced implicitly from \ptrinst{\var{S}} to \uncheckedptrvoid\ to
-\uncheckedptrinst{\var{T}}, where \var{S} and \var{T} are different types.
+Here are functions from the C Standard Library with type annotations.
+In the examples, type annotations for return types are placed 
+after the parameter list, the same way that bounds expression for
+return values are placed:
+\begin{verbatim}
+void modf(double value, double *iptr : itype(ptr<double>));
+int fclose(FILE *stream : itype(ptr<FILE>));
+FILE *tmpfile(void) : itype(ptr<FILE>);
+struct tm *gmtime(const time_t *timer : itype(ptr<const time_t>)) :
+    itype(ptr<struct tm>);
+\end{verbatim}
 
-\subsection{Type compatibility}
+The \var{type name} in a type annotation must be compatible
+with the original unchecked pointer type when checkedness
+of pointers and arrays is ignored. The \var{type name} cannot
+lose checking.  It must be at least as checked as the
+original type.  Finally, the \var{type name} must be
+a checked type.   Checked types are defined inductively:
+checked pointer and array types are checked types,
+array and pointer types constructed from checked types
+are checked types, and function types constructed from
+at least one checked type are checked types.
+
+\subsection{Examples}
+\label{section:bounds-safe-interface-examples}
+
+Here are some examples:
+\begin{verbatim}
+void copy(array_ptr<int> dest : count(len),
+          array_ptr<int> src : count(len), int len)
+{
+    // dest, src will be converted implicitly to void * pointers.
+    // Even though this is an unchecked context, the function call
+    // arguments will be checked to make sure that they meet the
+    // bounds requirements of memcpy.  This is because the argument
+    // expressions have checked pointer types.
+    memcpy(dest, src, len * sizeof(int));
+}
+
+f(S s) 
+{
+     int len = s.len;
+     array_ptr<char> sp : count(len) = s.arr;
+     ...
+     if (len > 0) {
+        sp[0] = 'a';
+     }
+}
+\end{verbatim}
+
+This example will fail at compile time:
+\begin{verbatim}
+void bad_copy(int *dest,
+              array_ptr<int> src : count(len), int len)
+{
+    // dest, src will be converted implicitly to void * pointers.
+    // Because an argument had a checked pointer type, the function call
+    // will be checked to make sure parameters meet the bounds
+    // requirements.  This will fail because dest has no bounds.
+    memcpy(dest, src, len * sizeof(int));
+}
+\end{verbatim}
+
+In contrast, this example will compile:
+\begin{verbatim}
+void subtle_copy(int *dest,
+                 array_ptr<int> src : count(len), int len)
+{
+    // This function call will not be checked for bounds
+    // requirements because no arguments have checked pointer
+    // types.  This shows both that the programmer has control
+    // over checking by using types and why checked contexts
+    // should be used with checked pointers when possible (perhaps
+    // the programmer did not want to do this).
+    memcpy(dest, (void *) src, len * sizeof(int));
+}
+\end{verbatim}
+
+\subsection{Redeclaring existing functions and variables with bounds-safe interfaces}
+\label{section:bounds-safe-interface-redeclaration}
 
 C allows variables or functions to be declared with types that are missing information.
 There can be other declarations of the variables or functions with types that are more complete
@@ -636,6 +744,49 @@ where bounds information is missing for a parameter, the argument passed to \tex
 for that parameter cannot have an \arrayptr\ type.  The typing rules prevent arguments
 with checked type from being used with parameters of \texttt{g} that are missing
 bounds information.
+
+\subsection{Type checking}
+\label{section:bounds-safe-interface-type-checking}
+
+Bounds-safe interfaces allow unchecked pointer types to be used
+where checked pointer types with assignment compatible referent types are
+expected and {\it vice versa}.
+To handle this, implicit pointer conversions are inserted during type checking.
+Section~\ref{section:implicit-conversions} covered implicit conversions from unchecked pointer types to checked pointer types.
+
+Implicit conversions from checked pointer types to unchecked pointer types
+with assignment-compatible referent types are allowed exactly at the uses of functions,
+variables, or members with a  bounds-safe interface.  In this case, assignment
+compatibility is applied in a reverse fashion.  The source referent type must be
+assignment compatible with the destination referent type.  The conversions are
+done for rvalue expressions by inserting C cast operators to the desired unchecked types.
+They may be done at:
+\begin{itemize}
+\item Function call arguments: If the function being called has a
+      bounds-safe interface for unchecked pointer type arguments, a parameter
+      type has an unchecked pointer type, the corresponding argument expression
+      has a checked pointer type, and the argument referent type is assignment
+      compatible with the parameter referent type, then the argument expression
+      will be converted implicitly to the unchecked pointer type.
+\item Assignments to a variable with external scope: if the variable being
+     assigned to has an unchecked pointer type and a bounds-safe interface, the
+     right-hand side expression has a checked pointer type, and the right-hand
+     side expression referent type is assignment compatible with the referent
+     type of the variable, then the right-hand side expression will be converted
+     implicitly to the unchecked pointer type.
+\item
+   Member assignments: a similar conversion is done for member assignments.
+\end{itemize}
+
+Implicit conversions at bounds-safe interfaces are allowed from checked pointer types to
+\uncheckedptrvoid.  This rule is likely to change in the future.  There is not a  design for
+checking type-safety of casts yet and the design will amost certainly affect 
+\uncheckedptrvoid\ casts.
+
+Only one implicit pointer conversion is allowed for an expression at a bounds-safe
+interface.  For example, an expression will not be
+coerced implicitly from \ptrinst{\var{S}} to \uncheckedptrvoid\ to
+\uncheckedptrinst{\var{T}}, where \var{S} and \var{T} are different types.
 
 \subsection{Checking bounds declarations}
 \label{section:checking-bounds-interfaces}
@@ -694,59 +845,6 @@ checked and unchecked  pointer types in one function call.  The checking of boun
 for function arguments is done for all arguments, so this also implies that the unchecked
 pointer-typed expressions will need to have valid bounds.
 
-\subsection{Examples}
-
-Here are some examples:
-\begin{verbatim}
-void copy(array_ptr<int> dest : count(len), 
-          array_ptr<int> src : count(len), int len)
-{
-    // dest, src will be converted implicitly to void * pointers.
-    // Even though this is an unchecked context, the function call
-    // arguments will be checked to make sure that they meet the
-    // bounds requirements of memcpy.  This is because the argument
-    // expressions have checked pointer types.
-    memcpy(dest, src, len * sizeof(int));
-}
- 
-f(S s) 
-{
-     int len = s.len;
-     array_ptr<char> sp : count(len) = s.arr;
-     ...
-     if (len > 0) {
-        sp[0] = 'a';
-     }
-}
-\end{verbatim}
-
-This example will fail at compile time:
-\begin{verbatim}
-void bad_copy(int *dest,
-              array_ptr<int> src : count(len), int len)
-{
-    // dest, src will be converted implicitly to void * pointers.
-    // Because an argument had a checked pointer type, the function call
-    // will be checked to make sure parameters meet the bounds
-    // requirements.  This will fail because dest has no bounds.
-    memcpy(dest, src, len * sizeof(int));
-}
-\end{verbatim}
-
-In contrast, this example will compile:
-\begin{verbatim}
-void subtle_copy(int *dest,
-                 array_ptr<int> src : count(len), int len)
-{
-    // This function call will not be checked for bounds
-    // requirements because no arguments have checked pointer
-    // types.  This shows both that the programmer has control
-    // over checking by using types and why checked contexts
-    // should be used with checked pointers when possible (perhaps
-    // the programmer did not want to do this).
-    memcpy(dest, (void *) src, len * sizeof(int));
-}
-\end{verbatim}
 
 \section{Conversions between pointers and integers}
 \label{section:pointer-integer-conversions}

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
 // Test expressions with standard signed and unsigned integers types as
 // arguments to count and byte_count.
@@ -845,6 +845,7 @@ struct s8 {
 // count
 array_ptr<int> fn1(void) : count(5) { return 0; }
 int *fn2(void) : count(5) { return 0; }
+int *fn3(int len) : count(len) { return 0; }
 
 // byte_count
 extern array_ptr<int> fn4(void) : byte_count(5 * sizeof(int));
@@ -912,52 +913,176 @@ void (*fn75(void) : bounds(s1, s1 + 1))(int);  // expected-error {{bounds declar
 ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed for a _Ptr return type}}
 
 //
-// Spot check bounds declaration on parameters of function pointer types
+// Test bounds declarations on function parameters
 //
 
-void fn100(int (*fnptr)(array_ptr<int> p1 : count(5)));
-void fn101(int (*fnptr)(int p1 : count(5)));             // expected-error {{expected 'p1' to have a pointer or array type}}
-void fn102(int (*fnptr)(array_ptr<void> p1 : count(5))); // expected-error {{expected 'p1' to have a non-void pointer type}}
+// These are numbered so that they correspond to the numbering of
+// functions with function pointer parameters in the next section of
+// tests.
+void fn100(array_ptr<int> p1 : count(5));
+void fn100a(array_ptr<int> p1 : count(6));
+void fn101(int p1 : count(5));             // expected-error {{expected 'p1' to have a pointer or array type}}
+void fn102(array_ptr<void> p1 : count(5)); // expected-error {{expected 'p1' to have a non-void pointer type}}
 
-void fn103(int (*fnptr)(array_ptr<int> p1 : byte_count(5 * sizeof(int))));
-void fn104(int (*fnptr)(float p1 : byte_count(5 * sizeof(int)))); // expected-error {{expected 'p1' to have a pointer, array, or integer type}}
-void fn105(int (*fnptr)(array_ptr<void> p1 : byte_count(5 * sizeof(int))));
+int fn103(array_ptr<int> p1 : byte_count(5 * sizeof(int)));
+int fn103a(array_ptr<int> p1 : byte_count(7 * sizeof(int)));
+int fn104(int *p1 : byte_count(5 * sizeof(int)));
+int fn104a(int *p1 : byte_count(6 * sizeof(int)));
+int fn104b(float *p1 : byte_count(6 * sizeof(float)));
+int fn105(int p1 : byte_count(5 * sizeof(int)));
+int fn106(float p1 : byte_count(5 * sizeof(int))); // expected-error {{expected 'p1' to have a pointer, array, or integer type}}
+int fn107(array_ptr<void> p1 : byte_count(5 * sizeof(int)));
 
-void fn106(int (*fnptr)(array_ptr<int> p1 : bounds(p1, p1 + 5)));
-void fn107(int (*fnptr)(array_ptr<int> p1, float p2 : bounds(p1, p1 + 5))); // expected-error {{expected 'p2' to have a pointer, array, or integer type}}
-void fn108(int (*fnptr)(array_ptr<void> p1 : bounds((char *) p1, (char *) p1 + (5 * sizeof(int)))));
+void fn108(array_ptr<int> p1 : bounds(p1, p1 + 5));
+void fn108a(array_ptr<int> p1 : bounds(p1, p1 + 5));
+void fn109(array_ptr<int> p1, int p2 : bounds(p1, p1 + 5));
+void fn110(array_ptr<int> p1, float p2 : bounds(p1, p1 + 5)); // expected-error {{expected 'p2' to have a pointer, array, or integer type}}
+void fn111(array_ptr<void> p1 : bounds((char *)p1, (char *)p1 + (5 * sizeof(int))));
+
+// A few functions with multiple arguments.
+void fn120(array_ptr<int> mid : bounds(p1, p1 + 5), array_ptr<int> p1);
+void fn122(array_ptr<void> mid : bounds((char *)p1, (char *)p1 + (5 * sizeof(int))),
+           array_ptr<int> p1);
+
+//
+// Test bounds declaration on parameters of function pointer types
+//
+
+// These are numbered so that they correspond to the numbering of
+// functions in the prior section of tests: fn200 - fn211 take fn100 - fn111 as
+//  arguments.  fn220-231 are versions of fn200 - fn211 that take checked
+// function pointers.
+
+// Unchecked function pointers
+void fn200(void (*fnptr)(array_ptr<int> p1 : count(5)));
+void fn201(void (*fnptr)(int p1 : count(5)));             // expected-error {{expected 'p1' to have a pointer or array type}}
+void fn202(void (*fnptr)(array_ptr<void> p1 : count(5))); // expected-error {{expected 'p1' to have a non-void pointer type}}
+
+void fn203(int (*fnptr)(array_ptr<int> p1 : byte_count(5 * sizeof(int))));
+void fn204(int (*fnptr)(int * : byte_count(5 * sizeof(int))));
+void fn205(int (*fnptr)(int p1 : byte_count(5 * sizeof(int))));
+void fn206(int (*fnptr)(float p1 : byte_count(5 * sizeof(int)))); // expected-error {{expected 'p1' to have a pointer, array, or integer type}}
+void fn207(int (*fnptr)(array_ptr<void> p1 : byte_count(5 * sizeof(int))));
+
+void fn208(void (*fnptr)(array_ptr<int> p1 : bounds(p1, p1 + 5)));
+void fn209(void (*fnptr)(array_ptr<int> p1, int p2 : bounds(p1, p1 + 5)));
+void fn210(void (*fnptr)(array_ptr<int> p1, float p2 : bounds(p1, p1 + 5))); // expected-error {{expected 'p2' to have a pointer, array, or integer type}}
+void fn211(void (*fnptr)(array_ptr<void> p1 : bounds((char *) p1, (char *) p1 + (5 * sizeof(int)))));
+
+// Checked function pointers
+void fn220(ptr<void (array_ptr<int> p1 : count(5))> fnptr);
+void fn221(ptr<void (int p1 : count(5))> fnptr);             // expected-error {{expected 'p1' to have a pointer or array type}}
+void fn222(ptr<void (array_ptr<void> p1 : count(5))> fnptr); // expected-error {{expected 'p1' to have a non-void pointer type}}
+
+void fn223(ptr<int (array_ptr<int> p1 : byte_count(5 * sizeof(int)))> fnptr);
+void fn224(ptr<int (int * : byte_count(5 * sizeof(int)))> fnptr);
+void fn225(ptr<int (int p1 : byte_count(5 * sizeof(int)))> fnptr);
+void fn226(ptr<int (float p1 : byte_count(5 * sizeof(int)))> fnptr); // expected-error {{expected 'p1' to have a pointer, array, or integer type}}
+void fn227(ptr<int (array_ptr<void> p1 : byte_count(5 * sizeof(int)))> fnptr);
+
+void fn228(ptr<void (array_ptr<int> p1 : bounds(p1, p1 + 5))> fnptr);
+void fn229(ptr<void (array_ptr<int> p1, int p2 : bounds(p1, p1 + 5))> fnptr);
+void fn230(ptr<void (array_ptr<int> p1, float p2 : bounds(p1, p1 + 5))> fnptr); // expected-error {{expected 'p2' to have a pointer, array, or integer type}}
+void fn231(ptr<void (array_ptr<void> p1 : bounds((char *)p1, (char *)p1 + (5 * sizeof(int))))> fnptr);
+
+// Function pointers with multiple arguments.
+void fn240(ptr<int (array_ptr<int> mid : bounds(p1, p1 + 5), array_ptr<int> p1)> fnptr);
+void fn241(ptr<int (array_ptr<void> mid : bounds((char *)p1, (char *)p1 + (5 * sizeof(int))),
+                    array_ptr<int> p1)> fnptr);
+
+//
+// Spot check bounds-safe interfaces on parameters of function pointer types
+//
+
+void fn250(int(*fnptr)(int *p1 : count(5)));
+void fn251(int(*fnptr)(int *p1 : byte_count(5 * sizeof(int))));
+void fn252(int(*fnptr)(int *p1 : bounds(p1, p1 + 5)));
 
 //
 // Spot check bounds declaration for return values of function pointer types
 //
 
-void fn120(array_ptr<int> (*fnptr)(void) : count(5));
-void fn121(int (*fnptr)(void) : count(5)); // expected-error {{count bounds expression only allowed for pointer return type}}
-void fn122(array_ptr<void> (*fnptr)(void) : count(5)); // expected-error {{count bounds expression not allowed for a void pointer return type}}
+void fn260(array_ptr<int> (*fnptr)(void) : count(5));
+void fn261(array_ptr<int>(*fnptr)(int i) : count(i));
+void fn262(int (*fnptr)(void) : count(5)); // expected-error {{count bounds expression only allowed for pointer return type}}
+void fn263(array_ptr<void> (*fnptr)(void) : count(5)); // expected-error {{count bounds expression not allowed for a void pointer return type}}
 
 //
 // Test bounds declarations for function pointers
 //
 
 void function_pointers() {
-  // Assignments to function pointers with return bounds
+  // Assignments to function pointers with return bounds on array_ptr types
   array_ptr<int>(*t1)(void) : count(5) = fn1;
-  // Local variables can't have bounds-safe interfaces
+  // Assignment to function pointers with bounds-safe interfaces on
+  // unchecked pointer return types.  Unchecked pointers are compatible with
+  // unchecked pointers with bounds-safe interfaces.  This extends recursively
+  // to parameters and returns of function types.
   int *(*t2)(void) = fn2;
-  array_ptr<int>(*t4)(void) : byte_count(5 * sizeof(int)) = fn4;
-  array_ptr<void>(*t5)(void) : byte_count(5 * sizeof(int)) = fn5;
-  // Local variables can't have bounds-safe interfaces
-  int *(*t6)(void) = fn6;
-  array_ptr<int>(*t10)(void) : bounds(s1, s1 + 5) = fn10;
-  int *(*t12)(void) = fn12;
+  int *(*t3)(void) : count(5) = fn2;
+  ptr<int *(void) : count(5)> t4 = fn2;
 
-  // Assignments to function pointers with parameter bounds
+  int *(*t5)(int i) = fn3;
+  int *(*t6)(int i) : count(i) = fn3;
+  ptr<int *(int j) : count(j)> t7 = fn3;
+
+  array_ptr<int>(*t8)(void) : byte_count(5 * sizeof(int)) = fn4;
+  array_ptr<void>(*t9)(void) : byte_count(5 * sizeof(int)) = fn5;
+  int *(*t10)(void) = fn6;
+  int *(*t11)(void) : byte_count(5*sizeof(int)) = fn6;
+  ptr<int *(void) : byte_count(5*sizeof(int))> t12 = fn6;
+
+  array_ptr<int>(*t13)(void) : bounds(s1, s1 + 5) = fn10;
+  int *(*t14)(void) = fn12;
+  int *(*t15)(void) : bounds(s1, s1 + 5) = fn12;
+  int *(*t16)(void) : bounds(s1, s1 + 6) = fn12;    // expected-warning {{incompatible pointer types}}
+  ptr<int *(void) : bounds(s1, s1 + 6)> t17 = fn12; // expected-error {{incompatible type}}
 
   // Unchecked pointer to function assigned to checked pointer to
   // function.
   ptr<array_ptr<int>(void) : count(5)> t100 = fn1;
+
   // The reverse is not allowed
   array_ptr<int>(*t101)(void) : count(5) = t100; // expected-error {{incompatible type}}
+
+  // Calls that pass function pointers with bounds
+  fn200(fn100);
+  fn200(fn100a); // expected-error {{parameter of incompatible type}}
+  fn201(fn101);
+  fn202(fn102);
+  fn203(fn103);
+  fn203(fn103a); // expected-error {{parameter of incompatible type}}
+  fn204(fn104);
+  // These are mismatched unchecked function pointers with bounds-safe interfaces
+  // on parameters.
+  fn204(fn104a); // expected-warning {{incompatible pointer types}}
+  fn204(fn104b); // expected-warning {{incompatible pointer types}}
+  fn205(fn105);
+  fn206(fn106);
+  fn207(fn107);
+  fn208(fn108);
+  fn209(fn109);
+  fn210(fn110);
+  fn211(fn111);
+
+  fn220(fn100);
+  fn220(fn100a); // expected-error {{parameter of incompatible type}}
+  fn221(fn101);
+  fn222(fn102);
+  fn223(fn103);
+  fn223(fn103a); // expected-error {{parameter of incompatible type}}
+  fn224(fn104);
+  // These are mismatched checked function pointers with bounds-safe interfaces
+  // on parameters.
+  fn224(fn104a); // expected-error {{parameter of incompatible type}}
+  fn224(fn104b); // expected-error {{parameter of incompatible type}}
+  fn225(fn105);
+  fn226(fn106);
+  fn227(fn107);
+  fn228(fn108);
+  fn229(fn109);
+  fn230(fn110);
+  fn231(fn111);
 }
 
 void invalid_function_pointers() {

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -793,7 +793,7 @@ array_ptr<int> fn10(void) : bounds(s1, s1 + 5) { return 0; }
 array_ptr<void> fn11(void) : bounds(s1, s1 + 5) { return 0; }
 int *fn12(void) : bounds(s1, s1 + 5) { return 0; }
 
-// Test valid rEturn bounds declarations for integer-typed values
+// Test valid return bounds declarations for integer-typed values
 short int fn20(void) : byte_count(5 * sizeof(int)) { return (short int) s1; }
 int fn21(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
 long int fn22(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
@@ -847,3 +847,35 @@ union U1 fn73(void) : bounds(s1, s1 + 1);   // expected-error {{expected 'fn73' 
 ptr<int> fn74(void) : bounds(s1, s1 + 1);   // expected-error {{bounds declaration not allowed because 'fn74' has a _Ptr return type}}
 void (*fn75(void) : bounds(s1, s1 + 1))(int);  // expected-error {{bounds declaration not allowed because 'fn75' has a function pointer return type}}
 ptr<void(int)> fn76(void) : bounds(s1, s1 + 1);  // expected-error {{bounds declaration not allowed because 'fn76' has a _Ptr return type}}
+
+//
+// Test bounds declarations for function pointers
+//
+
+void function_pointers() {
+   // Assignments to function pointers with return bounds
+   array_ptr<int> (*t1)(void) : count(5) = fn1;
+     // Local variables can't have bounds-safe interfaces
+   int *(*t2)(void) = fn2;
+   array_ptr<int> (*t4)(void) : byte_count(5 * sizeof(int)) = fn4;
+   array_ptr<void> (*t5)(void) : byte_count(5 * sizeof(int)) = fn5;
+   // Local variables can't have bounds-safe interfaces
+   int *(*t6)(void) = fn6;
+   array_ptr<int> (*t10)(void) : bounds(s1, s1 + 5) = fn10;
+   int *(*t12)(void) = fn12;
+
+   // Assignments to function pointers with parameter bounds
+
+   // Unchecked pointer to function assigned to checked pointer to
+   // function.
+   ptr<array_ptr<int>(void) : count(5)> t100 = fn1;
+   // The reverse is not allowed
+   array_ptr<int>(*t101)(void) : count(5) = t100; // expected-error {{incompatible type}}
+}
+
+void invalid_function_pointers() {
+  array_ptr<int> (*t1)(void) : count(4) = fn1;  // expected-error {{incompatible type}}
+  ptr<array_ptr<int> (void) : count(4)> t1a = fn1;  // expected-error {{incompatible type}}
+  array_ptr<int> (*t4)(void) : byte_count(6 * sizeof(int)) = fn4; // expected-error {{incompatible type}}
+  array_ptr<int>(*t10)(void) : bounds(s1, s1 + 4) = fn10; // expected-error {{incompatible type}}
+}

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -139,12 +139,12 @@ extern struct S8 *f40();
 extern struct S9 *f41();
 
 //
-// No prototype functions cannot have return bounds declarations.  They can
+// No prototype functions cannot return checked types.  They can
 // declare bounds-safe interfaces.
 //
 
-extern array_ptr<int> f50() : count(5); // expected-error {{function with no prototype cannot have a return type that is a checked type}} expected-error {{function with no prototype cannot have a return bounds}}
-extern int f51() : byte_count(10);      // expected-error {{cannot have a return bounds}}
+extern array_ptr<int> f50() : count(5); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
+extern int f51() : byte_count(10);
 extern int *f52() : byte_count(10);
 extern int *f53() : itype(ptr<int>);
 
@@ -223,10 +223,13 @@ extern void f83(int f(ptr<int>));  // expected-error {{conflicting types for 'f8
 extern void f84(int f(ptr<int>));  
 extern void f84(int f());   // expected-error {{conflicting types for 'f84'}}
 
-// No prototype functions cannot be redeclared to take arguments that have
-// bounds declarations.
+// No prototype functions can be redeclared with bounds-safe interfaces on integer and
+// unchecked pointer arguments.
 extern void f85();
-extern void f85(int p : bounds((char *)p, (char *)p + len), int len); // expected-error {{cannot redeclare a function with no prototype to have an argument bounds}}
+extern void f85(char *p : bounds(p, p + len), int len);
+
+extern void f86();
+extern void f86(int p : bounds((char *)p, (char *)p + len), int len);
 
 //
 // Redeclaring a function with a checked argument as a no prototype function is not allowed.
@@ -235,12 +238,13 @@ extern void f85(int p : bounds((char *)p, (char *)p + len), int len); // expecte
 extern void f90(ptr<int>);
 extern void f90(); // expected-error {{cannot redeclare a function that has a checked argument or argument bounds to have no prototype}}
 
-// TODO: Github checkedc-clang issue 20 this is an error, but the Checked C
-// clang implementation isn't catching it yet.  It doesn't detect that
-// the types are incompatible because bounds information is not represented
-// in function types yet..
-extern void f91(int p : bounds((char *)p, (char *)p + len), int len);
+// Redeclaring a function with a bounds-safe interface on an argument as a no protoype
+// functino is allowed.  The function types are considered compatible.
+extern void f91(char *p : bounds(p, p + len), int len);
 extern void f91();
+
+extern void f92(int p : bounds((char *)p, (char *)p + len), int len);
+extern void f92();
 
 //
 // Spot-check other attempts at creating no prototype functions that return

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -40,7 +40,7 @@ void f8(int *p, int len);
 //---------------------------------------------------------------------------//
 // Declarations of functions that return unchecked types are compatible      //
 // with declarations that add bounds-safe interfaces.                        //
-//---------------------------------------------------------------------------// 
+//---------------------------------------------------------------------------//
 
 int *f20(int len);
 int *f20(int len) : count(len);
@@ -84,7 +84,7 @@ void f32(int *p : bounds(p, p + len + 1), int len);  // expected-error {{conflic
 void f33(int *p : bounds(p, p + len), int len);
 void f33(int *p, int len);
 // A redeclaration without a bounds-safe interface is compatible with the
-// original declaration, but the function retains its original bounds-safe 
+// original declaration, but the function retains its original bounds-safe
 // interface
 void f33(int *p : bounds(p, p + len + 1), int len);  // expected-error {{conflicting types for 'f33'}}
 
@@ -92,7 +92,7 @@ void f34(int *p : itype(ptr<int>), int len);
 void f34(int *p : count(len), int len);  // expected-error {{conflicting types for 'f34'}}
 
 //---------------------------------------------------------------------------//
-// Redeclarations of functions that have parameters that have bounds         // 
+// Redeclarations of functions that have parameters that have bounds         //
 // declarations must have matching declarations.                             //
 //---------------------------------------------------------------------------//
 void f40(array_ptr<int> p : count(len), int len);
@@ -126,7 +126,7 @@ int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // exp
 int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
 int *f53(int *p, int len);
 // A redeclaration without a bounds-safe interface is compatible with the
-// original declaration, but the function retains its original bounds-safe 
+// original declaration, but the function retains its original bounds-safe
 // interface.
 int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // expected-error {{conflicting types for 'f53'}}
 
@@ -134,7 +134,7 @@ int *f54(int len) : itype(ptr<int>);
 int *f54(int len) : count(len);  // expected-error {{conflicting types for 'f54'}}
 
 //---------------------------------------------------------------------------//
-// Redeclarations of functions that have bounds declarations for returns     // 
+// Redeclarations of functions that have bounds declarations for returns     //
 // must have matching declarations.                                          //
 //---------------------------------------------------------------------------//
 array_ptr<int> f60(int len) : count(len);
@@ -146,13 +146,36 @@ array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);
 array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len - 1); // expected-error {{conflicting types for 'f61'}}
 
 //---------------------------------------------------------------------------//
+// Redeclarations of functions that have paraemters with function pointer    //
+// types that have bounds-safe interfaces must have matching bounds-safe     //
+// interfaces.                                                               //
+//---------------------------------------------------------------------------//
+
+// Interface type on parameter with function pointer type.
+void f70(int * fn(int *, int *));
+void f70(int * fn(int *, int *) :
+           itype(array_ptr<int> (ptr<int>, ptr<int>)));
+// identical redeclaration.
+void f70(int * fn(int *, int *) :
+           itype(array_ptr<int> (ptr<int>, ptr<int>)));
+// return type of itype differs.
+void f70(int *fn(int *, int *) : itype(ptr<int> (ptr<int>, ptr<int>))); // expected-error {{conflicting types for 'f70'}}
+
+// Interface type on parameters of a function pointer type
+void f71(int * fn(int *, int *));
+void f71(int * fn(int * : count(5), int *: count(5)));
+void f71(int * fn(int * : count(6), int * : count(6))); // expected-error {{conflicting types for 'f71'}}
+
+// Interface type on return value of a function pointer type
+void f72(int * fn(int *, int *));
+void f72(int * fn(int *, int *) : itype(ptr<int>));
+//---------------------------------------------------------------------------//
 // The bounds declarations must be syntactically identical for now.          //
 //---------------------------------------------------------------------------//
 
-void f70(int *p : count(len), int len);
-void f70(int *p : count((len)), int len); // expected-error {{conflicting types for 'f70'}}
+void f80(int *p : count(len), int len);
+void f80(int *p : count((len)), int len); // expected-error {{conflicting types for 'f80'}}
 
-void f71(int *p : count(len), int len);
-void f71(int *p : bounds(p, p + len), int len);  // expected-error {{conflicting types for 'f71'}}
-
+void f81(int *p : count(len), int len);
+void f81(int *p : bounds(p, p + len), int len);  // expected-error {{conflicting types for 'f81'}}
 

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -103,6 +103,13 @@ void f41(array_ptr<int> p : bounds(p, p + len), int len);
 void f41(array_ptr<int> p : bounds(p, p + len), int len);
 void f41(array_ptr<int> p : bounds(p, p + len + 1), int len); // expected-error {{conflicting types for 'f41'}}
 
+// Add a parameter bounds declaration.
+void f42(array_ptr<int> p, int len);
+void f42(array_ptr<int> p : count(len), int len);  // expected-error {{conflicting types for 'f42'}}
+
+// Drop a parameter bounds declaration.
+void f43(array_ptr<int> p : count(len), int len);
+void f43(array_ptr<int> p, int len);               // expected-error {{conflicting types for 'f43'}}
 
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have bounds-safe interfaces for returns  //
@@ -145,8 +152,17 @@ array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);
 array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);
 array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len - 1); // expected-error {{conflicting types for 'f61'}}
 
+// Add a bounds declaration.
+array_ptr<int> f62(int len);
+array_ptr<int> f62(int len) : count(len);   // expected-error {{conflicting types for 'f62'}}
+
+// Drop a bounds declaration.
+array_ptr<int> f63(int len) : count(len);
+array_ptr<int> f63(int len);                // expected-error {{conflicting types for 'f63'}}
+
+
 //---------------------------------------------------------------------------//
-// Redeclarations of functions that have paraemters with function pointer    //
+// Redeclarations of functions that have parameters with function pointer    //
 // types that have bounds-safe interfaces must have matching bounds-safe     //
 // interfaces.                                                               //
 //---------------------------------------------------------------------------//
@@ -158,8 +174,13 @@ void f70(int * (fn(int *, int *)) :
 // identical redeclaration.
 void f70(int * (fn(int *, int *)) :
            itype(array_ptr<int> (ptr<int>, ptr<int>)));
+// Add interface types for parameters, still valid
+void f70(int * (fn(int * : itype(ptr<int>), int * : itype(ptr<int>))) :
+  itype(array_ptr<int>(ptr<int>, ptr<int>)));
 // return type of itype differs.
 void f70(int (*fn(int *, int *)) : itype(ptr<int> (ptr<int>, ptr<int>))); // expected-error {{conflicting types for 'f70'}}
+// changed interface types for parameters of function pointer
+void f70(int * (fn(int * : itype(array_ptr<int>), int * : itype(array_ptr<int>)))); // expected-error {{conflicting types for 'f70'}}
 
 // Interface type on parameters of a function pointer type
 void f71(int * fn(int *, int *));
@@ -169,11 +190,39 @@ void f71(int * fn(int * : count(6), int * : count(6))); // expected-error {{conf
 // Interface type on return value of a function pointer type
 void f72(int * fn(int *, int *));
 void f72(int * fn(int *, int *) : itype(ptr<int>));
+
 //---------------------------------------------------------------------------//
-// The bounds declarations must be syntactically identical for now.          //
+// Redeclarations of functions that have parameters with function pointer    //
+// types that have bounds declarations must have matching bounds declarations//
+//---------------------------------------------------------------------------//
+
+void fn80(void (*fnptr)(array_ptr<int> p1 : count(5)));
+void fn80(void (*fnptr)(array_ptr<int> p2 : count(5)));
+void fn80(void (*fnptr)(array_ptr<int> p1 : count(6)));  // expected-error {{conflicting types for 'fn80'}}
+
+void fn81(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 5), array_ptr<int> p1)> fnptr);
+void fn81(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 5), array_ptr<int> p1)> fnptr);
+void fn81(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 6), array_ptr<int> p1)> fnptr);  // expected-error {{conflicting types for 'fn81'}}
+
+void fn82(array_ptr<int>(*fnptr)(int i, int k) : count(i));
+void fn82(array_ptr<int>(*fnptr)(int j, int k) : count(j));
+void fn82(array_ptr<int>(*fnptr)(int j, int k) : count(k)); // expected-error {{conflicting types for 'fn82'}}
+
+void fn83(array_ptr<int>(*fnptr)(void) : count(5));
+void fn83(array_ptr<int>(*f)(void) : count(5));
+void fn83(array_ptr<int>(*f)(void) : count(6));          // expected-error {{conflicting types for 'fn83'}}
+
+
+
+//---------------------------------------------------------------------------//
+// The bounds declarations must be syntactically identical for now, modulo   //
+// parameter names.                                                          //
 //---------------------------------------------------------------------------//
 
 void f80(int *p : count(len), int len);
+// Rename parameters
+void f80(int *p : count(mylen), int mylen);
+void f80(int *r : count(i), int i);
 void f80(int *p : count((len)), int len); // expected-error {{conflicting types for 'f80'}}
 
 void f81(int *p : count(len), int len);

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -1,0 +1,158 @@
+// Feature tests of typechecking redeclarations of functions
+// and variables
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+
+#include "../../include/stdchecked.h"
+
+//---------------------------------------------------------------------------//
+// Declarations of functions with unchecked parameters are compatible with   //
+// declarations that add bounds-safe interfaces.                             //
+//---------------------------------------------------------------------------//
+
+void f1(int *p, int len);
+void f1(int *p : count(len), int len);
+
+void f2(int *p, int len);
+void f2(int *p : bounds(p, p + len), int len);
+
+void f3(int *p, int len);
+void f3(int *p : byte_count(len * sizeof(int)), int len);
+
+void f4(int *p, int len);
+void f4(int *p : itype(ptr<int>), int len);
+
+// Order doesn't matter for declarations
+void f5(int *p : count(len), int len);
+void f5(int *p, int len);
+
+void f6(int *p : bounds(p, p + len), int len);
+void f6(int *p, int len);
+
+void f7(int *p : byte_count(len * sizeof(int)), int len);
+void f7(int *p, int len);
+
+void f8(int *p : itype(ptr<int>), int len);
+void f8(int *p, int len);
+
+//---------------------------------------------------------------------------//
+// Declarations of functions that return unchecked types are compatible      //
+// with declarations that add bounds-safe interfaces.                        //
+//---------------------------------------------------------------------------// 
+
+int *f20(int len);
+int *f20(int len) : count(len);
+
+int *f21(int len);
+int *f21(int len) : byte_count(len * sizeof(int));
+
+int *f22(int len);
+int *f22(int len) : itype(ptr<int>);
+
+// Order doesn't matter
+int *f23(int len) : count(len);
+int *f23(int len);
+
+int *f24(int len) : byte_count(len * sizeof(int));
+int *f24(int len);
+
+int *f25(int len) : itype(ptr<int>);
+int *f25(int len);
+
+//---------------------------------------------------------------------------//
+// Redeclarations of functions that have parameters that have bounds-safe    //
+// interfaces must have matching interfaces.                                 //
+//---------------------------------------------------------------------------//
+
+void f30(int *p : count(len), int len);
+void f30(int *p : count(len), int len);
+void f30(int *p : count(len + 1), int len);  // expected-error {{conflicting types for 'f30'}}
+
+void f31(int *p : count(len), int len);
+// A redeclaration without bounds-safe interface is compatible with the
+// original declaration, but the function retains its original bounds-safe
+// interface.
+void f31(int *p, int len);
+void f31(int *p : count(len + 1), int len);  // expected-error {{conflicting types for 'f31'}}
+
+void f32(int *p : bounds(p, p + len), int len);
+void f32(int *p : bounds(p, p + len), int len);
+void f32(int *p : bounds(p, p + len + 1), int len);  // expected-error {{conflicting types for 'f32'}}
+
+void f33(int *p : bounds(p, p + len), int len);
+void f33(int *p, int len);
+// A redeclaration without a bounds-safe interface is compatible with the
+// original declaration, but the function retains its original bounds-safe 
+// interface
+void f33(int *p : bounds(p, p + len + 1), int len);  // expected-error {{conflicting types for 'f33'}}
+
+void f34(int *p : itype(ptr<int>), int len);
+void f34(int *p : count(len), int len);  // expected-error {{conflicting types for 'f34'}}
+
+//---------------------------------------------------------------------------//
+// Redeclarations of functions that have parameters that have bounds         // 
+// declarations must have matching declarations.                             //
+//---------------------------------------------------------------------------//
+void f40(array_ptr<int> p : count(len), int len);
+void f40(array_ptr<int> p : count(len), int len);
+void f40(array_ptr<int> p : count(len + 1), int len); // expected-error {{conflicting types for 'f40'}}
+
+void f41(array_ptr<int> p : bounds(p, p + len), int len);
+void f41(array_ptr<int> p : bounds(p, p + len), int len);
+void f41(array_ptr<int> p : bounds(p, p + len + 1), int len); // expected-error {{conflicting types for 'f41'}}
+
+
+//---------------------------------------------------------------------------//
+// Redeclarations of functions that have bounds-safe interfaces for returns  //
+// must have matching interfaces.                                            //
+//---------------------------------------------------------------------------//
+int *f50(int len) : count(len);
+int *f50(int len) : count(len);
+int *f50(int len) : count(len + 1);  // expected-error {{conflicting types for 'f50'}}
+
+int *f51(int len) : count(len);
+// A redeclaration without bounds-safe interface is compatible with the
+// original declaration, but the function retains its original bounds-safe
+// interface.
+int *f51(int len);
+int *f51(int len) : count(len + 1);  // expected-error {{conflicting types for 'f51'}}
+
+int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
+int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
+int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // expected-error {{conflicting types for 'f52'}}
+
+int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
+int *f53(int *p, int len);
+// A redeclaration without a bounds-safe interface is compatible with the
+// original declaration, but the function retains its original bounds-safe 
+// interface.
+int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // expected-error {{conflicting types for 'f53'}}
+
+int *f54(int len) : itype(ptr<int>);
+int *f54(int len) : count(len);  // expected-error {{conflicting types for 'f54'}}
+
+//---------------------------------------------------------------------------//
+// Redeclarations of functions that have bounds declarations for returns     // 
+// must have matching declarations.                                          //
+//---------------------------------------------------------------------------//
+array_ptr<int> f60(int len) : count(len);
+array_ptr<int> f60(int len) : count(len);
+array_ptr<int> f60(int len) : count(len + 1); // expected-error {{conflicting types for 'f60'}}
+
+array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);
+array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);
+array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len - 1); // expected-error {{conflicting types for 'f61'}}
+
+//---------------------------------------------------------------------------//
+// The bounds declarations must be syntactically identical for now.          //
+//---------------------------------------------------------------------------//
+
+void f70(int *p : count(len), int len);
+void f70(int *p : count((len)), int len); // expected-error {{conflicting types for 'f70'}}
+
+void f71(int *p : count(len), int len);
+void f71(int *p : bounds(p, p + len), int len);  // expected-error {{conflicting types for 'f71'}}
+
+

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -1,5 +1,5 @@
-// Feature tests of typechecking redeclarations of functions
-// and variables
+// Feature tests of typechecking bounds-safe
+// interfaces for the C standard library.
 //
 // The following lines are for the LLVM test harness:
 //

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -1,0 +1,17 @@
+// Feature tests of typechecking redeclarations of functions
+// and variables
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang -fcheckedc-extension -fsyntax-only %s
+
+#include "../../include/fenv_checked.h"
+#include "../../include/inttypes_checked.h"
+#include "../../include/math_checked.h"
+#include "../../include/signal_checked.h"
+#include "../../include/stdio_checked.h"
+#include "../../include/stdlib_checked.h"
+#include "../../include/string_checked.h"
+#define _CHECKEDC_MOCKUP_THREADS 1
+#include "../../include/threads_checked.h"
+#include "../../include/time_checked.h"


### PR DESCRIPTION
This change adds tests of redeclarations of functions with bounds declarations.  This  matches a corresponding change for the Checked C clang implementation.  The tests check that functions can be redeclared with identical bounds declarations on parameters and returns.  They also check that error messages are produced when the bounds declarations are not identical. This change also checks redeclarations of functions with bounds-safe interfaces. For now, the bounds declaration must be syntactically identical modulo parameter names.  Later this will be changed to require that the bounds declaration be provably semantically identical.

To further test redeclarations of functions, this change also adds header files that redeclare functions in the C standard library with bounds-safe interfaces, when the functions can have a bounds-safe interfaces.   This exercise shows three things, two of which were known and one that is new:
- There needs to be type system support for null-terminated arrays.
- That there is not a way to specify a bounds-safe interface to variable argument functions.
- That bounds declaration may need refer to parameters in an enclosing parameter list (bsearch and qsort demonstrate the need for this).   The Checked C clang implementation does not account for this.

This change also improves the testing of typechecking of bounds on parameters and return types, including bounds and returns of function types.