### PR TITLE
Fixes to function casts on 64-bit

### DIFF
--- a/tests/typechecking/pointer-sized-long-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/function_casts.c
@@ -17,9 +17,9 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   ptr<int(int)> local_weird_unsafe1 = (ptr<int(int)>)~(long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe2 = (ptr<int(int)>)~(long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe3 = (ptr<int(int)>)~(long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)!(long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)!(long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)!(long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)(long long)!(long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)(long long)!(long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)(long long)!(long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe7 = (ptr<int(int)>) + (long long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe8 = (ptr<int(int)>) + (long long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe9 = (ptr<int(int)>) + (long long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}

--- a/tests/typechecking/pointer-sized-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long/function_casts.c
@@ -17,9 +17,9 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   ptr<int(int)> local_weird_unsafe1 = (ptr<int(int)>)~(long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe2 = (ptr<int(int)>)~(long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe3 = (ptr<int(int)>)~(long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)!(long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)!(long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
-  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)!(long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe4 = (ptr<int(int)>)(long)!(long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe5 = (ptr<int(int)>)(long)!(long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
+  ptr<int(int)> local_weird_unsafe6 = (ptr<int(int)>)(long)!(long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe7 = (ptr<int(int)>) + (long)f1; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe8 = (ptr<int(int)>) + (long)f2; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
   ptr<int(int)> local_weird_unsafe9 = (ptr<int(int)>) + (long)f0; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -46,15 +46,15 @@ int s1 checked[16];
 // byte_count
 // Cannot initialize this at compile time.
 // short int g20 : byte_count(5 * sizeof(int)) = (short int) s1;
-int g21 : byte_count(5 * sizeof(int)) = (int)s1;
+long g21 : byte_count(5 * sizeof(int)) = (long)s1;
 long int g22 : byte_count(5 * sizeof(int)) = (long int)s1;
 unsigned long int g23 : byte_count(5 * sizeof(int)) = (unsigned long int) s1;
 // TODO: Enum size is implementation-defined
 // enum E1 g24 : byte_count(8) = EnumVal1;
 
 // bounds
-int g25 : bounds(s1, s1 + 5) = (int)s1;
-long int g26 : bounds(s1, s1 + 5) = (int)s1;
-unsigned long int g27 : bounds(s1, s1 + 5) = (int)s1;
+long g25 : bounds(s1, s1 + 5) = (long)s1;
+long int g26 : bounds(s1, s1 + 5) = (long)s1;
+unsigned long int g27 : bounds(s1, s1 + 5) = (long)s1;
 // TODO: Enum size is implementation-defined
 // enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;


### PR DESCRIPTION
These were fixes that I should have caught earlier. My fault entirely. 

This is to do with the fact that the "!" operator always returns an int, but on most platforms you can't just cast that directly to a pointer, so we cast it to the correct number size then cast it to a pointer.