### PR TITLE
Fixing missing header file include for test.

### DIFF
--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -9,6 +9,7 @@
 // null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
+#include <stddef.h> // wchar_t wcstoimax and wcstoumax
 #include <inttypes.h>
 
 intmax_t strtoimax(const char * restrict nptr,

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -9,7 +9,7 @@
 // null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
-#include <stddef.h> // wchar_t wcstoimax and wcstoumax
+#include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
 #include <inttypes.h>
 
 intmax_t strtoimax(const char * restrict nptr,


### PR DESCRIPTION
This addresses issue #93.   In the tests of bounds-safe interfaces for `wcstoimax` and `wcstoumax`, we are only including `<inttypes.h>`. We are not including `<stddef.h>`. This results in a test failure on a Linux x64 Ubuntu box because `wchar_t` is missing.  The fix is to add the missing include.

Testing:
- Test now passes on Linux Ubuntu x64.
- Test continues to pass on Windows x86.
