### PR TITLE
Adds Verification of Explicit Dynamic Check Warnings

### DIFF
--- a/tests/dynamic_checking/failing-arith-dynamic_check.c
+++ b/tests/dynamic_checking/failing-arith-dynamic_check.c
@@ -2,9 +2,12 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -o %t.exe %s
+// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
 // LLVM thinks that exiting via llvm.trap() is a crash.
 // RUN: not --crash %t.exe
+
+// The dynamic_check in f1 cannot be statically checked by clang yet
+// expected-no-diagnostics
 
 #include "../../include/stdchecked.h"
 

--- a/tests/dynamic_checking/failing-simple-dynamic_check.c
+++ b/tests/dynamic_checking/failing-simple-dynamic_check.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -o %t.exe %s
+// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
 // LLVM thinks that exiting via llvm.trap() is a crash.
 // RUN: not --crash %t.exe
 
@@ -10,8 +10,8 @@
 #include "../../include/stdchecked.h"
 
 int main(void) {
-  // This is expected fail at runtime
-  dynamic_check(false);
+  // This is expected fail at runtime. It is simple enough for clang to issue a warning
+  dynamic_check(false); // expected-warning {{dynamic check will always fail}}
 
   return 0;
 }

--- a/tests/dynamic_checking/passing-arith-dynamic_check.c
+++ b/tests/dynamic_checking/passing-arith-dynamic_check.c
@@ -2,8 +2,10 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -o %t.exe %s
+// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
 // RUN: %t.exe
+
+// expected-no-diagnostics
 
 #include "../../include/stdchecked.h"
 

--- a/tests/dynamic_checking/passing-simple-dynamic_check.c
+++ b/tests/dynamic_checking/passing-simple-dynamic_check.c
@@ -2,8 +2,10 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -o %t.exe %s
+// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
 // RUN: %t.exe
+
+// expected-no-diagnostics
 
 #include <stdbool.h>
 #include "../../include/stdchecked.h"


### PR DESCRIPTION
This updates some of the tests for Microsoft/checkedc-clang#128 to make sure we get some warnings on super-simple dynamic checks that will fail. 

We probably want to be careful to only use the `-verify` flag in a few tests, so the tests are not too coupled to clang's constant folder/default optimization level/the accuracy of our implemented static analysis. I think it's fine in these tests, but probably no others. 