### PR TITLE
Add missing bounds declarations.

### DIFF
--- a/tests/parsing/pointer_types.c
+++ b/tests/parsing/pointer_types.c
@@ -39,11 +39,11 @@ extern void f5(ptr<ptr<ptr<int>>> p, int y) {
    ***p = y;
 }
 
-extern void f6(array_ptr<int> p, int y) {
+extern void f6(array_ptr<int> p : count(1), int y) {
     *p = y;
 }
 
-extern void f7(array_ptr<int> p, int y) {
+extern void f7(array_ptr<int> p : count(1), int y) {
    *p = y;
    f6(p, y);
 }
@@ -73,7 +73,7 @@ extern void g5(int y, ptr<ptr<ptr<int>>> p) {
 }
 
 
-extern void g6(int y, array_ptr<int> p) {
+extern void g6(int y, array_ptr<int> p : count(1)) {
    *p = y;
    f7(p, y);
 }
@@ -92,7 +92,7 @@ extern const ptr<int> h2(int y, const ptr<int> p) {
    return p;
 }
 
-extern ptr<const int> h3(int y, array_ptr<ptr<const int>> p) {
+extern ptr<const int> h3(int y, array_ptr<ptr<const int>> p : count(1)) {
    y = **p;
    return *p;
 }
@@ -115,8 +115,8 @@ extern void k1(int y)
 {
    int v = y;
    ptr<int> t1 = &v;
-   array_ptr<int> t2 = &v;
-   array_ptr<ptr<int>> t3 = &t1;
+   array_ptr<int> t2 : count(1) = &v;
+   array_ptr<ptr<int>> t3  : count(1) = &t1;
    *t1 = 0;
    *t2 = 0;
    *t3 = 0;
@@ -127,7 +127,7 @@ extern void k1(int y)
 //
 
 struct Vector {
-    array_ptr<float> data;
+    array_ptr<float> data : count(len);
     int len;
 };
 

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -20,7 +20,9 @@ extern void check_indirection_checked(int p checked[10], const int const_p check
   y = *const_p;
 }
 
-extern void check_indirection_checked_incomplete(int p checked[], const int const_p checked[], int y) {
+extern void check_indirection_checked_incomplete(int p checked[] : count(len),
+                                                 const int const_p checked[] : count(len),
+                                                 int len, int y) {
   *p = y;
   y = *p;
   *const_p = y; // expected-error {{read-only variable is not assignable}}
@@ -45,7 +47,9 @@ extern void check_subscript_checked(int p checked[10], const int p_const[10], in
   y = 0[p_const];  // OK
 }
 
-extern void check_subscript_checked_incomplete(int p checked[], const int p_const[], int y) {
+extern void check_subscript_checked_incomplete(int p checked[] : count(len),
+                                               const int p_const[] : count(len),
+                                               int len, int y) {
   p[0] = y;  // OK
   y = p[0];  // OK
   0[p] = y;  // OK
@@ -121,7 +125,6 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   // is converted to a pointer type.
   p = q;
   q = p;
-  r = s;
   s = r;
   r = t;
   p = r;  // expected-error {{assigning to 'int *' from incompatible type '_Array_ptr<int>'}}
@@ -275,9 +278,9 @@ extern void check_assign_cv(int param[10],
   p = param;
   p_const = param;
   p_volatile = param;
-  q = param;
-  q_const = param;
-  q_volatile = param;
+  // q = param;          not allowed: param has unknown bounds
+  // q_const = param;    not allowed: param has unknown bounds
+  // q_volatile = param; not allowed: param has unknown bounds
   r = param;
   r_const = param;
   r_volatile = param;
@@ -297,9 +300,9 @@ extern void check_assign_cv(int param[10],
   p = const_param;              // expected-warning {{discards qualifiers}}
   p_const = const_param;
   p_volatile = const_param;     // expected-warning {{discards qualifiers}}  
-  q = const_param;              // expected-warning {{discards qualifiers}}
-  q_const = const_param;
-  q_volatile = const_param;     // expected-warning {{discards qualifiers}}
+  // q = const_param;           not allowed: param has unknown bounds
+  // q_const = const_param;     not allowed: param has unknown bounds
+  // q_volatile = const_param;  not allowed: param has unknown bounds
   r = const_param;              // expected-warning {{discards qualifiers}}
   r_const = const_param;
   r_volatile = const_param;     // expected-warning {{discards qualifiers}}

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -20,8 +20,9 @@ extern void check_indirection_ptr(ptr<int> p, ptr<const int> const_p, int y) {
 	y = *const_p;
 }
 
-// TODO: add bounds constraints when they are implemented.
-extern void check_indirection_array_ptr(array_ptr<int> p, array_ptr<const int> const_p, int y) {
+extern void check_indirection_array_ptr(array_ptr<int> p : count(1),
+                                        array_ptr<const int> const_p : count(1),
+                                        int y) {
 	*p = y;
 	y = *p;
 	*const_p = y; // expected-error {{read-only variable is not assignable}}
@@ -46,7 +47,9 @@ extern void check_subscript_ptr(ptr<int> p, ptr<const int> p_const, int y) {
    y = 0[p_const];  // expected-error {{subscript of '_Ptr<const int>'}}
 }
 
-extern void check_subscript_array_ptr(array_ptr<int> p, array_ptr<const int> p_const, int y) {
+extern void check_subscript_array_ptr(array_ptr<int> p : count(1),
+                                      array_ptr<const int> p_const : count(1),
+                                      int y) {
    p[0] = y;  // OK
    y = p[0];  // OK
    0[p] = y;  // OK
@@ -197,12 +200,12 @@ extern void check_assign(int val, int *p, ptr<int> q, array_ptr<int> r,
     unchecked_ptr_to_checked_ptr = checked_ptr_to_checked_ptr;     // expected-error {{incompatible type}}
 
     checked_ptr_to_checked_ptr = unchecked_ptr_to_unchecked_ptr; // expected-error {{incompatible type}}
-    checked_ptr_to_checked_ptr = unchecked_ptr_to_checked_ptr;   // OK
+    // checked_ptr_to_checked_ptr = unchecked_ptr_to_checked_ptr;    not allowed: right-hand side has unknown bounds.
     checked_ptr_to_checked_ptr = checked_ptr_to_unchecked_ptr;   // expected-error {{incompatible type}}
     checked_ptr_to_checked_ptr = checked_ptr_to_checked_ptr;     // OK
 
     array_ptr_to_checked_ptr = unchecked_ptr_to_unchecked_ptr; // expected-error {{incompatible type}}
-    array_ptr_to_checked_ptr = unchecked_ptr_to_checked_ptr;   // OK
+    // array_ptr_to_checked_ptr = unchecked_ptr_to_checked_ptr;  not allowed: right-hand side has unknown bounds.
     array_ptr_to_checked_ptr = checked_ptr_to_unchecked_ptr;   // expected-error {{incompatible type}}
     array_ptr_to_checked_ptr = checked_ptr_to_checked_ptr;     // expected-error {{incompatible type}}
 


### PR DESCRIPTION
The compiler now checks that assignments through array_ptrs and reads through array_ptrs use array_ptrs that have bounds.   These checks found some tests where bounds declarations are missing for array_ptr variables.  Add the missing bounds declarations.   

The compiler also found tests where an unchecked pointer with unknown bounds is incorrectly cast to a checked pointer Remove those tests.
