### PR TITLE
Fixes non-portable casts in tests

### DIFF
--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -437,19 +437,7 @@ unsigned int g16[5] : bounds(g16, g16 + 5);
 
 int s1 checked[16];
 
-// byte_count
-// Cannot initialize this at compile time.
-// short int g20 : byte_count(5 * sizeof(int)) = (short int) s1;
-int g21 : byte_count(5 * sizeof(int)) = (int)s1;
-long int g22 : byte_count(5 * sizeof(int)) = (long int)s1;
-unsigned long int g23 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
-enum E1 g24 : byte_count(8) = EnumVal1;
 
-// bounds
-int g25 : bounds(s1, s1 + 5) = (int)s1;
-long int g26 : bounds(s1, s1 + 5) = (int)s1;
-unsigned long int g27 : bounds(s1, s1 + 5) = (int)s1;
-enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
 
 //
 // Test invalid bounds declarations for global variables

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -41,12 +41,6 @@ struct S8 {
   int m1 checked[];
 };
 
-struct S9 {
-  int len;
-  // bound declaration on an integer-typed member.
-  int p : bounds((char *) p, (char *) p + len);
-};
-
 union U1 {
   ptr<int> m1;
   int *m2;
@@ -97,7 +91,6 @@ extern struct S5 f7();     // expected-error {{function with no prototype cannot
 extern struct S6 f8();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
 extern struct S7 f9();     // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
 extern struct S8 f10();    // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
-extern struct S9 f11();    // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
 extern union U1 f12();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
 extern union U2 f13();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
 extern union U3 f14();     // expected-error {{function with no prototype cannot have a return type that is a union with a member with a checked type}}
@@ -181,9 +174,6 @@ extern void f68(struct S7); // expected-error {{cannot redeclare a function with
 extern void f69();
 extern void f69(struct S8); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
 
-extern void f70();
-extern void f70(struct S9); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
-
 extern void f71();
 extern void f71(union U1); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a union with a member with a checked type}}
 
@@ -228,9 +218,6 @@ extern void f84(int f());   // expected-error {{conflicting types for 'f84'}}
 extern void f85();
 extern void f85(char *p : bounds(p, p + len), int len);
 
-extern void f86();
-extern void f86(int p : bounds((char *)p, (char *)p + len), int len);
-
 //
 // Redeclaring a function with a checked argument as a no prototype function is not allowed.
 //
@@ -242,9 +229,6 @@ extern void f90(); // expected-error {{cannot redeclare a function that has a ch
 // functino is allowed.  The function types are considered compatible.
 extern void f91(char *p : bounds(p, p + len), int len);
 extern void f91();
-
-extern void f92(int p : bounds((char *)p, (char *)p + len), int len);
-extern void f92();
 
 //
 // Spot-check other attempts at creating no prototype functions that return

--- a/tests/typechecking/pointer-sized-long-long/lit.local.cfg
+++ b/tests/typechecking/pointer-sized-long-long/lit.local.cfg
@@ -1,7 +1,6 @@
 import re
 
-# Stolen from somewhere checking for LLP64 vs LP64.
-# Only on LLP64 is a pointer the size of `long long`
+# On 64-bit windows a pointer is the same size as long long
 if re.match(r'^x86_64.*-(win32|mingw32|windows-gnu)$', config.target_triple):
     config.available_features.add('pointer-sized-long-long')
 

--- a/tests/typechecking/pointer-sized-long-long/lit.local.cfg
+++ b/tests/typechecking/pointer-sized-long-long/lit.local.cfg
@@ -1,0 +1,9 @@
+import re
+
+# Stolen from somewhere checking for LLP64 vs LP64.
+# Only on LLP64 is a pointer the size of `long long`
+if re.match(r'^x86_64.*-(win32|mingw32|windows-gnu)$', config.target_triple):
+    config.available_features.add('pointer-sized-long-long')
+
+if not 'pointer-sized-long-long' in config.available_features:
+    config.unsupported = True

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -1,0 +1,60 @@
+// Check Pointer Casts on platforms where pointers and `long long`s are the same size
+
+// RUN: %clang_cc1 -std=c11 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+
+#include "../../../include/stdchecked.h"
+
+_Static_assert(sizeof(void*) == sizeof(long long),
+  "Pointers and longs must be the same size");
+
+struct S1 {
+  int len;
+  // bound declaration on a long-typed member.
+  long long p : bounds((char *)p, (char *)p + len);
+};
+
+extern struct S1 f1();    // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+
+extern void f2();
+extern void f2(struct S1); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
+
+extern void f3();
+extern void f3(long long p : bounds((char *)p, (char *)p + len), int len);
+
+extern void f4(long long p : bounds((char *)p, (char *)p + len), int len);
+extern void f4();
+
+//
+// Spot-check other attempts at creating no prototype functions that return
+// a checked value.
+//
+
+// I don't understand the cast here either.
+struct S20 {
+  ptr<int>(*f)(); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
+};
+
+enum E1 {
+  EnumVal1,
+  EnumVal2
+};
+
+//
+// Valid bounds declarations for integer-typed global variables.
+//
+
+int s1 checked[16];
+
+// byte_count
+long long g21 : byte_count(5 * sizeof(int)) = (long long)s1;
+long long int g22 : byte_count(5 * sizeof(int)) = (long long int)s1;
+unsigned long long int g23 : byte_count(5 * sizeof(int)) = (unsigned long long int) s1;
+// TODO: is this right? Enums are always sizeof(int)
+enum E1 g24 : byte_count(4) = EnumVal1;
+
+// bounds
+long long g25 : bounds(s1, s1 + 5) = (long long)s1;
+long long int g26 : bounds(s1, s1 + 5) = (long long)s1;
+unsigned long long int g27 : bounds(s1, s1 + 5) = (long long)s1;
+// not valid where sizeof(int) != sizeof(void*), because enums are always int-sized
+// enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -1,4 +1,8 @@
 // Check Pointer Casts on platforms where pointers and `long long`s are the same size
+// In particular, this includes 64-bit windows.
+
+// To configure the list of platforms, change lit.local.cfg in this directory
+// to make the 'pointer-sized-long-long' feature available
 
 // RUN: %clang_cc1 -std=c11 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -5,7 +5,7 @@
 #include "../../../include/stdchecked.h"
 
 _Static_assert(sizeof(void*) == sizeof(long long),
-  "Pointers and longs must be the same size");
+  "Pointers and long longs must be the same size");
 
 struct S1 {
   int len;

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -49,12 +49,12 @@ int s1 checked[16];
 long long g21 : byte_count(5 * sizeof(int)) = (long long)s1;
 long long int g22 : byte_count(5 * sizeof(int)) = (long long int)s1;
 unsigned long long int g23 : byte_count(5 * sizeof(int)) = (unsigned long long int) s1;
-// TODO: is this right? Enums are always sizeof(int)
-enum E1 g24 : byte_count(4) = EnumVal1;
+// TODO: Enum size is implementation-defined
+// enum E1 g24 : byte_count(8) = EnumVal1;
 
 // bounds
 long long g25 : bounds(s1, s1 + 5) = (long long)s1;
 long long int g26 : bounds(s1, s1 + 5) = (long long)s1;
 unsigned long long int g27 : bounds(s1, s1 + 5) = (long long)s1;
-// not valid where sizeof(int) != sizeof(void*), because enums are always int-sized
+// TODO: Enum size is implementation-defined
 // enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;

--- a/tests/typechecking/pointer-sized-long/lit.local.cfg
+++ b/tests/typechecking/pointer-sized-long/lit.local.cfg
@@ -1,9 +1,7 @@
 import re
 
-print config.target_triple
 
-# Stolen from somewhere checking for LLP64 vs LP64.
-# Only on LLP64 is a pointer not the size of `long`
+# On 64-bit windows a pointer is not the same size as long
 if not re.match(r'^x86_64.*-(win32|mingw32|windows-gnu)$', config.target_triple):
     config.available_features.add('pointer-sized-long')
 

--- a/tests/typechecking/pointer-sized-long/lit.local.cfg
+++ b/tests/typechecking/pointer-sized-long/lit.local.cfg
@@ -1,0 +1,11 @@
+import re
+
+print config.target_triple
+
+# Stolen from somewhere checking for LLP64 vs LP64.
+# Only on LLP64 is a pointer not the size of `long`
+if not re.match(r'^x86_64.*-(win32|mingw32|windows-gnu)$', config.target_triple):
+    config.available_features.add('pointer-sized-long')
+
+if not 'pointer-sized-long' in config.available_features:
+    config.unsupported = True

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -46,11 +46,12 @@ int s1 checked[16];
 int g21 : byte_count(5 * sizeof(int)) = (int)s1;
 long int g22 : byte_count(5 * sizeof(int)) = (long int)s1;
 unsigned long int g23 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
-// TODO: is this right? Enums are always sizeof(int)
-enum E1 g24 : byte_count(8) = EnumVal1;
+// TODO: Enum size is implementation-defined
+// enum E1 g24 : byte_count(8) = EnumVal1;
 
 // bounds
 int g25 : bounds(s1, s1 + 5) = (int)s1;
 long int g26 : bounds(s1, s1 + 5) = (int)s1;
 unsigned long int g27 : bounds(s1, s1 + 5) = (int)s1;
-enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
+// TODO: Enum size is implementation-defined
+// enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -1,0 +1,56 @@
+// Check Pointer Casts on platforms where pointers and `long`s are the same size
+// This pretty much only excludes LLP64
+
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+
+#include "../../../include/stdchecked.h"
+
+_Static_assert(sizeof(void*) == sizeof(long),
+  "Pointers and longs must be the same size");
+
+struct S1 {
+  int len;
+  // bound declaration on a long-typed member.
+  long p : bounds((char *)p, (char *)p + len);
+};
+
+extern struct S1 f1();    // expected-error {{function with no prototype cannot have a return type that is a structure with a member with a checked type}}
+
+extern void f2();
+extern void f2(struct S1); // expected-error {{cannot redeclare a function with no prototype to have an argument type that is a structure with a member with a checked type}}
+
+extern void f3();
+extern void f3(long p : bounds((char *)p, (char *)p + len), int len);
+
+extern void f4(long p : bounds((char *)p, (char *)p + len), int len);
+extern void f4();
+
+//
+// Valid bounds declarations for integer-typed global variables.
+//
+
+enum E1 {
+  EnumVal1,
+  EnumVal2
+};
+
+//
+// Valid bounds declarations for integer-typed global variables.
+//
+
+int s1 checked[16];
+
+// byte_count
+// Cannot initialize this at compile time.
+// short int g20 : byte_count(5 * sizeof(int)) = (short int) s1;
+int g21 : byte_count(5 * sizeof(int)) = (int)s1;
+long int g22 : byte_count(5 * sizeof(int)) = (long int)s1;
+unsigned long int g23 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
+// TODO: is this right? Enums are always sizeof(int)
+enum E1 g24 : byte_count(8) = EnumVal1;
+
+// bounds
+int g25 : bounds(s1, s1 + 5) = (int)s1;
+long int g26 : bounds(s1, s1 + 5) = (int)s1;
+unsigned long int g27 : bounds(s1, s1 + 5) = (int)s1;
+enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -1,5 +1,8 @@
 // Check Pointer Casts on platforms where pointers and `long`s are the same size
-// This pretty much only excludes LLP64
+// This pretty much only excludes 64-bit windows
+
+// To configure the list of platforms, change lit.local.cfg in this directory
+// to make the 'pointer-sized-long' feature available
 
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 


### PR DESCRIPTION
The C Standard is purposefully vague on the subject of the size of pointers, and their comparison to the size of various integral types.

Here, we split the tests that contain integer <-> pointer casts into two groups. In the first group (the vast majority of platforms), `void*` is the same size as `long`, so we do all our casts to `long`s. In the second group (notably including Win64), `void*` is not the same size as `long`, but it is the same size as `long long`, so we do all our casts to that.

The only place this approach doesn't work is with Enums, which have an implementation-defined size (according to my reading of the spec), so I've commented out the pointer->enum casts. 

Fixes #92 
