### PR TITLE
Renames parameters called 'ptr' in checked headers

### DIFF
--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -106,11 +106,11 @@ int putc(int c, FILE *stream : itype(_Ptr<FILE>));
 // int puts(const char *str);
 int ungetc(int c, FILE *stream : itype(_Ptr<FILE>));
 
-size_t fread(void * restrict ptr : byte_count(size * nmemb),
+size_t fread(void * restrict pointer : byte_count(size * nmemb),
              size_t size, size_t nmemb,
              FILE * restrict stream : itype(restrict _Ptr<FILE>));
 
-size_t fwrite(const void * restrict ptr : byte_count(size * nmemb),
+size_t fwrite(const void * restrict pointer : byte_count(size * nmemb),
               size_t size, size_t nmemb,
               FILE * restrict stream : itype(restrict _Ptr<FILE>));
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -42,9 +42,9 @@ unsigned long long int strtoull(const char * restrict nptr,
 // TODO: express alignment constraints once where clauses have been added.
 void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
-void free(void *ptr : itype(_Ptr<void>));
+void free(void *pointer : itype(_Ptr<void>));
 void *malloc(size_t size) : byte_count(size);
-void *realloc(void *ptr  : itype(_Ptr<void>), size_t size) : byte_count(size);
+void *realloc(void *pointer  : itype(_Ptr<void>), size_t size) : byte_count(size);
 
 // TODO: strings
 // char *getenv(const char *n);


### PR DESCRIPTION
Before this change, it was required that programmers were careful with the order in which they included headers - in particular, the inclusion of `<stdchecked.h>` must come after the final inclusion of `<stdlib_checked.h>` or the final inclusion of `<stdio_checked.h>`, whichever came later.

This is a problem if you want to be able to use the `ptr<T>` in a header file rather than `_Ptr<T>`, especially as this almost definitely brings the include of `<stdchecked.h>` earlier.

The solution is to rename these parameters. As these are declarations, all that matters is the types are compatible, the names are effectively erased (even if we use them in a `count(e)` or `bounds(e1, e2)` expression, these are canonicalised to argument position rather than name.