### PR TITLE
Adds Missing Header to Sample 2.8

### DIFF
--- a/samples/2_8_append.c
+++ b/samples/2_8_append.c
@@ -1,5 +1,6 @@
 // Simple Example of Checked C, from Section 2.8 of the spec
 
+#include <stddef.h>
 #include "../include/stdchecked.h"
 
 void append(array_ptr<char> dst : count(dst_count),


### PR DESCRIPTION
This sample uses `size_t`, which is in `stddef.h`. I forgot that header when originally writing this sample, this fixes it and allows the sample to compile. 