### PR TITLE
Fixes issues with checked system headers on Mac with ifdefs

### DIFF
--- a/include/_builtin_stdio_checked.h
+++ b/include/_builtin_stdio_checked.h
@@ -1,0 +1,57 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for compiler-defined builtin functions       //
+// corresponding to stdio.h functions                                  //
+//                                                                     //
+// These are given in the order they appear in clang's Builtins.def.   //
+// Functions that do not appear can not have checked interfaces        //
+// defined.                                                            //
+//                                                                     //
+// These are based on the types as declared within clang               //
+// and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#ifndef __has_builtin
+#define _undef__has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin___snprintf_chk) || defined(__GNUC__)
+extern int __snprintf_chk (char * __restrict s : count(n),
+                           size_t n,
+                           int flag,
+                           size_t obj_size,
+			               const char * __restrict format,
+                           ...);
+
+int __builtin___snprintf_chk(char * restrict s : count(n),
+                             size_t n,
+                             int flag,
+                             size_t obj_size,
+                             const char * restrict format,
+                             ...);
+#endif
+
+
+#if __has_builtin(__builtin___vsnprintf_chk) || defined(__GNUC__)
+extern int __vsnprintf_chk (char * __restrict s : count(n),
+                            size_t n,
+                            int flag,
+                            size_t obj_size,
+			                const char * __restrict format,
+                            va_list);
+
+int __builtin___vsnprintf_chk(char * restrict s : count(n),
+                              size_t n,
+                              int flag,
+                              size_t obj_size,
+                              const char * restrict format,
+                              va_list arg);
+#endif
+
+#ifdef _undef__has_builtin
+#undef _undef__has_builtin
+#undef __has_builtin
+#endif

--- a/include/_builtin_stdio_checked.h
+++ b/include/_builtin_stdio_checked.h
@@ -19,12 +19,12 @@
 #endif
 
 #if __has_builtin(__builtin___snprintf_chk) || defined(__GNUC__)
-extern int __snprintf_chk (char * __restrict s : count(n),
-                           size_t n,
-                           int flag,
-                           size_t obj_size,
-			               const char * __restrict format,
-                           ...);
+extern int __snprintf_chk(char * __restrict s : count(n),
+                          size_t n,
+                          int flag,
+                          size_t obj_size,
+                          const char * __restrict format,
+                          ...);
 
 int __builtin___snprintf_chk(char * restrict s : count(n),
                              size_t n,
@@ -36,12 +36,12 @@ int __builtin___snprintf_chk(char * restrict s : count(n),
 
 
 #if __has_builtin(__builtin___vsnprintf_chk) || defined(__GNUC__)
-extern int __vsnprintf_chk (char * __restrict s : count(n),
-                            size_t n,
-                            int flag,
-                            size_t obj_size,
-			                const char * __restrict format,
-                            va_list);
+extern int __vsnprintf_chk(char * __restrict s : count(n),
+                           size_t n,
+                           int flag,
+                           size_t obj_size,
+                           const char * __restrict format,
+                           va_list);
 
 int __builtin___vsnprintf_chk(char * restrict s : count(n),
                               size_t n,

--- a/include/_builtin_string_checked.h
+++ b/include/_builtin_string_checked.h
@@ -1,0 +1,61 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for compiler-defined builtin functions       //
+// corresponding to string.h functions                                 //
+//                                                                     //
+// These are given in the order they appear in clang's Builtins.def.   //
+// Functions that do not appear can not have checked interfaces        //
+// defined.                                                            //
+//                                                                     //
+// These are based on the types as declared within clang               //
+// and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#ifndef __has_builtin
+#define _undef__has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin___memcpy_chk) || defined(__GNUC__)
+
+
+void *__builtin___memcpy_chk(void * restrict dest : byte_count(n),
+                             const void * restrict src : byte_count(n),
+                             size_t n,
+                             size_t obj_size) : bounds(dest, (char *) dest + n);
+#endif
+
+#if __has_builtin(__builtin__memmove_chk) || defined(__GNUC__)
+void *__builtin__memmove_chk(void * restrict dest : byte_count(n),
+                             const void * restrict src : byte_count(n),
+                             size_t n,
+                             size_t obj_size) : bounds(dest, (char *)dest + n);
+#endif
+
+#if __has_builtin(__builtin__memset_chk) || defined(__GNUC__)
+void *__builtin__memset_chk(void * s : byte_count(n),
+                            int c,
+                            size_t n,
+                            size_t obj_size) : bounds(s, (char *) s + n);
+#endif
+
+#if __has_builtin(__builtin___strncat_chk) || defined(__GNUC__)
+char *__builtin___strncat_chk(char * restrict dest : count(n),
+                              const char * restrict src : count(n),
+                              size_t n,
+                              size_t obj_size) : bounds(dest, (char *)dest + n);
+#endif
+
+#if __has_builtin(__builtin___strncpy_chk) || defined(__GNUC__)
+char *__builtin___strncpy_chk(char * restrict dest : count(n),
+                              const char * restrict src : count(n),
+                              size_t n,
+                              size_t obj_size) : bounds(dest, (char *)dest + n);
+#endif
+
+#ifdef _undef__has_builtin
+#undef _undef__has_builtin
+#undef __has_builtin
+#endif

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -7,9 +7,12 @@
 //                                                                     //
 // TODO: revise string types after support for pointers to             //
 // null-terminated arrays is added to C.                               //
+//                                                                     //
+// TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
 #include <stdio.h>
+
 
 // TODO: handle strings
 // int remove(const char *name);
@@ -57,7 +60,7 @@ int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 // int sscanf(const char * restrict s,
 //            const char * restrict format, ...);
 // TODO: Apple System Headers Support
-#ifndef __APPLE__
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 int snprintf(char * restrict s : count(n), size_t n,
              const char * restrict format, ...);
 #endif
@@ -75,7 +78,7 @@ int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 // int vscanf(const char * restrict format,
 //            va_list arg);
 // TODO: Apple System Headers Support
-#ifndef __APPLE__
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 int vsnprintf(char * restrict s : count(n), size_t n,
               const char * restrict format,
               va_list arg);
@@ -126,3 +129,5 @@ int feof(FILE *stream : itype(_Ptr<FILE>));
 int ferror(FILE *stream : itype(_Ptr<FILE>));
 // TODO: strings
 // void perror(const char *s);
+
+#include "_builtin_stdio_checked.h"

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -56,8 +56,11 @@ int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 // TODO: handle strings
 // int sscanf(const char * restrict s,
 //            const char * restrict format, ...);
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
 int snprintf(char * restrict s : count(n), size_t n,
              const char * restrict format, ...);
+#endif
 
 int vfprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
              const char * restrict format,
@@ -71,9 +74,12 @@ int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 //             va_list arg);
 // int vscanf(const char * restrict format,
 //            va_list arg);
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
 int vsnprintf(char * restrict s : count(n), size_t n,
               const char * restrict format,
               va_list arg);
+#endif
 // OMITTED INTENTIONALLY:
 // vsprintf cannot be made checked. it is missing the bounds
 // for the output buffer.

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -10,6 +10,9 @@
 /////////////////////////////////////////////////////////////////////////
 #include <string.h>
 
+
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
 void *memcpy(void * restrict dest : byte_count(n),
              const void * restrict src : byte_count(n),
              size_t n) : bounds(dest, (char *) dest + n);
@@ -17,6 +20,7 @@ void *memcpy(void * restrict dest : byte_count(n),
 void *memmove(void * restrict dest : byte_count(n),
               const void * restrict src : byte_count(n),
               size_t n) : bounds(dest, (char *)dest + n);
+#endif
 // TODO: strings
 // char *strcpy(char * restrict dest,
 //              const char * restrict src);
@@ -26,18 +30,24 @@ void *memmove(void * restrict dest : byte_count(n),
 // char *strcpy(char * restrict s1,
 //              const char * restrict s2);
 
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
 char *strncpy(char * restrict dest : count(n),
               const char * restrict src : count(n),
               size_t n) : bounds(dest, (char *)dest + n);
+#endif
 
 // OMITTED INTENTIONALLY: this cannot be made checked.
 // There is no bound on dest.
 // char *strcat(char * restrict dest,
 //              const char * restrict src);
 
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
 char *strncat(char * restrict dest : count(n),
               const char * restrict src : count(n),
               size_t n) : bounds(dest, (char *)dest + n);
+#endif
 
 int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
            size_t n);
@@ -64,8 +74,11 @@ void *memchr(const void *s : byte_count(n), int c, size_t n) :
 // char *strtok(char * restrict s1,
 //              const char * restrict s2);
 
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
 void *memset(void *s : byte_count(n), int c, size_t n) :
   bounds(s, (char *) s + n);
+#endif
 
 // TODO: strings
 // char *strerror(int errnum);

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -7,12 +7,14 @@
 //                                                                     //
 // TODO: revise string types after support for pointers to             //
 // null-terminated arrays is added to C.                               //
+//                                                                     //
+// TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 #include <string.h>
 
 
 // TODO: Apple System Headers Support
-#ifndef __APPLE__
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 void *memcpy(void * restrict dest : byte_count(n),
              const void * restrict src : byte_count(n),
              size_t n) : bounds(dest, (char *) dest + n);
@@ -31,7 +33,7 @@ void *memmove(void * restrict dest : byte_count(n),
 //              const char * restrict s2);
 
 // TODO: Apple System Headers Support
-#ifndef __APPLE__
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 char *strncpy(char * restrict dest : count(n),
               const char * restrict src : count(n),
               size_t n) : bounds(dest, (char *)dest + n);
@@ -75,7 +77,7 @@ void *memchr(const void *s : byte_count(n), int c, size_t n) :
 //              const char * restrict s2);
 
 // TODO: Apple System Headers Support
-#ifndef __APPLE__
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 void *memset(void *s : byte_count(n), int c, size_t n) :
   bounds(s, (char *) s + n);
 #endif
@@ -83,3 +85,5 @@ void *memset(void *s : byte_count(n), int c, size_t n) :
 // TODO: strings
 // char *strerror(int errnum);
 // size_t strlen(const char *s);
+
+#include "_builtin_string_checked.h"


### PR DESCRIPTION
This is a first pass at making the build pass on mac.

Apple defines the `__APPLE__` constant, which we can use to find out if we're on mac. For the moment I'm just not defining our checked versions of these stdlib functions if we're on a mac, I want to circle back around to getting the definitions correct, but this may take some time because of how Apple have structured their C system headers. 

Expect another commit which provides alternative definitions which we can actually use on Macs.