### PR TITLE
Add tests for redeclarations of variables with bounds.

### DIFF
--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -25,7 +25,7 @@ static array_ptr<float> l : count(5) = vals;
 static _Thread_local array_ptr<int> m : count(5);
 
 array_ptr<int> b : count(3 + 2) = 0;
-array_ptr<int> d : byte_count(5 * sizeof(int)) = 0;
+array_ptr<int> d : byte_count(20) = 0;
 array_ptr<int> g : bounds(none) = 0;
 
 // Declare a bounds for a checked array.  This is legal, but

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -225,4 +225,242 @@ void f93(array_ptr<int>(*fnptr)(void) : count(5));
 void f93(array_ptr<int>(*f)(void) : count(5));
 void f93(array_ptr<int>(*f)(void) : count(6));          // expected-error {{conflicting bounds for 'f93'}}
 
+//---------------------------------------------------------------------------//
+// Declarations of variables with unchecked pointer or array types are       //
+// compatible with declarations that add bounds-safe interfaces.             //
+//---------------------------------------------------------------------------//
 
+// Unchecked pointer types
+int *g1;
+int *g1 : count(5);
+
+int *g2;
+int *g2 : bounds(g2, g2 + 5);
+
+int *g3;
+int *g3 :  byte_count(5 * sizeof(int));
+
+int *g4;
+int *g4 : itype(ptr<int>);
+
+// Order doesn't matter for declarations
+int *g5 : count(5);
+int *g5;
+
+int *g6 : bounds(g6, g6 + 5);
+int *g6;
+
+int *g7: byte_count(5 * sizeof(int));
+int *g7;
+
+int *g8 : itype(ptr<int>);
+int *g8;
+
+// Umchecked array types
+extern int g10[];
+extern int g10[] : count(5);
+
+int g11[5];
+int g11[5] : bounds(g11, g11 + 5);
+
+extern int g12[];
+extern int g12[] :  byte_count(5 * sizeof(int));
+
+int g13[10];
+int g13[10] : itype(int checked[10]);
+
+// Order doesn't matter for declarations
+int g14[10] : count(5);
+int g14[10];
+
+int g15[5] : bounds(g15, g15 + 5);
+int g15[5];
+
+int g16[5]: byte_count(5 * sizeof(int));
+int g16[];
+
+int g17[5] : itype(int checked[5]);
+int g17[5];
+
+//---------------------------------------------------------------------------//
+// Redeclarations of  variables that have bounds-safe interfaces must have   //
+// matching interfaces.                                                      //
+//---------------------------------------------------------------------------//
+
+// Unchecked pointers
+int  len;
+int *g30 : count(len);
+int *g30 : count(len);
+int *g30 : count(len + 1);  // expected-error {{conflicting bounds}}
+
+int *g31 : count(len);
+// A redeclaration without bounds-safe interface is compatible with the
+// original declaration, but the variable retains its original bounds-safe
+// interface.
+int *g31;
+int *g31 : count(len + 1); // expected-error {{conflicting bounds}}
+
+int *g32 : bounds(g32, g32 + len);
+int *g32 : bounds(g32, g32 + len);
+int *g32 : bounds(g32, g32 + len + 1);   // expected-error {{conflicting bounds}}
+
+int *g33 : bounds(g33, g33 + len);
+int *g33;
+// A redeclaration without a bounds-safe interface is compatible with the
+// original declaration, but the function retains its original bounds-safe
+// interface
+int *g33 : bounds(g33, g33 + len + 1);  // expected-error {{conflicting bounds}}
+
+int *g34 : itype(ptr<int>);
+int *g34 : count(1);      // expected-error {{conflicting bounds}}
+
+// Unchecked arrays
+extern int g35[] : count(len);
+extern int g35[] : count(len);
+extern int g35[] : count(len + 1);  // expected-error {{conflicting bounds}}
+
+extern int g36[] : count(len);
+// A redeclaration without bounds-safe interface is compatible with the
+// original declaration, but the variable retains its original bounds-safe
+// interface.
+extern int g36[];
+extern int g36[] : count(len + 1); // expected-error {{conflicting bounds}}
+
+extern int g37[] : bounds(g37, g37 + len);
+extern int g37[] : bounds(g37, g37 + len);
+extern int g37[] : bounds(g37, g37 + len + 1);   // expected-error {{conflicting bounds}}
+
+int g38[5] : bounds(g38, g38 + 5);
+int g38[];
+// A redeclaration without a bounds-safe interface is compatible with the
+// original declaration, but the function retains its original bounds-safe
+// interface
+int g38[] : bounds(g38, g38 + 6);  // expected-error {{conflicting bounds}}
+
+int g39[5] : itype(int checked[5]);
+int g39[5] : count(5);             // expected-error {{conflicting bounds}}
+
+//---------------------------------------------------------------------------//
+// Redeclarations of variables that have bounds declarations must have       //
+// matching declarations.                                                    //
+//---------------------------------------------------------------------------//
+
+// Checked pointer
+array_ptr<int> g40 : count(len);
+array_ptr<int> g40 : count(len);
+array_ptr<int> g40 : count(len + 1);   // expected-error {{conflicting bounds}}
+
+array_ptr<int> g41 : bounds(g41, g41 + 5);
+array_ptr<int> g41 : bounds(g41, g41 + 5);
+array_ptr<int> g41 : bounds(g41, g41 + 6); // expected-error {{conflicting bounds}}
+
+// Add a bounds declaration.
+array_ptr<int> g42;
+array_ptr<int> g42 : count(5);  // expected-error {{variable redeclaration added bounds}}
+
+// Drop a bounds declaration.
+array_ptr<int> g43 : count(len);
+array_ptr<int> g43;             // expected-error {{variable redeclaration dropped bounds}}
+
+// Checked arrays with bounds.
+// This is useful for incomplete array types.
+extern float g50 checked[] : count(5);
+float g50 checked[5] : count(5);
+
+float g51 checked[10] : count(len);
+float g51 checked[10] : count(len);
+float g51 checked[10] : count(len + 1);   // expected-error {{conflicting bounds}}
+
+extern float g52 checked[] : bounds(g52, g52 + 5);
+extern float g52 checked[] : bounds(g52, g52 + 5);
+extern float g52 checked[] : bounds(g52, g52 + 6); // expected-error {{conflicting bounds}}
+
+
+// Add a bounds declaration.
+extern float g53 checked[];
+extern float g53 checked[] : count(5);  // expected-error {{variable redeclaration added bounds}}
+
+// Drop a bounds declaration.
+extern float g54 checked[] : count(len);
+extern float g54 checked[];   // expected-error {{variable redeclaration dropped bounds}}
+
+//---------------------------------------------------------------------------//
+// Variables that hide global variables can be declared and have             //
+// different bounds than the hidden variables.                               //
+//---------------------------------------------------------------------------//
+
+array_ptr<int> g100 : count(5);
+array_ptr<int> g101 : bounds(g2, g2 + 3);
+array_ptr<char> g102 : byte_count(len);
+int g103;
+
+// Locals
+void f100(void) {
+  int g100 = 0;
+  array_ptr<float> g101 : byte_count(sizeof(float)*5) = 0;
+  array_ptr<int> g102 = 0;
+}
+
+// Parameters
+void f102(array_ptr<int> g100, array_ptr<int> g101 : count(5)) {
+}
+
+array_ptr<int> f103(array_ptr<int> g103 : count(5)) : bounds(g103, g103 + 2) {
+  return 0;
+}
+
+
+//---------------------------------------------------------------------------//
+// Variables that hide local variables can be declared in nested scopes      //
+// and have different bounds.                                                //
+//---------------------------------------------------------------------------//
+
+void f104(int len) {
+  array_ptr<int> g102 = 0;
+  {
+    int g102;
+    {
+      array_ptr<int> g102 : count(len) = 0;
+      {
+         int len = 5;
+         array_ptr<int> g102  : byte_count(len * sizeof(int));
+      }
+    }
+  }
+}
+
+//---------------------------------------------------------------------------//
+// Local extern declarations with different bounds than external (top-level) //
+// extern declarations are not allowed.                                      //
+//---------------------------------------------------------------------------//
+
+// External-scoped extern declarations followed by locally-scoped extern
+// declarations
+extern int buf1_count;
+extern array_ptr<int> buf1 : count(buf1_count);
+
+void f105(void) {
+  extern int buf1_count;
+  extern array_ptr<int> buf1;  // expected-error {{dropped bounds}}
+}
+
+// Local-scoped extern declarations followed by externally-scoped extern
+// declarations
+void f106(void) {
+  extern int buf2_count;
+  extern array_ptr<int> buf2;
+}
+
+extern int buf2_count;
+extern array_ptr<int> buf2 : count(buf2_count);  // expected-error {{added bounds}}
+
+// Sibling locally-scoped extern declarations.
+void f107(void) {
+  extern int buf3_count;
+  extern array_ptr<int> buf3;
+}
+
+void f108(void) {
+  extern int buf3_count;
+  extern array_ptr<int> buf3 : count(buf3_count); // expected-error {{added bounds}}
+}

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -283,7 +283,7 @@ int g17[5] : itype(int checked[5]);
 int g17[5];
 
 //---------------------------------------------------------------------------//
-// Redeclarations of  variables that have bounds-safe interfaces must have   //
+// Redeclarations of variables that have bounds-safe interfaces must have    //
 // matching interfaces.                                                      //
 //---------------------------------------------------------------------------//
 
@@ -294,7 +294,7 @@ int *g30 : count(len);
 int *g30 : count(len + 1);  // expected-error {{conflicting bounds}}
 
 int *g31 : count(len);
-// A redeclaration without bounds-safe interface is compatible with the
+// A redeclaration without a bounds-safe interface is compatible with the
 // original declaration, but the variable retains its original bounds-safe
 // interface.
 int *g31;
@@ -320,7 +320,7 @@ extern int g35[] : count(len);
 extern int g35[] : count(len + 1);  // expected-error {{conflicting bounds}}
 
 extern int g36[] : count(len);
-// A redeclaration without bounds-safe interface is compatible with the
+// A redeclaration without a bounds-safe interface is compatible with the
 // original declaration, but the variable retains its original bounds-safe
 // interface.
 extern int g36[];


### PR DESCRIPTION
This adds tests for:
- variables with unchecked pointer type or unchecked array type and bounds-safe interfaces.
- variables with checked pointer type or checked array and bounds declarations.
- locally-scoped variables that hide global variables.
- locally-scoped extern variable declaration.

For now, we require that bounds expressions be identically syntactically when they need to match.  This will be generalized later.