### PR TITLE
Use signals for out-of-bound memory access tests.

### DIFF
--- a/tests/dynamic_checking/deref-arith-check-opt.c
+++ b/tests/dynamic_checking/deref-arith-check-opt.c
@@ -15,23 +15,23 @@
 // RUN: %t 2 4 8 8  0 4   0 3 2  | FileCheck %S/deref-arith-check.c
 // RUN: %t 2 4 8 8  1 3   0 1 5  | FileCheck %S/deref-arith-check.c
 // RUN: %t 2 4 8 8  2 -1  2 -1 2 | FileCheck %S/deref-arith-check.c
-// RUN: not --crash %t 3        | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t -1       | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 5      | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 -1     | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 9    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 -1   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 9  | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 -1 | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 0  3 0   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  2 3   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  0 9   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  -1 -1 | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  0 0  3 0 0    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  2 9 0    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  2 2 3    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  0 0 27   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
+// RUN:  %t 3        | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t -1       | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 5      | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 -1     | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 9    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 -1   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 0 9  | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 0 -1 | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 0 0  3 0   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  2 3   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  0 9   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  -1 -1 | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  0 0  3 0 0    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  2 9 0    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  2 2 3    | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  0 0 27   | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/deref-arith-check.c --check-prefix=CHECK-FAIL-3
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/deref-arith-check.c
+++ b/tests/dynamic_checking/deref-arith-check.c
@@ -9,26 +9,27 @@
 // RUN: %t 2 4 8 8  0 4   0 3 2  | FileCheck %s
 // RUN: %t 2 4 8 8  1 3   0 1 5  | FileCheck %s
 // RUN: %t 2 4 8 8  2 -1  2 -1 2 | FileCheck %s
-// RUN: not --crash %t 3        | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 5      | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 9  | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN:  %t 3        | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 5      | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 0 9  | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN:  %t 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN:  %t 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN:  %t 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 
-#include <stdlib.h>
+#include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "../../include/stdchecked.h"
 
 int a0 checked[9] = { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
@@ -41,9 +42,20 @@ int ma2 checked[3][3][3] = {
 
 array_ptr<int> a1 : count(3) = a0;
 
+// Handle an out-of-bounds reference by immediately exiting. This causes
+// some output to be missing.
+void handle_error(int err) {
+  _Exit(0);
+}
+
 // This signature for main is exactly what we want here,
 // it also means any uses of argv[i] are checked too!
 int main(int argc, array_ptr<char*> argv : count(argc)) {
+
+  // Set up the handler for a failing bounds check.  Currently the Checked C
+  // clang implementation raises a SIGILL when a bounds check fails.  This
+  // may change in the future.
+  signal(SIGILL, handle_error);
 
   // Unfortunately, using atoi everywhere below isn't super
   // great, as it will return 0 if it can't parse, which is a valid, 

--- a/tests/dynamic_checking/deref-check-opt.c
+++ b/tests/dynamic_checking/deref-check-opt.c
@@ -11,10 +11,10 @@
 // RUN: %clang -fcheckedc-extension %S/deref-check.c -o %t -Werror -O3
 // RUN: %t pass1 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-1
 // RUN: %t pass2 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-2
-// RUN: not --crash %t fail1 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-1
-// RUN: not --crash %t fail2 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-2
-// RUN: not --crash %t fail3 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-3
-// RUN: not --crash %t fail4 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-4
+// RUN: %t fail1 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-1
+// RUN: %t fail2 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-2
+// RUN: %t fail3 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-3
+// RUN: %t fail4 | FileCheck %S/deref-check.c --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-4
 
 #import <stdlib.h>
 

--- a/tests/dynamic_checking/failing-simple-dynamic_check.c
+++ b/tests/dynamic_checking/failing-simple-dynamic_check.c
@@ -3,15 +3,24 @@
 // The following lines are for the LLVM test harness:
 //
 // RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
-// LLVM thinks that exiting via llvm.trap() is a crash.
-// RUN: not --crash %t.exe
+// RUN: %t.exe
 
 #include <stdbool.h>
+#include <signal.h>
+#include <stdlib.h>
 #include "../../include/stdchecked.h"
 
+void handle_error(int err) {
+  _Exit(0);
+}
+
 int main(void) {
+  // Currently the Checked C clang implementation raises a SIGILL when a
+  // dynamic check fails.  This may change in the future.
+  signal(SIGILL, handle_error);
+
   // This is expected fail at runtime. It is simple enough for clang to issue a warning
   dynamic_check(false); // expected-warning {{dynamic check will always fail}}
 
-  return 0;
+  return 1;
 }

--- a/tests/dynamic_checking/subscript-check-opt.c
+++ b/tests/dynamic_checking/subscript-check-opt.c
@@ -15,23 +15,23 @@
 // RUN: %t 2 4 8 8  0 4   0 3 2  | FileCheck %S/subscript-check.c
 // RUN: %t 2 4 8 8  1 3   0 1 5  | FileCheck %S/subscript-check.c
 // RUN: %t 2 4 8 8  2 -1  2 -1 2 | FileCheck %S/subscript-check.c
-// RUN: not --crash %t 3        | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t -1       | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 5      | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 -1     | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 9    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 -1   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 9  | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 -1 | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
-// RUN: not --crash %t 0 0 0 0  3 0   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  2 3   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  0 9   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  -1 -1 | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
-// RUN: not --crash %t 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
-// RUN: not --crash %t 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
+// RUN: %t 3        | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t -1       | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 5      | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 -1     | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 0 9    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 0 -1   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 0 0 9  | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 0 0 -1 | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-1
+// RUN: %t 0 0 0 0  3 0   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
+// RUN: %t 0 0 0 0  2 3   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
+// RUN: %t 0 0 0 0  0 9   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
+// RUN: %t 0 0 0 0  -1 -1 | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-2
+// RUN: %t 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
+// RUN: %t 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
+// RUN: %t 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
+// RUN: %t 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
+// RUN: %t 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript-check.c --check-prefix=CHECK-FAIL-3
 
 #include <stdlib.h>
 


### PR DESCRIPTION
This way processes exit gracefully, instead of relying on the OS to handle
a crash.  On Windows, crashes cause Windows Error Reporting (WER) to fire up,
invoking system logging.

We have been using the not program from the LLVM test harness with the --crash
option to determine when processes have exited with a crash.  We have found
that this approach is not working reliably on Windows.  The not program spawns
a child process and looks at the process exit code, looking for negative exit
codes to indicate a crash. When running automated testing under Visual Studio
Team Services, sometimes the exit code is a positive number.

Testing:
- Tested this change on Windows and Linux and all the Checked C tests passed as expected.
