### PR TITLE
Update tests to ensure automatic variables are initialized.

### DIFF
--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -71,7 +71,7 @@ extern void f3(array_ptr<int> arr : count(5)) {
   array_ptr<int> t : byte_count(5 * (sizeof(int))) = arr;
   array_ptr<int> u : byte_count((len) * sizeof(int)) = arr;
   array_ptr<int> v : bounds(v, (v + 5) + len - len) = arr;
-  array_ptr<int> w: bounds((w + len - (len)), (w + len));
+  array_ptr<int> w: bounds((w + len - (len)), (w + len)) = arr;
   array_ptr<int> midarr : bounds(midarr - 1, (midarr - 1) + 2) = arr + 2;
 }
 

--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -135,18 +135,18 @@ struct S15 {
 // return values
 extern void S16(void) {
   // Checked pointer to a function that returns an array_ptr to 5 integers.
-  ptr<array_ptr<int>(void) : count(5)> p1;
+  ptr<array_ptr<int>(void) : count(5)> p1 = 0;
   // Checked pointer to a function that returns an array_ptr to n integers,
   // where n is n argument.
-  ptr<array_ptr<int>(int n) : count(n)> p2;
+  ptr<array_ptr<int>(int n) : count(n)> p2 = 0;
   // Use 'byte_count; instead of 'count'
-  ptr<array_ptr<int>(void) : byte_count(5 * sizeof(int))> q1;
-  ptr<int(int arg) : byte_count(5 * sizeof(int))> q2;
-  ptr<int(int n, int arg) : byte_count(n * sizeof(int))> q3;
+  ptr<array_ptr<int>(void) : byte_count(5 * sizeof(int))> q1 = 0;
+  ptr<int(int arg) : byte_count(5 * sizeof(int))> q2 = 0;
+  ptr<int(int n, int arg) : byte_count(n * sizeof(int))> q3 = 0;
   // Use 'bounds' instead of 'count'.
   ptr<array_ptr<int>(array_ptr<int> arg : count(5)) : bounds(arg, arg + 5)>
-    r1;
-  ptr<int(array_ptr<int> arg : count(n), int n) : bounds(arg, arg + n)> r2;
+    r1 = 0; 
+  ptr<int(array_ptr<int> arg : count(n), int n) : bounds(arg, arg + n)> r2 = 0;
   // Unchecked pointers to functions.
   int(*s1)(array_ptr<int> : count(5));
   int(*s2)(array_ptr<int> arg : count(5));

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -1,0 +1,26 @@
+// Feature tests of static checking of bounds declarations for variables with
+//  initializers. 
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+
+#include "../../include/stdchecked.h"
+
+// Check that declarations of automatic variables with Checked C bounds 
+// declarations or _Ptr types always have initializers.
+extern void f() {
+  array_ptr<int> v1;
+  array_ptr<int> v2 = 0;
+  array_ptr<int> v3 : bounds(none);
+  array_ptr<int> v4 : bounds(none) = 0;
+  array_ptr<int> v5 : count(5) = 0;
+  array_ptr<int> v6 : count(5);                       // expected-error {{automatic variable 'v6' with bounds must have initializer}}
+  array_ptr<int> v7 : byte_count(5 * sizeof(int)) = 0;
+  array_ptr<int> v8 : byte_count(5 * sizeof(int));    // expected-error {{automatic variable 'v8' with bounds must have initializer}}
+  array_ptr<int> v9 : bounds(v9, v9 + 5) = 0;
+  array_ptr<int> v10 : bounds(v10, v10 + 5);          // expected-error {{automatic variable 'v10' with bounds must have initializer}}
+
+  ptr<int> v20 = 0;
+  ptr<int> v21;         // expected-error {{automatic variable 'v21' with _Ptr type must have initializer}}
+}

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -174,12 +174,12 @@ extern void bounds_exprs(void) {
    array_ptr<int> t1 : bounds(array_ptr_lb, array_ptr_ub) = i;
    array_ptr<int> t2 : bounds(ptr_lb, array_ptr_ub) = i;
    array_ptr<int> t3 : bounds(array_ptr_lb, ptr_ub) = i;
-   array_ptr<int> t4 : bounds(unchecked_ptr_lb, array_ptr_ub);
-   array_ptr<int> t5 : bounds(array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t4 : bounds(unchecked_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t5 : bounds(array_ptr_lb, unchecked_ptr_ub) = i;
    array_ptr<int> t6 : bounds(ptr_lb, ptr_ub) = i;
    array_ptr<int> t7 : bounds(unchecked_ptr_lb, ptr_ub) = i;
    array_ptr<int> t8 : bounds(ptr_lb, unchecked_ptr_ub) = i;
-   array_ptr<int> t9 : bounds(unchecked_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t9 : bounds(unchecked_ptr_lb, unchecked_ptr_ub) = i;
 
    // use an array-typed value as the lower bound.  This value
    // should be converted implicitly to be a pointer type.
@@ -196,12 +196,12 @@ extern void bounds_exprs(void) {
    array_ptr<int> t21 : bounds(void_array_ptr_lb, void_array_ptr_ub) = i;
    array_ptr<int> t22 : bounds(void_ptr_lb, void_array_ptr_ub) = i;
    array_ptr<int> t23 : bounds(void_array_ptr_lb, void_ptr_ub) = i;
-   array_ptr<int> t24 : bounds(void_unchecked_ptr_lb, void_array_ptr_ub);
-   array_ptr<int> t25 : bounds(void_array_ptr_lb, void_unchecked_ptr_ub);
+   array_ptr<int> t24 : bounds(void_unchecked_ptr_lb, void_array_ptr_ub) = i;
+   array_ptr<int> t25 : bounds(void_array_ptr_lb, void_unchecked_ptr_ub) = i;
    array_ptr<int> t26 : bounds(void_ptr_lb, void_ptr_ub) = i;
    array_ptr<int> t27 : bounds(void_unchecked_ptr_lb, void_ptr_ub) = i;
    array_ptr<int> t28 : bounds(void_ptr_lb, void_unchecked_ptr_ub) = i;
-   array_ptr<int> t29 : bounds(void_unchecked_ptr_lb, void_unchecked_ptr_ub);
+   array_ptr<int> t29 : bounds(void_unchecked_ptr_lb, void_unchecked_ptr_ub) = i;
 
    // check combinations of pointers to void and pointers to non-void types
 
@@ -210,10 +210,10 @@ extern void bounds_exprs(void) {
    array_ptr<int> t44 : bounds(void_ptr_lb, array_ptr_ub) = i;
    array_ptr<int> t45 : bounds(void_array_ptr_lb, ptr_ub) = i;
    array_ptr<int> t46 : bounds(array_ptr_lb, void_ptr_ub) = i;
-   array_ptr<int> t47 : bounds(unchecked_ptr_lb, void_array_ptr_ub);
-   array_ptr<int> t48 : bounds(void_unchecked_ptr_lb, array_ptr_ub);
-   array_ptr<int> t49 : bounds(void_array_ptr_lb, unchecked_ptr_ub);
-   array_ptr<int> t50 : bounds(array_ptr_lb, void_unchecked_ptr_ub);
+   array_ptr<int> t47 : bounds(unchecked_ptr_lb, void_array_ptr_ub) = i;
+   array_ptr<int> t48 : bounds(void_unchecked_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t49 : bounds(void_array_ptr_lb, unchecked_ptr_ub) = i;
+   array_ptr<int> t50 : bounds(array_ptr_lb, void_unchecked_ptr_ub) = i;
 
    array_ptr<int> t51 : bounds(void_ptr_lb, ptr_ub) = i;
    array_ptr<int> t52 : bounds(ptr_lb, void_ptr_ub) = i;
@@ -248,12 +248,12 @@ extern void bounds_exprs(void) {
    array_ptr<int> t91 : bounds(typedef_array_ptr_lb, array_ptr_ub) = i;
    array_ptr<int> t92 : bounds(ptr_lb, typedef_array_ptr_ub) = i;
    array_ptr<int> t93 : bounds(array_ptr_lb, typedef_ptr_ub) = i;
-   array_ptr<int> t94 : bounds(typedef_unchecked_ptr_lb, array_ptr_ub);
-   array_ptr<int> t95 : bounds(typedef_array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t94 : bounds(typedef_unchecked_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t95 : bounds(typedef_array_ptr_lb, unchecked_ptr_ub) = i;
    array_ptr<int> t96 : bounds(typedef_ptr_lb, ptr_ub) = i;
    array_ptr<int> t97 : bounds(unchecked_ptr_lb, typedef_ptr_ub) = i;
    array_ptr<int> t98 : bounds(ptr_lb, typedef_unchecked_ptr_ub) = i;
-   array_ptr<int> t99 : bounds(typedef_unchecked_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t99 : bounds(typedef_unchecked_ptr_lb, unchecked_ptr_ub) = i;
 
    // check that type qualifiers are discarded when comparing pointer types
    // in bounds expressions
@@ -296,12 +296,12 @@ extern void bounds_exprs(void) {
 
    array_ptr<int> t130 : bounds(ptr_lb, array_ptr_ub) = i;
    array_ptr<int> t131 : bounds(array_ptr_lb, ptr_ub) = i;
-   array_ptr<int> t132 : bounds(unchecked_ptr_lb, array_ptr_ub);
-   array_ptr<int> t133 : bounds(array_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t132 : bounds(unchecked_ptr_lb, array_ptr_ub) = i;
+   array_ptr<int> t133 : bounds(array_ptr_lb, unchecked_ptr_ub) = i;
    array_ptr<int> t134 : bounds(ptr_lb, ptr_ub) = i;
    array_ptr<int> t135 : bounds(unchecked_ptr_lb, ptr_ub) = i;
    array_ptr<int> t136 : bounds(ptr_lb, unchecked_ptr_ub) = i;
-   array_ptr<int> t137 : bounds(unchecked_ptr_lb, unchecked_ptr_ub);
+   array_ptr<int> t137 : bounds(unchecked_ptr_lb, unchecked_ptr_ub) = i;
  }
 
  extern void invalid_bounds_exprs(void) {

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -423,7 +423,7 @@ void f104(int len) {
       array_ptr<int> g102 : count(len) = 0;
       {
          int len = 5;
-         array_ptr<int> g102  : byte_count(len * sizeof(int));
+         array_ptr<int> g102  : byte_count(len * sizeof(int)) = 0;
       }
     }
   }


### PR DESCRIPTION
This change matches a corresponding change in the Checked C clang repo (https://github.com/Microsoft/checkedc-clang/pull/110). The compiler will be checking that automatic variables with _Ptr types or bounds declarations are always initialized using an initializer.

This adds missing initializers to existing tests.  It also adds tests that the compiler produces errors for uninitialized automatic variables.

Note that static variables are always initialized to 0, if they do not have an initializer.  This means that we do not have to check that they are initialized.  0 is valid for any bounds declaration, so it works well as
a default initialization value.