### PR TITLE
Fixes Tests that rely on int->ptr conversions

### DIFF
--- a/tests/static_checking/nme_bounds.c
+++ b/tests/static_checking/nme_bounds.c
@@ -216,6 +216,8 @@ void f2(int i, int* loc) {
 
   array_ptr<int> as19a : count(i == j) = 0;
   array_ptr<int> as19b : byte_count(i == j) = 0;
+  array_ptr<int> as19c : bounds(loc + (loc == loc2), loc) = 0;
+  array_ptr<int> as19d : bounds(loc, loc + (loc == loc2)) = 0;
 
   array_ptr<int> as20a : count(i & j) = 0;
   array_ptr<int> as20b : byte_count(i & j) = 0;

--- a/tests/static_checking/nme_bounds.c
+++ b/tests/static_checking/nme_bounds.c
@@ -216,8 +216,6 @@ void f2(int i, int* loc) {
 
   array_ptr<int> as19a : count(i == j) = 0;
   array_ptr<int> as19b : byte_count(i == j) = 0;
-  array_ptr<int> as19c : bounds((int*)(loc == loc2), loc) = 0;
-  array_ptr<int> as19d : bounds(loc, (int*)(loc == loc2)) = 0;
 
   array_ptr<int> as20a : count(i & j) = 0;
   array_ptr<int> as20b : byte_count(i & j) = 0;

--- a/tests/typechecking/function_casts.c
+++ b/tests/typechecking/function_casts.c
@@ -193,9 +193,6 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   ptr<int(int)> local_weird_unsafe1 = (ptr<int(int)>)~(intptr_t)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe2 = (ptr<int(int)>)~(intptr_t)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe3 = (ptr<int(int)>)~(intptr_t)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)!(intptr_t)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)!(intptr_t)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)!(intptr_t)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe7 = (ptr<int(int)>)+(intptr_t)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe8 = (ptr<int(int)>)+(intptr_t)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe9 = (ptr<int(int)>)+(intptr_t)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}

--- a/tests/typechecking/function_casts.c
+++ b/tests/typechecking/function_casts.c
@@ -4,7 +4,6 @@
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 //
 
-#include <stdint.h>
 #include "../../include/stdchecked.h"
 
 int f0(int a) {
@@ -188,17 +187,7 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   // Weird Unary Operators
   //
 
-  // There's no good reason to do this to any function pointers
-  // and it's definitely not safe.
-  ptr<int(int)> local_weird_unsafe1 = (ptr<int(int)>)~(intptr_t)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe2 = (ptr<int(int)>)~(intptr_t)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe3 = (ptr<int(int)>)~(intptr_t)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe7 = (ptr<int(int)>)+(intptr_t)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe8 = (ptr<int(int)>)+(intptr_t)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe9 = (ptr<int(int)>)+(intptr_t)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe10 = (ptr<int(int)>)-(intptr_t)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe11 = (ptr<int(int)>)-(intptr_t)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe12 = (ptr<int(int)>)-(intptr_t)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  // There are more tests in the platform-specific tests
 
   int(**local_more_unsafe1)(int) = &local_unsafe;
   ptr<int(int)> local_more_unsafe2 = *local_more_unsafe1; // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}

--- a/tests/typechecking/pointer-sized-long-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/function_casts.c
@@ -1,0 +1,30 @@
+// These are some platform-specific tests to go with
+// the tests in ../function_casts.c
+//
+// The following line is for the LLVM test harness:
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+//
+
+#include "../../../include/stdchecked.h"
+
+int f0(int a) {
+  return a;
+}
+
+void local_convert(int(*f1)(int), ptr<int(int)> f2) {
+  // There's no good reason to do this to any function pointers
+  // and it's definitely not safe.
+  ptr<int(int)> local_weird_unsafe1 = (ptr<int(int)>)~(long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe2 = (ptr<int(int)>)~(long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe3 = (ptr<int(int)>)~(long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)!(long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)!(long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)!(long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe7 = (ptr<int(int)>) + (long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe8 = (ptr<int(int)>) + (long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe9 = (ptr<int(int)>) + (long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe10 = (ptr<int(int)>) - (long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe11 = (ptr<int(int)>) - (long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe12 = (ptr<int(int)>) - (long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+
+}

--- a/tests/typechecking/pointer-sized-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long/function_casts.c
@@ -1,0 +1,30 @@
+// These are some platform-specific tests to go with
+// the tests in ../function_casts.c
+//
+// The following line is for the LLVM test harness:
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+//
+
+#include "../../../include/stdchecked.h"
+
+int f0(int a) {
+  return a;
+}
+
+void local_convert(int(*f1)(int), ptr<int(int)> f2) {
+  // There's no good reason to do this to any function pointers
+  // and it's definitely not safe.
+  ptr<int(int)> local_weird_unsafe1 = (ptr<int(int)>)~(long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe2 = (ptr<int(int)>)~(long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe3 = (ptr<int(int)>)~(long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)!(long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)!(long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)!(long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe7 = (ptr<int(int)>) + (long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe8 = (ptr<int(int)>) + (long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe9 = (ptr<int(int)>) + (long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe10 = (ptr<int(int)>) - (long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe11 = (ptr<int(int)>) - (long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe12 = (ptr<int(int)>) - (long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+
+}


### PR DESCRIPTION
These tests all fail on x86_64.

I think I'm happy enough with coverage that we can get rid of them, but I'll defer to david.