### PR TITLE
 Add test code for variable argument function call issue in checked block (#251) & BOUNDS_CHECKED pragma (#247)

### DIFF
--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -740,8 +740,7 @@ the top-level scope is a checked scope:
 #pragma BOUNDS_CHECKED \textit{on-off-switch}
 \end{alltt}
 
-Where \texttt{\textit{on-off-switch}} is one of \verb|on off|
-and it is \verb|off| by default
+Where \texttt{\textit{on-off-switch}} is one of \verb|ON OFF DEFAULT|
 
 By default, function definitions are not checked. A block inherits the
 checking properties of its parent. This preserves the meaning of

--- a/tests/typechecking/checked_scope.c
+++ b/tests/typechecking/checked_scope.c
@@ -973,35 +973,6 @@ extern void check_dimensions1(void) checked {
   array_ptr<int> t13 = t6[0];
 }
 
-// Test that dimensions for incomplete array types are either all checked or unchecked arrays.
-checked void check_dimensions2(int r2d checked[][10] : count(len), int len) {
-}
-
-checked void check_dimensions3(int (r2d checked[])[10] : count(len), int len) {
-}
-
-checked void check_dimensions4(int r2d []checked[10] : count(len), int len) { // expected-error {{unchecked array of checked array not allowed}}
-}
-
-checked void check_dimensions5(int (r2d[])checked[10] : count(len), int len) { // expected-error {{unchecked array of checked array not allowed}}
-}
-
-// Test that qualifiers on the outermost dimension of a checked array-typed parameter are preserved.
-checked void check_dimensions6(int r2d checked[const][10] : count(len), int len) {
-  r2d = 0;          // expected-error {{cannot assign to variable 'r2d' with const-qualified type}}
-  int *t1 = r2d[0]; // expected-error {{variable cannot have an unchecked pointer type }}
-}
-
-checked void check_dimensions7(int (r2d checked[const])[10] : count(len), int len) {
-  r2d = 0;          // expected-error {{cannot assign to variable 'r2d' with const-qualified type}}
-  int *t1 = r2d[0]; // expected-error {{variable cannot have an unchecked pointer type }}
-}
-
-checked void check_dimensions8(int (r2d) checked[const][10] : count(len), int len) {
-  r2d = 0;          // expected-error {{cannot assign to variable 'r2d' with const-qualified type}}
-  int *t1 = r2d[0]; // expected-error {{variable cannot have an unchecked pointer type }}
-}
-
 // Test conditional expressions where arms have different
 // kinds of checked and unchecked arrays.
 extern void check_condexpr(int val) {

--- a/tests/typechecking/checked_scope.c
+++ b/tests/typechecking/checked_scope.c
@@ -830,22 +830,6 @@ extern void check_indirection_unchecked(int p[10], const int const_p[10], int y)
   y = *const_p; // expected-error {{cannot use a parameter with an unchecked type}}
 }
 
-extern void check_indirection_checked(int p checked[10], const int const_p checked[10], int y) checked {
-  *p = y;
-  y = *p;
-  *const_p = y; // expected-error {{read-only variable is not assignable}}
-  y = *const_p;
-}
-
-extern void check_indirection_checked_incomplete(int p checked[] : count(len),
-                                                 const int const_p checked[] : count(len),
-                                                 int len, int y) checked {
-  *p = y;
-  y = *p;
-  *const_p = y; // expected-error {{read-only variable is not assignable}}
-  y = *const_p;
-}
-
 extern void check_subscript_unchecked(int p[10], int y) checked {
   p[0] = y;     // expected-error {{cannot use a parameter with an unchecked type}}
   y = p[0];     // expected-error {{cannot use a parameter with an unchecked type}}
@@ -864,19 +848,6 @@ extern void check_subscript_checked(int p checked[10], const int p_const[10], in
   y = 0[p_const];  // expected-error {{cannot use a parameter with an unchecked type}}
 }
 
-extern void check_subscript_checked_incomplete(int p checked[] : count(len),
-                                               const int p_const[] : count(len),
-                                               int len, int y) checked {
-  p[0] = y;  // OK
-  y = p[0];  // OK
-  0[p] = y;  // OK
-  y = 0[p];  // OK
-  p_const[0] = y;  // expected-error {{read-only variable is not assignable}}
-  y = p_const[0];  // OK
-  0[p_const] = y;  // expected-error {{read-only variable is not assignable}}
-  y = 0[p_const];  // OK
-}
-
 static int global_arr[10];
 static int global_checked_arr checked[10];
 
@@ -885,83 +856,91 @@ typedef int checked_arr_type[10];
 
 // Test assignments between pointers and arrays, excluding const/volatile attributes.
 extern void check_assign(int val, int p[10], int q[], int r checked[10], int s checked[],
-                         int s2d checked[10][10]) checked {
-  int t[10];              // expected-error {{variable cannot have an unchecked array type}}
-  int t2d[10][10];        // expected-error {{variable cannot have an unchecked array type}}
+                         int s2d checked[10][10]) {
+  int t[10];
+  int t2d[10][10];
   int u checked[10];
-  int u2d checked[10][10]; // This is a checked array of checked arrays. checked propagates
+  int u2d checked[10][10];  // This is a checked array of checked arrays. checked propagates
                             // to immediately nested array types in array declarators.  It does
                             // not propagate through typedefs
 
+  int *t1, *t2, *t3, *t4, *t5, *t6;
+  array_ptr<int> t7, t8, t9, t10, t11, t12, t13, t14, t15;
+  int *t16, *t17, *t18;
+  int (*t19)[10];
+  int (*t20)[10];
+  int (*t21)[10];
+
+  array_ptr<int[10]> t22, t23, t24;
+  array_ptr<int checked[10]> t25, t26, t27;
+
+  checked {
   // Single-dimensional array type conversions to pointer types.
-  int *t1 = p;          // expected-error {{variable cannot have an unchecked pointer type}} \
-                        // expected-error {{cannot use a parameter with an unchecked type}}
-                        // T *  = T[constant] OK
-  int *t2 = q;          // expected-error {{variable cannot have an unchecked pointer type}} \
-                        // expected-error {{cannot use a parameter with an unchecked type}}
-                        // T *  = T[] OK
-  int *t3 = t;          // expected-error {{variable cannot have an unchecked pointer type}}
-                        // T *  = T[constant] OK;
-  int *t4 = r;          // expected-error {{variable cannot have an unchecked pointer type}}
-                        // Assignment of checked pointer to unchecked pointer not allowed
-  int *t5 = s;          // expected-error {{variable cannot have an unchecked pointer type}}
-  int *t6 = u;          // expected-error {{variable cannot have an unchecked pointer type}}
+  t1 = p; // expected-error {{cannot use a parameter with an unchecked type}} \
+          // expected-error {{cannot use a variable with an unchecked type}}
+          // T *  = T[constant] OK
+  t2 = q; // expected-error {{cannot use a parameter with an unchecked type}} \
+          // expected-error {{cannot use a variable with an unchecked type}}
+          // T *  = T[] OK
+  t3 = t; // expected-error 2 {{cannot use a variable with an unchecked type}} \
+          // T *  = T[constant] OK;
+  t4 = r; // expected-error {{cannot use a variable with an unchecked type}} \
+          // Assignment of checked pointer to unchecked pointer not allowed
+  t5 = s; // expected-error {{cannot use a variable with an unchecked type}}
+  t6 = u; // expected-error {{cannot use a variable with an unchecked type}}
 
   // Various forms of array_ptr<T> = T[]. Note that the rhs does not need to have known bounds
   // because the lhs pointers have no bounds (and cannot be dereferenced).
   //
   // Note if there need to be known bounds, the bounds of p and q are unknown
   // because C does not guarantee that array sizes match for parameter passing
-  array_ptr<int> t7 = p;        // expected-error {{cannot use a parameter with an unchecked type}}
-  array_ptr<int> t8 = q;        // expected-error {{cannot use a parameter with an unchecked type}}
-  array_ptr<int> t9 = r;
-  array_ptr<int> t10  = s;
-  array_ptr<int> t11 = t;
-  array_ptr<int> t12 = u;
-  array_ptr<int> t13 = s2d[0];
-  array_ptr<int> t14 = t2d[0];
-  array_ptr<int> t15 = u2d[0];
+  t7 = p;         // expected-error {{cannot use a parameter with an unchecked type}}
+  t8 = q;         // expected-error {{cannot use a parameter with an unchecked type}}
+  t9 = r;
+  t10 = s;
+  t11 = t;        // expected-error {{cannot use a variable with an unchecked type}}
+  t12 = u;
+  t13 = s2d[0];
+  t14 = t2d[0];   // expected-error {{cannot use a variable with an unchecked type}}
+  t15 = u2d[0];
 
 
   // Multi-dimensional array type conversions to pointer types.
-  int *t16 = s2d[0];        // expected-error {{variable cannot have an unchecked pointer type}}
-  int *t17 = t2d[0];        // expected-error {{variable cannot have an unchecked pointer type}}
-  int *t18 = u2d[0];        // expected-error {{variable cannot have an unchecked pointer type}}
-  int(*t19)[10] = s2d;      // expected-error {{variable cannot have an unchecked pointer type}}
-                            // assignment of checked array to unchecked array not allowed
-  int (*t20)[10] = t2d;     // expected-error {{variable cannot have an unchecked pointer type}}
-  int (*t21)[10] = u2d;     // expected-error {{variable cannot have an unchecked pointer type}}
-                            // assignment of checked array to unchecked array not allowed
+  t16 = s2d[0]; // expected-error {{cannot use a variable with an unchecked type}}
+  t17 = t2d[0]; // expected-error 2 {{cannot use a variable with an unchecked type}}
+  t18 = u2d[0]; // expected-error {{cannot use a variable with an unchecked type}}
+  t19 = s2d;    // expected-error {{cannot use a variable with an unchecked type}}
+  t20 = t2d;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  t21 = u2d;    // expected-error {{cannot use a variable with an unchecked type}}
 
   // Constructed type that contains unchecked pointer/array types in a checked scope
   // Checked pointer type to unchecked pointer/array type is not allowed
-  array_ptr<int[10]> t22 = s2d; // expected-error {{variable cannot have an unchecked array type}} \
-                                // array_ptr<unchecked array type>, not OK
-  array_ptr<int[10]> t23 = t2d; // expected-error {{variable cannot have an unchecked array type}} \
-                                // array_ptr<unchecked array type>, not OK
-  array_ptr<int[10]> t24 = u2d; // expected-error {{variable cannot have an unchecked array type}} \
-                                // array_ptr<unchecked array type>, not OK
-  array_ptr<int checked[10]> t25 = s2d;
-  array_ptr<int checked[10]> t26 = t2d;
-  array_ptr<int checked[10]> t27 = u2d;
+  t22 = s2d;  // expected-error {{cannot use a variable with an unchecked type}} array_ptr<unchecked array type>, not OK
+  t23 = t2d;  // expected-error 2 {{cannot use a variable with an unchecked type}} array_ptr<unchecked array type>, not OK
+  t24 = u2d;  // expected-error {{cannot use a variable with an unchecked type}} array_ptr<unchecked array type>, not OK
+  t25 = s2d;
+  t26 = t2d;  // expected-error {{cannot use a variable with an unchecked type}}
+  t27 = u2d;
 
   // Assignments to array-typed parameters are allowed.  The outermost array modifier
   // is converted to a pointer type.
   p = q;  // expected-error 2 {{cannot use a parameter with an unchecked type}}
   q = p;  // expected-error 2 {{cannot use a parameter with an unchecked type}}
   s = r;
-  r = t;
+  r = t;  // expected-error {{cannot use a variable with an unchecked type}}
   p = r;  // expected-error {{cannot use a parameter with an unchecked type}}
           // assignment of checked pointer to unchecked pointer not allowed
 
   // Assignments to array-typed local and global variables are not allowed
-  t = p;  // expected-error {{cannot use a parameter with an unchecked type}}
-  t = r;  // use of unchecked type, invalid declaration ignore others
+  t = p;  // expected-error {{cannot use a parameter with an unchecked type}} \
+          // expected-error {{cannot use a variable with an unchecked type}}
+  t = r;  // expected-error {{cannot use a variable with an unchecked type}}
   u = r;  // expected-error {{array type 'int checked[10]' is not assignable}}
   global_arr = p; // expected-error {{cannot use a variable with an unchecked type}} \
                   // expected-error {{cannot use a parameter with an unchecked type}}
   global_arr = r; // expected-error {{cannot use a variable with an unchecked type}}
   global_checked_arr = r; // expected-error {{array type 'int checked[10]' is not assignable}}
+  }
 }
 
 // Test that dimensions in multi-dimensional arrays are either all checked or unchecked arrays.
@@ -1023,357 +1002,41 @@ checked void check_dimensions8(int (r2d) checked[const][10] : count(len), int le
   int *t1 = r2d[0]; // expected-error {{variable cannot have an unchecked pointer type }}
 }
 
-// Test assignments between pointers of different kinds with const/volatile
-// attributes on referent types
-extern void check_assign_cv(int param[10],
-                            int checked_param checked[10],
-                            int param_const_ptr[const 10],
-                            int checked_param_const_ptr checked[const 10],
-                            const int const_param[10],
-                            const int const_checked_param checked[10],
-                            const int const_param_const_ptr[const 10],
-                            const int const_checked_param_const_ptr checked[const 10],
-                            volatile int volatile_param[10],
-                            volatile int checked_volatile_param checked[10]) checked {
-  int a[10];                          // expected-error {{variable cannot have an unchecked array type}}
-  int b checked[10];
-  const int const_a[10];              // expected-error {{variable cannot have an unchecked array type}}
-  const int const_b checked[10];
-  volatile int volatile_a[10];        // expected-error {{variable cannot have an unchecked array type}}
-
-  // NOTE : checked scope error fails to precede
-  int a_const_ptr[const 10]; // expected-error {{variable cannot have an unchecked array type}} expected-error {{type qualifier used in array declarator}}
-
-  //
-  // check assignments to parameters
-  //
-  // assign an unchecked array,where the element type does not have modifiers
-  param = a;                          //  expected-error {{cannot use a parameter with an unchecked type}}
-  checked_param = a;
-  param_const_ptr = a;                //  expected-error {{cannot use a parameter with an unchecked type}}
-  checked_param_const_ptr = a;
-  const_param = a;                    //  expected-error {{cannot use a parameter with an unchecked type}}
-  const_checked_param = a;
-  const_param_const_ptr = a;          //  expected-error {{cannot use a parameter with an unchecked type}}
-  const_checked_param_const_ptr = a;
-  volatile_param = a;                 //  expected-error {{cannot use a parameter with an unchecked type}}
-  checked_volatile_param = a;
-
-  // assign a checked array, where the element type does not have modifiers
-  param = b;                          // expected-error {{cannot use a parameter with an unchecked type}}
-  checked_param = b;
-  param_const_ptr = b;                // expected-error {{cannot use a parameter with an unchecked type}}
-  checked_param_const_ptr = b;        // expected-error {{cannot assign to variable}}
-  const_param = b;                    // expected-error {{cannot use a parameter with an unchecked type}}
-  const_checked_param = b;
-  const_param_const_ptr = b;          // expected-error {{cannot use a parameter with an unchecked type}}
-  const_checked_param_const_ptr = b;  // expected-error {{cannot assign to variable}}
-  volatile_param = b;                 // expected-error {{cannot use a parameter with an unchecked type}}
-
-  // check assigning an unchecked array where the element type has modifiers
-  param = const_a;                    // expected-error {{cannot use a parameter with an unchecked type}}
-  checked_param = const_a;
-  const_param = const_a;              // expected-error {{cannot use a parameter with an unchecked type}}
-  const_checked_param = const_a;
-  volatile_param = const_a;           // expected-error {{cannot use a parameter with an unchecked type}}
-  checked_volatile_param = const_a;
-
-  // spot check assigning a checked array where the element type has modifiers
-  checked_param = const_b;            // expected-warning {{discards qualifiers}}
-  const_checked_param = const_b;
-  volatile_param = const_b;           // expected-error {{cannot use a parameter with an unchecked type}}
-  checked_volatile_param = const_b;   // expected-warning {{discards qualifiers}}
-
-  //
-  // check assignments to local variable pointers
-  //
-
-  // the rhs is a parameter with array type
-  int *p = 0;                     // expected-error {{variable cannot have an unchecked pointer type}}
-  const int *p_const = 0;         // expected-error {{variable cannot have an unchecked pointer type}}
-  volatile int *p_volatile = 0;   // expected-error {{variable cannot have an unchecked pointer type}}
-  ptr<int> q = 0;
-  ptr<const int> q_const = 0;
-  ptr<volatile int> q_volatile = 0;
-  array_ptr<int> r = 0;
-  array_ptr<const int> r_const = 0;
-  array_ptr<volatile int> r_volatile = 0;
-
-  // the rhs is an unchecked array where the element type does not have modifiers
-  p = param;            // expected-error {{cannot use a parameter with an unchecked type}}
-  p_const = param;      // expected-error {{cannot use a parameter with an unchecked type}}
-  p_volatile = param;   // expected-error {{cannot use a parameter with an unchecked type}}
-  // q = param;          not allowed: param has unknown bounds
-  // q_const = param;    not allowed: param has unknown bounds
-  // q_volatile = param; not allowed: param has unknown bounds
-  r = param;            // expected-error {{cannot use a parameter with an unchecked type}}
-  r_const = param;      // expected-error {{cannot use a parameter with an unchecked type}}
-  r_volatile = param;   // expected-error {{cannot use a parameter with an unchecked type}}
-
-  // the rhs is a checked array where the element type does not have modifiers
-  p = checked_param;
-  p_const = checked_param;
-  p_volatile = checked_param;
-  q = checked_param;              // ptr<T> = array_ptr<T> OK
-  q_const = checked_param;        // ptr<T> = array_ptr<T> OK
-  q_volatile = checked_param;     // ptr<T> = array_ptr<T> OK
-  r = checked_param;
-  r_const = checked_param;
-  r_volatile = checked_param;
-
-  // the rhs is an unchecked array where the element type has modifiers
-  p = const_param;              // expected-error {{cannot use a parameter with an unchecked type}}
-  p_const = const_param;        // expected-error {{cannot use a parameter with an unchecked type}}
-  p_volatile = const_param;     // expected-error {{cannot use a parameter with an unchecked type}}
-  // q = const_param;           not allowed: param has unknown bounds
-  // q_const = const_param;     not allowed: param has unknown bounds
-  // q_volatile = const_param;  not allowed: param has unknown bounds
-  r = const_param;              // expected-error {{cannot use a parameter with an unchecked type}}
-  r_const = const_param;        // expected-error {{cannot use a parameter with an unchecked type}}
-  r_volatile = const_param;     // expected-error {{cannot use a parameter with an unchecked type}}
-
-  // the rhs is an checked array where the element type has modifiers
-  q = const_checked_param;      // expected-warning {{discards qualifiers}}
-                                // ptr<T> = array_ptr<T> OK
-  r = const_checked_param;      // expected-warning {{discards qualifiers}}
-  r_const = const_checked_param;
-  r_volatile = const_checked_param; // expected-warning {{discards qualifiers}}
-
-  //
-  // the rhs is a local array
-  //
-
-  // the rhs is an unchecked array where the element type does not have modifiers
-  p = a;
-  p_const = a;
-  p_volatile = a;
-  q = a;
-  q_const = a;
-  q_volatile = a;
-  r = a;
-  r_const = a;
-
-  // the rhs is an checked array where the element type does not have modifiers
-  p = b;
-  p_const = b;
-  p_volatile = b;
-  q = b;              // ptr<T> = array_ptr<T> OK
-  q_const = b;        // ptr<T> = array_ptr<T> OK
-  q_volatile = b;     // ptr<T> = array_ptr<T> OK
-  r = b;
-  r_const = b;
-  r_volatile = b;
-
-  // the rhs is an unchecked array where the element type has modifiers
-  p = const_a;
-  p_const = const_a;
-  p_volatile = const_a;
-  q = const_a;
-  q_const = const_a;
-  q_volatile = const_a;
-  r = const_a;
-  r_const = const_a;
-  r_volatile = const_a;
-
-  // the rhs is an checked array where the element type has modifiers
-  q = const_b;      // expected-warning {{discards qualifiers}}
-                    // ptr<T> = array_ptr<T> OK
-  r = const_b;      // expected-warning {{discards qualifiers}}
-  r_const = const_b;
-  r_volatile = const_b; // expected-warning {{discards qualifiers}}
-}
-
 // Test conditional expressions where arms have different
 // kinds of checked and unchecked arrays.
-extern void check_condexpr(int val) checked {
-  int p [5];        // expected-error {{variable cannot have an unchecked array type}}
+extern void check_condexpr(int val) {
+  int p [5];
   int r checked[5];
-  float s[5];       // expected-error {{variable cannot have an unchecked array type}}
+  float s[5];
   float u checked[5];
+  int *t1;
+  array_ptr<int> t2, t3, t4;
 
-  int *t1 = val ? p : p;            // T[5] and T[5] OK, expected-error {{variable cannot have an unchecked pointer type}}
-  array_ptr<int> t2 = val ? p : r;  // T[5] and T checked[5] OK
-  array_ptr<int> t3 = val ? r : p;  // T checked[5] and T[5] OK
-  array_ptr<int> t4 = val ? r : r;  // T checked[5] and T checked[5] OK.
+  checked {
+  t1 = val ? p : p; // expected-error 3 {{cannot use a variable with an unchecked type}} T[5] and T[5] OK
+  t2 = val ? p : r; // expected-error {{cannot use a variable with an unchecked type}} T[5] and T checked[5] OK
+  t3 = val ? r : p; // expected-error {{cannot use a variable with an unchecked type}} T checked[5] and T[5] OK
+  t4 = val ? r : r; // T checked[5] and T checked[5] OK.
 
   // omit assignment because type of expression is not valid when there is an error.
-  val ? s : r;
-                   // S[5] and T checked[5] not OK;
-  val ? r : s;
-                   // T checked[5] and S[5] not OK.
-  val ? r : u;     // expected-error {{pointer type mismatch}}
-                    // T checked[5] and S checked[5] not OK
-  val ? u : r;     // expected-error {{pointer type mismatch}}
-                   // S checked[5] and T checked[5] not OK
+  val ? s : r;    // expected-error {{cannot use a variable with an unchecked type}}
+  val ? r : s;    // expected-error {{cannot use a variable with an unchecked type}}
+  val ? r : u;    // expected-error {{pointer type mismatch}}
+  val ? u : r;    // expected-error {{pointer type mismatch}}
 
   // Some C compilers have allowed implicit integer to pointer conversions.
   // These are errors for the new safe pointer types.
   val ? r : val;   // expected-error {{incompatible operand types}}
-                   // T checked[5] and int not OK
   val ? val : r;   // expected-error {{incompatible operand types}}
-                   // int and T checked[5] not OK
   val ? u : val;   // expected-error {{incompatible operand types}}
-                   // T checked[5] and int not OK
   val ? val : u;   // expected-error {{incompatible operand types}}
-                    // int and T checked[5] not OK
 
   // Implicit conversion of 0 to a safe pointer type is OK.
   array_ptr<int> t5 = val ? r : 0;
   array_ptr<int> t6 = val ? 0 : r;
   array_ptr<float> t7 = val ? u : 0;
   array_ptr<float> t8 = val ? 0 : u;
-}
-
-extern void check_condexpr_2d(int val) checked {
-  int p[5][6];    // expected-error {{variable cannot have an unchecked array type}}
-  int r checked[5][6];
-  float s[5][6];  // expected-error {{variable cannot have an unchecked array type}}
-  float u checked[5][6];
-  int y checked[5][20];
-
-  int (*t1)[6] = val ? p : p;                  // T[5][6] and T[5][6] OK, expected-error {{variable cannot have an unchecked pointer type}}
-  array_ptr<int checked[6]> t2 = val ? p : r;  // T[5][6] and T checked[5][6] OK
-  array_ptr<int checked[6]> t3 = val ? r : p;  // T checked[5][6] and T[5][6] OK
-  array_ptr<int checked[6]> t4 = val ? r : r;  // T checked[5][6] and T checked[5][6] OK.
-
-  array_ptr<int [6]> t5 = val ? p : r;  // expected-error {{variable cannot have an unchecked array type}}
-                                        // T[5][6] and T checked[5][6] produce a checked array
-  array_ptr<int [6]> t6 = val ? r : p;  // expected-error {{variable cannot have an unchecked array type}}
-                                        // T checked[5][6] and T[5][6] produce a checked array
-  array_ptr<int [6]> t7 = val ? r : r;  // expected-error {{variable cannot have an unchecked array type}} \
-                                        // T checked[5][6] and T checked[5][6] produce a checked array
-
-  // omit assignment because type of expression is not valid when there is an error.
-  val ? s : r;
-                    // S[5][6] and T checked[5][6] not OK;
-  val ? r : s;
-                    // T checked[5][6] and S[5][6] not OK.
-  val ? r : u;      // expected-error {{pointer type mismatch}}
-                    // T checked[5][6] and S checked[5][6] not OK
-  val ? u : r;      // expected-error {{pointer type mismatch}}
-                    // S checked[5][6] and T checked[5][6] not OK
-
-                    // Some C compilers have allowed implicit integer to pointer conversions.
-                    // These are errors for the new safe pointer types.
-  val ? r : val;   // expected-error {{incompatible operand types}}
-                    // T checked[5][6] and int not OK
-  val ? val : r;   // expected-error {{incompatible operand types}}
-                    // int and T checked[5][6] not OK
-  val ? u : val;   // expected-error {{incompatible operand types}}
-                    // T checked[5][6] and int not OK
-  val ? val : u;   // expected-error {{incompatible operand types}}
-                    // int and T checked[5][6] not OK
-
-  // check that mismatching dimension sizes for the 2nd dimension cause
-  // a typechecking error.
-  val ? r : y;      // expected-error {{pointer type mismatch}}
-                    // different dimension sizes are not OK
-
-  // Implicit conversion of 0 to a checked pointer type is OK.
-  array_ptr<int checked[6]> t11 = val ? r : 0;
-  array_ptr<int checked[6]> t12 = val ? 0 : r;
-  array_ptr<float checked[6]> t15 = val ? u : 0;
-  array_ptr<float checked[6]> t16 = val ? 0 : u;
-}
-
-// Test conditional expressions where arms have different kinds of
-// array types and const/volatile modifiers.
-extern void check_condexpr_cv(void) checked {
-  int val = 0;
-  int p[5];   // expected-error {{variable cannot have an unchecked array type}}
-  const int p_const[5] = { 0, 1, 2, 3, 4};    // expected-error {{variable cannot have an unchecked array type}}
-  volatile int p_volatile[5];   // expected-error {{variable cannot have an unchecked array type}}
-  int r checked[5];
-  const int r_const checked[5] = { 0, 1, 2, 3, 4};
-  volatile int r_volatile[5];   // expected-error {{variable cannot have an unchecked array type}}
-
-  // test different kinds of pointers with const modifiers
-  const int *t1 = val ? p : p_const;      // expected-error {{variable cannot have an unchecked pointer type}}
-                                          // int * and const int * OK
-  const int *t2 = val ? p_const : p;      // expected-error {{variable cannot have an unchecked pointer type}}
-                                          // const int * and int * OK
-  const int *t3 = val ? p_const : p_const;// expected-error {{variable cannot have an unchecked pointer type}}
-                                          // const int * and const int * OK
-
-  int *t4 = val ? p : p_const;            // expected-error {{variable cannot have an unchecked pointer type}}
-                                          // int * and const int * produce const int *
-  int *t5 = val ? p_const : p;            // expected-error {{variable cannot have an unchecked pointer type}}
-                                          // const int * and int * produce const int *
-  int *t6 = val ? p_const : p_const;      // expected-error {{variable cannot have an unchecked pointer type}}
-                                          // const int * and const int * produce const int *
-
-  array_ptr<const int> t25 = val ? p : r_const;       // int * and array_ptr<const int> OK
-  array_ptr<const int> t26 = val ? r_const : p;       // array_ptr<const int> and int * OK
-  array_ptr<const int> t27 = val ? p_const : r;       // const int * and array_ptr<int> OK
-  array_ptr<const int> t28 = val ? r : p_const;       // array_ptr<int> and const int * OK
-  array_ptr<const int> t29 = val ? p_const : r_const; // const int * and array_ptr<const int> OK
-  array_ptr<const int> t30 = val ? r_const : p_const; // array_ptr<const int> and const int * OK
-  array_ptr<const int> t31 = val ? r : r_const;       // array_ptr<int> and array_ptr<const int> OK
-  array_ptr<const int> t32 = val ? r_const : r;       // array_ptr<const int> and array_ptr<int> OK
-  array_ptr<const int> t33 = val ? r_const : r_const; // array_ptr<const int> and array_ptr<const int> OK
-
-  array_ptr<int> t34 = val ? p : r_const;
-                                                  // int * and array_ptr<const int> produce array_ptr<const int>
-  array_ptr<int> t35 = val ? r_const : p;
-                                                  // array_ptr<const int> and int * produce array_ptr<const int>
-  array_ptr<int> t36 = val ? p_const : r;
-                                                  // const int * and array_ptr<int> produce array_ptr<const int>
-  array_ptr<int> t37 = val ? r : p_const;
-                                                  // array_ptr<int> and const int * produce array_ptr<const int>
-  array_ptr<int> t38 = val ? p_const : r_const;
-                                                  // const int * and array_ptr<const int> produce array_ptr<const int>
-  array_ptr<int> t39 = val ? r_const : p_const;
-                                                  // array_ptr<const int> and const int * produce array_ptr<const int>
-  array_ptr<int> t40 = val ? r : r_const;         // expected-warning {{discards qualifiers}}
-                                                  // array_ptr<int> and array_ptr<const int> produce array_ptr<const int>
-  array_ptr<int> t41 = val ? r_const : r;         // expected-warning {{discards qualifiers}}
-                                                  // array_ptr<const int> and array_ptr<int> produce array_ptr<const int>
-  array_ptr<int> t42 = val ? r_const : r_const;   // expected-warning {{discards qualifiers}}
-                                                  // array_ptr<const int> and array_ptr<const int> produce array_ptr<const int>
-
-  // test different kinds of pointers with volatile modifers
-  volatile int *t50 = val ? p : p_volatile;           // expected-error {{variable cannot have an unchecked pointer type}}
-                                                      // int * and volatile int * OK
-  volatile int *t51 = val ? p_volatile : p;           // expected-error {{variable cannot have an unchecked pointer type}}
-                                                      // volatile int * and int * OK
-  volatile int *t52 = val ? p_volatile : p_volatile;  // expected-error {{variable cannot have an unchecked pointer type}}
-                                                      // volatile int * and volatile int * OK
-
-  int *t53 = val ? p : p_volatile;                    // expected-error {{variable cannot have an unchecked pointer type}}
-                                                      // int * and volatile int * produce volatile int *
-  int *t54 = val ? p_volatile : p;                    // expected-error {{variable cannot have an unchecked pointer type}}
-                                                      // volatile int * and int * produce volatile int *
-  int *t55 = val ? p_volatile : p_volatile;           // expected-error {{variable cannot have an unchecked pointer type}}
-                                                      // volatile int * and volatile int * produce volatile int *
-
-  array_ptr<volatile int> t74 = val ? p : r_volatile;         // int * and array_ptr<volatile int> OK
-  array_ptr<volatile int> t75 = val ? r_volatile : p;         // array_ptr<volatile int> and int * OK
-  array_ptr<volatile int> t76 = val ? p_volatile : r;         // volatile int * and array_ptr<int> OK
-  array_ptr<volatile int> t77 = val ? r : p_volatile;         // array_ptr<int> and volatile int * OK
-  array_ptr<volatile int> t78 = val ? p_volatile : r_volatile;// volatile int * and array_ptr<volatile int> OK
-  array_ptr<volatile int> t79 = val ? r_volatile : p_volatile;// array_ptr<volatile int> and volatile int * OK
-  array_ptr<volatile int> t80 = val ? r : r_volatile;         // array_ptr<int> and array_ptr<volatile int> OK
-  array_ptr<volatile int> t81 = val ? r_volatile : r;         // array_ptr<volatile int> and array_ptr<int> OK
-  array_ptr<volatile int> t82 = val ? r_volatile : r_volatile;// array_ptr<volatile int> and array_ptr<volatile int> OK
-
-  array_ptr<int> t83 = val ? p : r_volatile;
-                                                      // int * and array_ptr<volatile int> produce array_ptr<volatile int>
-  array_ptr<int> t84 = val ? r_volatile : p;
-                                                      // array_ptr<volatile int> and int * produce array_ptr<volatile int>
-  array_ptr<int> t85 = val ? p_volatile : r;          // pected-no-warning {{discards qualifiers}}
-                                                      // volatile int * and array_ptr<int> produce array_ptr<volatile int>
-  array_ptr<int> t86 = val ? r : p_volatile;          // pected-no-warning {{discards qualifiers}}
-                                                      // array_ptr<int> and volatile int * produce array_ptr<volatile int>
-  array_ptr<int> t87 = val ? p_volatile : r_volatile;
-                                                      // volatile int * and array_ptr<volatile int> produce array_ptr<volatile int>
-  array_ptr<int> t88 = val ? r_volatile : p_volatile;
-                                                      // array_ptr<volatile int> and volatile int * produce array_ptr<volatile int>
-  array_ptr<int> t89 = val ? r : r_volatile;          // pected-no-warning {{discards qualifiers}}
-                                                      // array_ptr<int> and array_ptr<volatile int> produce array_ptr<volatile int>
-  array_ptr<int> t90 = val ? r_volatile : r;          // pected-no-warning {{discards qualifiers}}
-                                                      // array_ptr<volatile int> and array_ptr<int> produce array_ptr<volatile int>
-  array_ptr<int> t92 = val ? r_volatile : r_volatile;
-                                                      // array_ptr<volatile int> and array_ptr<volatile int> produce array_ptr<volatile int>
+  }
 }
 
 // Define functions used to test typechecking of call expressions.
@@ -1449,142 +1112,100 @@ extern void g3(int y, int p checked[10]) {
   *p = y;
 }
 
-extern void check_call(void) checked {
-  int x[10];            // expected-error {{variable cannot have an unchecked array type}};
+extern void check_call(void) {
+  int x[10];
   int y checked[10];
-  int x2d[10][10];      // expected-error {{variable cannot have an unchecked array type}};
+  int x2d[10][10];
   int y2d checked[10][10];
 
-
+  checked {
   // checked scope error precedes function call type error/warning
   // f1(int *p, int y)
-  f1(x, 0);
+  f1(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f1(y, 0);               // expected-error {{parameter of incompatible type 'int *'}}
-  f1(x2d, 0);
+  f1(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f1(y2d, 0);             // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int *'}}
 
   // f2(int p[10], int y)
-  f2(x, 0);
+  f2(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f2(y, 0);               // expected-error {{parameter of incompatible type 'int *'}}
-  f2(x2d, 0);
+  f2(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f2(y2d, 0);             // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int *'}}
 
   // f3(int p checked[10], int y)
-  f3(x, 0);
+  f3(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f3(y, 0);
-  f3(x2d, 0);
+  f3(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f3(y2d, 0);             // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Array_ptr<int>'}}
 
   // f4(int **p, int y);
-  f4(x, 0);
+  f4(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f4(y, 0);               // expected-error {{passing 'int checked[10]' to parameter of incompatible type 'int **'}}
-  f4(x2d, 0);
+  f4(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f4(y2d, 0);             // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int **'}}
 
   // f5(int (*p)[10], int y);
-  f5(x, 0);
+  f5(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f5(y, 0);               // expected-error {{passing 'int checked[10]' to parameter of incompatible type 'int (*)[10]'}}
-  f5(x2d, 0);
+  f5(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f5(y2d, 0);             // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int (*)[10]'}}
 
    // f6(ptr<int[10]>, int y);
-  f6(x, 0);
+  f6(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f6(y, 0);               // expected-error {{passing 'int checked[10]' to parameter of incompatible type '_Ptr<int [10]>'}}
-  f6(x2d, 0);
+  f6(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f6(y2d, 0);             // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Ptr<int [10]>'}}
 
    // f7(array_ptr<int[10]>, int y);
-  f7(x, 0);
+  f7(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f7(y, 0);               // expected-error {{parameter of incompatible type}}
-  f7(x2d, 0);
+  f7(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f7(y2d, 0);             // expected-error {{parameter of incompatible type}}
 
   // f8(int (*p) checked[10], int y);
-  f8(x, 0);
+  f8(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f8(y, 0);               // expected-error {{parameter of incompatible type}}
-  f8(x2d, 0);
+  f8(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f8(y2d, 0);             // expected-error {{parameter of incompatible type}}
 
   // f9(ptr<int checked[10]> p, int y);
-  f8(x, 0);
+  f8(x, 0);               // expected-error {{cannot use a variable with an unchecked type}}
   f8(y, 0);               // expected-error {{parameter of incompatible type}}
-  f8(x2d, 0);
+  f8(x2d, 0);             // expected-error {{cannot use a variable with an unchecked type}}
   f8(y2d, 0);             // expected-error {{parameter of incompatible type}}
 
   // f10(array_ptr<int checked[10]> p, int y);
-  f10(x, 0);
-  f10(y, 0);               // expected-error {{parameter of incompatible type}}
-  f10(x2d, 0);
-  f10(y2d, 0);             // OK
+  f10(x, 0);              // expected-error {{cannot use a variable with an unchecked type}}
+  f10(y, 0);              // expected-error {{parameter of incompatible type}}
+  f10(x2d, 0);            // expected-error {{cannot use a variable with an unchecked type}}
+  f10(y2d, 0);            // OK
 
   // f11(int p[10][10], int y);
-  f11(x, 0);
+  f11(x, 0);              // expected-error {{cannot use a variable with an unchecked type}}
   f11(y, 0);              // expected-error {{parameter of incompatible type}}
-  f11(x2d, 0);
+  f11(x2d, 0);            // expected-error {{cannot use a variable with an unchecked type}}
   f11(y2d, 0);            // expected-error {{parameter of incompatible type}}
 
   // f12(int p checked[10][10], int y);
-  f12(x, 0);
+  f12(x, 0);              // expected-error {{cannot use a variable with an unchecked type}}
   f12(y, 0);              // expected-error {{parameter of incompatible type}}
-  f12(x2d, 0);
+  f12(x2d, 0);            // expected-error {{cannot use a variable with an unchecked type}}
   f12(y2d, 0);            // OK
 
   // f13(_Bool b, int y);
-  f13(x, 0);
+  f13(x, 0);              // expected-error {{cannot use a variable with an unchecked type}}
   f13(y, 0);              // OK
-  f13(x2d, 0);
+  f13(x2d, 0);            // expected-error {{cannot use a variable with an unchecked type}}
   f13(y2d, 0);            // OK
 
   // spot check calls where an array is the second argument
-  g1(0, x);
+  g1(0, x);   // expected-error {{cannot use a variable with an unchecked type}}
   g1(0, y);   // expected-error {{parameter of incompatible type}}
-  g2(0, x);
+  g2(0, x);   // expected-error {{cannot use a variable with an unchecked type}}
   g2(0, y);   // expected-error {{parameter of incompatible type}}
-  g3(0, x);
+  g3(0, x);   // expected-error {{cannot use a variable with an unchecked type}}
   g3(0, y);
-
-}
-
-extern void check_call_void(void) checked {
-  int val = 0;
-  int p[10];        // expected-error {{variable cannot have an unchecked array type}}
-  int r checked[10];
-
-  // TODO: s will need bounds information
-  void *s = 0;      // expected-error {{variable cannot have an unchecked pointer type}}
-  ptr<void> t = 0;
-  array_ptr<void> u = 0;
-
-  // Test different kinds of pointers where the parameter type is a pointer to void and
-  // the referent type is not a void pointer.
-
-  // Type of first parameter is a pointer type.
-  // Expected to typecheck
-  f1_void(p, val);    // param ptr<void>, arg int[10] OK.
-  f3_void(r, val);    // param array_ptr<void>, arg int checked[10] OK.
-  f3_void(p, val);    // param array_ptr<void>, arg int[10] OK, provided that param has no bounds.
-
-  // Expected to not typecheck
-  f1_void(r, val);    // expected-error {{incompatible type}}
-                      // param void *, arg int checked[10] not OK
-  f2_void(r, val);    // expected-error {{incompatible type}}
-                      // param ptr<void>, arg int checked[10] not OK
-
-  // Try passing void pointers to functions expected array types
-  // f1(int *, int)
-  f1(s, 0);
-  f1(t, 0);           // expected-error {{incompatible type}}
-  f1(u, 0);           // expected-error {{incompatible type}}
-
-  // f2(int p[10], int)
-  f2(s, 0);
-  f2(t, 0);           // expected-error {{incompatible type}}
-  f2(u, 0);           // expected-error {{incompatible type}}
-
-  // f3(int p checked[10], int)
-  f3(s, 0);
-  f3(t, 0);           // expected-error {{incompatible type}}
-  f3(u, 0);           // expected-error {{incompatible type}}
+  }
 }
 
 //
@@ -1708,31 +1329,32 @@ checked array_ptr<int checked[10]> h27(int arr checked[10][10]) {
   return arr;
 }
 
-
-
-checked void check_pointer_arithmetic(void) {
-  int p[5];           // expected-error {{variable cannot have an unchecked array type}}
+// Test for type restrictions on various kinds of expression
+// such as pointer arithmetic, logical operator, pointer difference or relational/equal compare
+void check_pointer_arithmetic(void) {
+  int p[5];
   int r checked[5];
 
-  int *p_tmp;         // expected-error {{variable cannot have an unchecked pointer type}}
+  int *p_tmp;
   array_ptr<int> r_tmp;
 
-  p_tmp = p + 5;
-  p_tmp = 5 + p;
-  p_tmp = p_tmp - 2;
-  p_tmp = 2 - p;
-  p_tmp = p++;
-  p_tmp = p--;
-  p_tmp = ++p;
-  p_tmp = --p;
-  p_tmp = (p += 1);
-  p_tmp = (p -= 1);
+  checked {
+  p_tmp = p + 5;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = 5 + p;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = p_tmp - 2;// expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = 2 - p;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = p++;      // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = p--;      // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = ++p;      // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = --p;      // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = (p += 1); // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = (p -= 1); // expected-error 2 {{cannot use a variable with an unchecked type}}
 
   // 0 interpreted as an integer, not null
-  p_tmp = p + 0;
-  p_tmp = 0 + p;
-  p_tmp = p - 0;
-  p_tmp = 0 - p;
+  p_tmp = p + 0;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = 0 + p;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = p - 0;    // expected-error 2 {{cannot use a variable with an unchecked type}}
+  p_tmp = 0 - p;    // expected-error 2 {{cannot use a variable with an unchecked type}}
 
   r_tmp = r + 5;
   r_tmp = 5 + r;
@@ -1752,55 +1374,58 @@ checked void check_pointer_arithmetic(void) {
 
   // adding two pointers is not allowed
   r + r; // expected-error {{invalid operands}}
+  }
 }
 
-checked void check_pointer_difference(int flag) {
+void check_pointer_difference(int flag) {
   int count;
-  int val_int[5];                 // expected-error {{variable cannot have an unchecked array type}}
-  float val_float[5];             // expected-error {{variable cannot have an unchecked array type}}
-  int *p_int = val_int;           // expected-error {{variable cannot have an unchecked pointer type}}
-  float *p_float = val_float;     // expected-error {{variable cannot have an unchecked pointer type}}
+  int val_int[5];
+  float val_float[5];
+  int *p_int = val_int;
+  float *p_float = val_float;
   array_ptr<int> r_int = val_int;
 
-  int a_int[5];                   // expected-error {{variable cannot have an unchecked array type}}
+  int a_int[5];
   int checked_a_int checked[5];
 
-  float a_float[5];               // expected-error {{variable cannot have an unchecked array type}}
+  float a_float[5];
   float checked_a_float checked[5];
 
+  checked {
   if (flag) {
-      p_int = a_int;
+      p_int = a_int;  // expected-error 2 {{cannot use a variable with an unchecked type}}
       r_int = checked_a_int;
   }
 
   // pointer - array
-  count = p_int - a_int;
-  count = p_int - checked_a_int;
-  count = r_int - a_int;
+  count = p_int - a_int;        // expected-error 2 {{cannot use a variable with an unchecked type}}
+  count = p_int - checked_a_int;// expected-error {{cannot use a variable with an unchecked type}}
+  count = r_int - a_int;        // expected-error {{cannot use a variable with an unchecked type}}
   count = r_int - checked_a_int;
 
   // array - pointer
-  count = a_int - p_int;
-  count = checked_a_int - p_int;
-  count = a_int - r_int;
+  count = a_int - p_int;        // expected-error 2 {{cannot use a variable with an unchecked type}}
+  count = checked_a_int - p_int;// expected-error {{cannot use a variable with an unchecked type}}
+  count = a_int - r_int;        // expected-error {{cannot use a variable with an unchecked type}}
   count = checked_a_int - r_int;
 
   // spot check mismatched types
-  count = a_float - p_int;
-  count = p_int - checked_a_float;
+  count = a_float - p_int;          // expected-error 2 {{cannot use a variable with an unchecked type}}
+  count = p_int - checked_a_float;  // expected-error {{cannot use a variable with an unchecked type}}
   count = checked_a_float - r_int;  // expected-error {{not pointers to compatible types}}
+  }
 }
 
-checked void check_pointer_relational_compare(void) {
+void check_pointer_compare(void) {
   int result;
 
-  int val_int[5];                 // expected-error {{variable cannot have an unchecked array type}}
-  float val_float[5];             // expected-error {{variable cannot have an unchecked array type}}
+  int val_int[5];
+  float val_float[5];
   int checked_val_int checked[5];
   float checked_val_float checked[5];
 
-  int *p_int = val_int;           // expected-error {{variable cannot have an unchecked pointer type}}
-  float *p_float = val_float;     // expected-error {{variable cannot have an unchecked pointer type}}
+  int *p_int = val_int;
+  float *p_float = val_float;
 
   ptr<int> q_int = 0;
   q_int = val_int;
@@ -1810,128 +1435,113 @@ checked void check_pointer_relational_compare(void) {
   array_ptr<int> r_int = val_int;
   array_ptr<float> r_float = val_float;
 
+  checked {
   // relational comparisons between pointers and unchecked arrays;
-  result = val_int < p_int;
-  result = val_int <= q_int;
-  result = val_int >= r_int;
+  result = val_int < p_int; // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = val_int <= q_int;// expected-error {{cannot use a variable with an unchecked type}}
+  result = val_int >= r_int;// expected-error {{cannot use a variable with an unchecked type}}
 
-  result = p_int > val_int;
-  result = q_int < val_int;
-  result = r_int <= val_int;
+  result = p_int > val_int; // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = q_int < val_int; // expected-error {{cannot use a variable with an unchecked type}}
+  result = r_int <= val_int;// expected-error {{cannot use a variable with an unchecked type}}
 
 
   // relational comparisons between pointers and checked arrays;
-  result = checked_val_int < p_int;
+  result = checked_val_int < p_int; // expected-error {{cannot use a variable with an unchecked type}}
   result = checked_val_int <= q_int;
   result = checked_val_int >= r_int;
 
-  result = p_int > checked_val_int;
+  result = p_int > checked_val_int; // expected-error {{cannot use a variable with an unchecked type}}
   result = q_int < checked_val_int;
   result = r_int <= checked_val_int;
 
   // invalid relational comparisons
 
   // spot check comparisons between pointers and unchecked arrays;
-  result = val_int < p_float;
-  result = val_float <= q_int;
-  result = val_int >= r_float;
+  result = val_int < p_float;   // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = val_float <= q_int;  // expected-error {{cannot use a variable with an unchecked type}}
+  result = val_int >= r_float;  // expected-error {{cannot use a variable with an unchecked type}}
 
-  result = p_int > val_float;
-  result = q_float < val_int;
-  result = r_int <= val_float;
+  result = p_int > val_float;   // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = q_float < val_int;   // expected-error {{cannot use a variable with an unchecked type}}
+  result = r_int <= val_float;  // expected-error {{cannot use a variable with an unchecked type}}
 
   // spot check comparisons between pointers and checked arrays;
-  result = checked_val_int < p_float;
-  result = checked_val_float <= q_int; // expected-warning {{comparison of distinct pointer types}}
-  result = checked_val_int >= r_float; // expected-warning {{comparison of distinct pointer types}}
+  result = checked_val_int < p_float; // expected-error {{cannot use a variable with an unchecked type}}
+  result = checked_val_float <= q_int;// expected-warning {{comparison of distinct pointer types}}
+  result = checked_val_int >= r_float;// expected-warning {{comparison of distinct pointer types}}
 
-  result = p_int > checked_val_float;
-  result = q_float < checked_val_int;  // expected-warning {{comparison of distinct pointer types}}
-  result = r_int <= checked_val_float; // expected-warning {{comparison of distinct pointer types}}
-}
-
-checked void check_pointer_equality_compare(void) {
-  int result;
-
-  int val_int[5];                 // expected-error {{variable cannot have an unchecked array type}}
-  float val_float[5];             // expected-error {{variable cannot have an unchecked array type}}
-  int checked_val_int checked[5];
-  float checked_val_float checked[5];
-
-  int *p_int = val_int;           // expected-error {{variable cannot have an unchecked pointer type}}
-  float *p_float = val_float;     // expected-error {{variable cannot have an unchecked pointer type}}
-
-  ptr<int> q_int = 0;
-  q_int = val_int;
-  ptr<float> q_float = 0;
-  q_float = val_float;
-
-  array_ptr<int> r_int = val_int;
-  array_ptr<float> r_float = val_float;
+  result = p_int > checked_val_float; // expected-error {{cannot use a variable with an unchecked type}}
+  result = q_float < checked_val_int; // expected-warning {{comparison of distinct pointer types}}
+  result = r_int <= checked_val_float;// expected-warning {{comparison of distinct pointer types}}
 
   // equality/inequality comparisons between pointers and unchecked arrays;
-  result = val_int == p_int;
-  result = val_int != q_int;
-  result = val_int == r_int;
+  result = val_int == p_int;  // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = val_int != q_int;  // expected-error {{cannot use a variable with an unchecked type}}
+  result = val_int == r_int;  // expected-error {{cannot use a variable with an unchecked type}}
 
-  result = p_int != val_int;
-  result = q_int == val_int;
-  result = r_int != val_int;
+  result = p_int != val_int;  // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = q_int == val_int;  // expected-error {{cannot use a variable with an unchecked type}}
+  result = r_int != val_int;  // expected-error {{cannot use a variable with an unchecked type}}
 
   // equality/inequality comparisons between pointers and checked arrays;
-  result = checked_val_int == p_int;
+  result = checked_val_int == p_int;  // expected-error {{cannot use a variable with an unchecked type}}
   result = checked_val_int != q_int;
   result = checked_val_int == r_int;
 
-  result = p_int != checked_val_int;
+  result = p_int != checked_val_int;  // expected-error {{cannot use a variable with an unchecked type}}
   result = q_int == checked_val_int;
   result = r_int != checked_val_int;
 
   // invalid equality/inequality comparisons
 
   // spot check equality comparisons between pointers and unchecked arrays;
-  result = val_int == p_float;
-  result = val_float != q_int;
-  result = val_int == r_float;
+  result = val_int == p_float;  // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = val_float != q_int;  // expected-error {{cannot use a variable with an unchecked type}}
+  result = val_int == r_float;  // expected-error {{cannot use a variable with an unchecked type}}
 
-  result = p_int != val_float;
-  result = q_float == val_int;
-  result = r_int != val_float;
+  result = p_int != val_float;  // expected-error 2 {{cannot use a variable with an unchecked type}}
+  result = q_float == val_int;  // expected-error {{cannot use a variable with an unchecked type}}
+  result = r_int != val_float;  // expected-error {{cannot use a variable with an unchecked type}}
 
   // spot check equality comparisons between pointers and checked arrays;
-  result = checked_val_int == p_float;
+  result = checked_val_int == p_float;  // expected-error {{cannot use a variable with an unchecked type}}
   result = checked_val_float != q_int;  // expected-warning {{comparison of distinct pointer types}}
   result = checked_val_int != r_float;  // expected-warning {{comparison of distinct pointer types}}
 
-  result = p_int == checked_val_float;
+  result = p_int == checked_val_float;  // expected-error {{cannot use a variable with an unchecked type}}
   result = q_float != checked_val_int;  // expected-warning {{comparison of distinct pointer types}}
   result = r_int == checked_val_float;  // expected-warning {{comparison of distinct pointer types}}
+
+  }
 }
 
-checked void check_logical_operators(void) {
-  int p[5]; // expected-error {{variable cannot have an unchecked array type}}
+void check_logical_operators(void) {
+  int p[5];
   int r checked[5];
 
   _Bool b;
 
-  b = !p;
+  checked {
+  b = !p;     // expected-error {{cannot use a variable with an unchecked type}}
   b = !r;
 
-  b = p || b;
+  b = p || b;     // expected-error {{cannot use a variable with an unchecked type}}
   b = r || b;
-  b = b || p;
+  b = b || p;     // expected-error {{cannot use a variable with an unchecked type}}
   b = b || r;
 
-  b = r || p;
-  b = p || r;
+  b = r || p;     // expected-error {{cannot use a variable with an unchecked type}}
+  b = p || r;     // expected-error {{cannot use a variable with an unchecked type}}
 
-  b = p && b;
+  b = p && b;     // expected-error {{cannot use a variable with an unchecked type}}
   b = r && b;
-  b = b && p;
+  b = b && p;     // expected-error {{cannot use a variable with an unchecked type}}
   b = b && r;
 
-  b = r && p;
-  b = p && r;
+  b = r && p;     // expected-error {{cannot use a variable with an unchecked type}}
+  b = p && r;     // expected-error {{cannot use a variable with an unchecked type}}
+  }
 }
 
 checked void check_cast_operator(void) {
@@ -1952,12 +1562,15 @@ checked void check_cast_operator(void) {
   parr = (int(*)checked[5]) ((int(*)checked[]) &arr); // expected-error {{invalid casting to unchecked pointer type}}
   parr = (int(*)checked[3]) &arr;   // expected-error {{invalid casting to unchecked pointer type}}
   parr = (int(*)[5]) &arr;          // expected-error {{invalid casting to unchecked pointer type}}
+  parr = (int**) &arr;              // expected-error {{invalid casting to unchecked pointer type}}
 
   // ptr to array, ptr to unchecked array
   parr = (ptr<int checked[5]>) &arr;
   parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr);
-  parr = (ptr<int checked[3]>) &arr; // expected-error {{incompatible type}}
-  parr = (ptr<int [5]>) &arr; // expected-error {{invalid casting to unchecked array type}}
+  parr = (ptr<int checked[3]>) &arr;  // expected-error {{incompatible type}}
+  parr = (ptr<int [5]>) &arr;   // expected-error {{invalid casting to unchecked array type}}
+  parr = (ptr<int *>) &arr;     // expected-error {{invalid casting to unchecked pointer type}}
+  parr = (ptr<ptr<int>>) &arr;  // expected-error {{incompatible type}}
 
   // array_ptr to array, array_ptr to unchecked array
   array_ptr<int checked[5]> aparr = 0;
@@ -1966,23 +1579,39 @@ checked void check_cast_operator(void) {
   aparr = (array_ptr<int checked[3]>) &arr; // expected-error {{incompatible type}}
   aparr = (array_ptr<int [5]>) &arr;  // expected-error {{invalid casting to unchecked array type}}
 
-  // ptr to variadic func pointers, unchecked func pointer
-  ptr<int(int, ...)> vpa = 0; // expected-error {{variable cannot have variable arguments}}
-  ptr<int(int, int(int, ...), ...)> vpb = 0;  // expected-error {{variable cannot have an unchecked pointer type}}
-  ptr<int*(int,int)> vpc = 0; // expected-error {{variable cannot have an unchecked pointer type}}
-  ptr<int(int, ptr<int(int, ...)>, ...)> vpd;  // expected-error {{variable cannot have variable arguments}}
+  // constructed type compatibility check, base type SHOULD be equal
+  ptr<int> pa = 0;
+  ptr<ptr<int>> ppa = 0;
+  ptr<array_ptr<int>> papa = 0;
 
-  vpa = (ptr<int(int, ...)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
-  vpb = (ptr<int(int, int(int, ...), ...)>) &arr; // expected-error {{invalid casting to unchecked pointer type}}
-  vpc = (ptr<int*(int,int)>) &arr;  // expected-error {{invalid casting to unchecked pointer type}}
-  vpd = (ptr<int(int, ptr<int(int, ...)>, ...)>) &arr; // expected-error {{invalid casting to type having variable arguments}}
+  ppa = (ptr<ptr<int>>) &pa;
+  ppa = (ptr<array_ptr<int>>) &pa;      // expected-error {{incompatible type}} \
+                                        // ptr<ptr<T>> = ptr<array_ptr<T>>, not OK
+  ppa = (array_ptr<ptr<int>>) &pa;      // ptr<ptr<T>> = array_ptr<ptr<T>>, OK
+  ppa = (array_ptr<array_ptr<int>>) &pa;// expected-error {{incompatible type}} \
+                                        // ptr<ptr<T>> = array_ptr<array_ptr<T>>, not OK
+
+  papa = (ptr<ptr<int>>) &pa;           // expected-error {{incompatible type}} \
+                                        // ptr<array_ptr<T>> = ptr<ptr<T>>, not OK
+  papa = (ptr<array_ptr<int>>) &pa;
+  papa = (array_ptr<ptr<int>>) &pa;     // expected-error {{incompatible type}} \
+                                        // ptr<array_ptr<T>> = array_ptr<ptr<T>>, not OK
+  papa = (array_ptr<array_ptr<int>>) &pa;
+
+
+  // ptr to variadic/unchecked func pointer
+  ptr<int(int,int)> vpa = 0;
+  vpa = (ptr<int(int,...)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
+  vpa = (ptr<int(int,ptr<int(int, ...)>)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
+  vpa = (ptr<int*(int,int)>) &arr;  // expected-error {{invalid casting to unchecked pointer type}}
+  vpa = (ptr<int(int,ptr<int(int, ...)>, ...)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
 
   int *upa;                         // expected-error {{variable cannot have an unchecked pointer type}}
   upa = arr;
   upa = (int *)(array_ptr<int>)arr; // expected-error {{invalid casting to unchecked pointer type in a checked scope}}
   upa = &x;
   upa = (int [])&x;                 // expected-error {{cast to incomplete type}}
-  upa = (int(*)[5])&x;              // expected-error {{invalid casting to unchecked}}
+  upa = (int(*)[5])&x;              // expected-error {{invalid casting to unchecked pointer type}}
 
   upa = pax;
   upa = (int *)(array_ptr<int>)pax; // expected-error {{invalid casting to unchecked pointer type in a checked scope}}
@@ -2001,165 +1630,6 @@ checked void check_cast_operator(void) {
   gptr2 = upa;                      // expected-error {{cannot use a variable with an unchecked type}}
   gptr2 = (ptr<int>)upa;            // expected-error {{cannot use a variable with an unchecked type}}
   gptr2 = (array_ptr<int>)upa;      // expected-error {{cannot use a variable with an unchecked type}}
-}
-checked void check_illegal_operators(void) {
-  int p[5]; // expected-error {{variable cannot have an unchecked array type}}
-  int r checked[5];
-  p * 5;
-  5 * p;
-  p *= 5;
-
-  r * 5;  // expected-error {{invalid operands to binary expression}}
-  5 * r;  // expected-error {{invalid operands to binary expression}}
-  r *= 5; // expected-error {{invalid operands to binary expression}}
-
-  p * p;
-  p *= p;
-
-  r * r;  // expected-error {{invalid operands to binary expression}}
-  r *= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test /
-  //
-
-  p / 5;
-  5 / p;
-  p /= 5;
-
-  r / 5;  // expected-error {{invalid operands to binary expression}}
-  5 / r;  // expected-error {{invalid operands to binary expression}}
-  r /= 5; // expected-error {{invalid operands to binary expression}}
-
-  p / p;
-  p /= p;
-
-  r / r;  // expected-error {{invalid operands to binary expression}}
-  r /= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test %
-  //
-
-  p % 5;
-  5 % p;
-  p %= 5;
-
-  r % 5;  // expected-error {{invalid operands to binary expression}}
-  5 % r;  // expected-error {{invalid operands to binary expression}}
-  r %= 5; // expected-error {{invalid operands to binary expression}}
-
-  p % p;
-  p %= p;
-
-  r % r;  // expected-error {{invalid operands to binary expression}}
-  r %= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test <<
-  //
-
-  p << 5;
-  5 << p;
-  p <<= 5;
-
-  r << 5;  // expected-error {{invalid operands to binary expression}}
-  5 << r;  // expected-error {{invalid operands to binary expression}}
-  r <<= 5; // expected-error {{invalid operands to binary expression}}
-
-  p << p;
-  p <<= p;
-
-  r << r;  // expected-error {{invalid operands to binary expression}}
-  r <<= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test >>
-  //
-  p >> 5;
-  5 >> p;
-  p >>= 5;
-
-  r >> 5;  // expected-error {{invalid operands to binary expression}}
-  5 >> r;  // expected-error {{invalid operands to binary expression}}
-  r >>= 5; // expected-error {{invalid operands to binary expression}}
-
-  p >> p;
-  p >>= p;
-
-  r >> r;  // expected-error {{invalid operands to binary expression}}
-  r >>= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test |
-  //
-
-  p | 5;
-  5 | p;
-  p |= 5;
-
-  r | 5;  // expected-error {{invalid operands to binary expression}}
-  5 | r;  // expected-error {{invalid operands to binary expression}}
-  r |= 5; // expected-error {{invalid operands to binary expression}}
-
-  p | p;
-  p |= p;
-
-  r | r;  // expected-error {{invalid operands to binary expression}}
-  r |= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test &
-  //
-
-  p & 5;
-  5 & p;
-  p &= 5;
-
-  r & 5;  // expected-error {{invalid operands to binary expression}}
-  5 & r;  // expected-error {{invalid operands to binary expression}}
-  r &= 5; // expected-error {{invalid operands to binary expression}}
-
-  p & p;
-  p &= p;
-
-  r & r;  // expected-error {{invalid operands to binary expression}}
-  r &= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test ^
-  //
-
-  p ^ 5;
-  5 ^ p;
-  p ^= 5;
-
-  r ^ 5;  // expected-error {{invalid operands to binary expression}}
-  5 ^ r;  // expected-error {{invalid operands to binary expression}}
-  r ^= 5; // expected-error {{invalid operands to binary expression}}
-
-  p ^ p;
-  p ^= p;
-
-  r ^ r;  // expected-error {{invalid operands to binary expression}}
-  r ^= r; // expected-error {{invalid operands to binary expression}}
-
-  //
-  // Test ~
-  //
-  ~p;
-  ~r;  // expected-error {{invalid argument type}}
-
-  //
-  // Test unary -
-  //
-  -p;
-  -r;  // expected-error {{invalid argument type}}
-  //
-  // Test unary +
-  //
-  +p;
-  +r;  // expected-error {{invalid argument type}}
 }
 
 // Test for constructed type
@@ -2185,31 +1655,6 @@ checked void check_checked_constructed_type(void) {
   ptr<ptr<int checked[5]>> pe = 0;
   ptr<ptr<ptr<int[]>>> pf = 0;      // expected-error {{variable cannot have an unchecked array type}}
   ptr<ptr<ptr<int checked[]>>> pg = 0;
-
-  unchecked {
-    int arr checked[10];
-    ptr<int checked[10]> pa = 0;
-    ptr<ptr<int checked[10]>> pb = 0;
-    ptr<int> pc = 0;
-    ptr<ptr<int>> ppa = 0;
-
-    pc = arr;
-    ppa = pa; // expected-error {{incompatible type}}
-
-    checked {
-    pa = (ptr<int[10]>) &arr;   // expected-error {{invalid casting to unchecked array type}}
-    pa = (ptr<int checked[10]>) &arr;
-    pa = (ptr<int *>) &arr;     // expected-error {{invalid casting to unchecked pointer type}}
-    pa = (ptr<ptr<int>>) &arr;  // expected-error {{incompatible type}}
-
-    pb = (ptr<ptr<int[10]>>) &pa;       // expected-error {{invalid casting to unchecked array type}}
-    pb = (ptr<ptr<int checked[10]>>) &pa;
-    pb = (array_ptr<ptr<int[10]>>) &pa; // expected-error {{invalid casting to unchecked array type}}
-    pb = (ptr<ptr<ptr<int>>>) &pa;      // expected-error {{incompatible type}}
-
-    pc = (ptr<int>)arr;
-    }
-  }
 }
 
 int g(ptr<int *> p) {

--- a/tests/typechecking/checked_scope_pragma.c
+++ b/tests/typechecking/checked_scope_pragma.c
@@ -448,91 +448,6 @@ unchecked int unchecked_func_cu2(int *p, int *q, int *r : itype(ptr<int>), int *
 typedef int unchecked_arr_type[10];
 typedef int checked_arr_type[10];
 
-// Test for extern checked function declarations
-extern void check_assign(int val, int p[10], int q[], int r checked[10], int s checked[], // expected-error 2 {{parameter cannot have an unchecked array type}}
-                         int s2d checked[10][10]) {
-}
-
-extern void check_assign_cv(int param[10],  // expected-error {{parameter cannot have an unchecked array type}}
-                            int checked_param checked[10],
-                            int param_const_ptr[const 10],  // expected-error {{parameter cannot have an unchecked array type}}
-                            int checked_param_const_ptr checked[const 10],
-                            const int const_param[10],  // expected-error {{parameter cannot have an unchecked array type}}
-                            const int const_checked_param checked[10],
-                            const int const_param_const_ptr[const 10],  // expected-error {{parameter cannot have an unchecked array type}}
-                            const int const_checked_param_const_ptr checked[const 10],
-                            volatile int volatile_param[10],  // expected-error {{parameter cannot have an unchecked array type}}
-                            volatile int checked_volatile_param checked[10]) {
-}
-
-extern void f1(int *p, int y) { // expected-error {{parameter cannot have an unchecked pointer type}}
-}
-
-extern void f2(int p[10], int y) {  // expected-error {{parameter cannot have an unchecked array type}}
-}
-
-extern void f3(int p checked[10], int y) {
-  *p = y;
-}
-
-extern void f4(int **p, int y) {  // expected-error {{parameter cannot have an unchecked pointer type}}
-}
-
-extern void f5(int(*p)[10], int y) {  // expected-error {{parameter cannot have an unchecked pointer type}}
-}
-
-extern void f6(ptr<int[10]> p, int y) { // expected-error {{parameter cannot have an unchecked array type}} \
-                                        // ptr<unchecked array> not OK in checked scope
-}
-
-extern void f7(array_ptr<int[10]> p, int y) { // expected-error {{parameter cannot have an unchecked array type}} \
-                                              // array_ptr<unchecked array> not OK in checked scope
-}
-
-extern void f8(int(*p) checked[10], int y) {  // expected-error {{parameter cannot have an unchecked pointer type}}
-}
-
-extern void f9(ptr<int checked[10]> p, int y) {
-}
-
-extern void f10(array_ptr<int checked[10]> p, int y) {
-}
-
-extern void f11(int p[10][10], int y) { // expected-error {{parameter cannot have an unchecked array type}}
-}
-
-extern void f12(int p checked[10][10],int y) {
-}
-
-extern void f13(_Bool p, int y) {
-}
-
-extern void f1_void(void *p, int y) { // expected-error {{parameter cannot have an unchecked pointer type}}
-}
-
-extern void f2_void(ptr<void> p, int y) {
-}
-
-extern void f3_void(array_ptr<void> p, int y) {
-}
-
-extern void f1_const(const int p[10], int y) {  // expected-error {{parameter cannot have an unchecked array type}}
-}
-
-extern void f2_const(const int p checked[10], int y) {
-}
-
-extern void g1(int y, int *p) { // expected-error {{parameter cannot have an unchecked pointer type}}
-}
-
-extern void g2(int y, int p[10]) {  // expected-error {{parameter cannot have an unchecked array type}}
-  *p = y;
-}
-
-extern void g3(int y, int p checked[10]) {
-  *p = y;
-}
-
 // Test for global variables in top-level checked scope
 int *a1 : itype(ptr<int>) = 0;
 int *a2 : itype(array_ptr<int>) = 0;
@@ -559,108 +474,6 @@ int global[10]; // expected-error {{variable cannot have an unchecked array type
 int checked_global checked[10];
 int global_arr1[10];  // expected-error {{variable cannot have an unchecked array type}}
 
-int *h3(void) {   // expected-error {{return cannot have an unchecked pointer type}}
-  return global;
-}
-
-ptr<int> h4(void) {
-  return global;
-}
-
-array_ptr<int> h5(void) {
-  return global;
-}
-
-int *h6(void) { // expected-error {{return cannot have an unchecked pointer type}}
-  return checked_global;  // expected-error {{incompatible result type}}
-}
-
-ptr<int> h7(void) {
-  return checked_global; // ptr<T> = array_ptr<T> OK
-}
-
-array_ptr<int> h8(void) {
-  return checked_global;
-}
-
-int *h9(int arr[10]) {  // expected-error {{return cannot have an unchecked pointer type}} \
-                        // expected-error {{parameter cannot have an unchecked array type}}
-  return arr;
-}
-
-ptr<int> h10(void) {
-  return global_arr1;
-}
-
-array_ptr<int> h11(int arr checked[10]) {
-  return arr;
-}
-
-int *h12(int arr checked[10]) {   // expected-error {{return cannot have an unchecked pointer type}}
-  return arr;  // expected-error {{incompatible result type}}
-}
-
-ptr<int> h13(int arr checked[10]) {
-  return arr;  // ptr<T> = array_ptr<T> OK
-}
-
-array_ptr<int> h14(int arr checked[10]) {
-  return arr;
-}
-
-int *h15(int arr checked[]) {   // expected-error {{return cannot have an unchecked pointer type}}
-  return arr;  // expected-error {{incompatible result type}}
-}
-
-ptr<int> h17(int arr checked[]) {
-  return arr;  // ptr<T> = array_ptr<T> OK, expected-error {{expression has no bounds}}
-}
-
-array_ptr<int> h18(int arr checked[]) {
-  return arr;
-}
-
-// h19 is a function that returns a pointer to a 10-element array of integers.
-int(*h19(int arr[10][10]))[10]{   // expected-error {{return cannot have an unchecked pointer type}} expected-error {{parameter cannot have an unchecked array type}}
-  return arr;
-}
-
-int global_arr2[10][10];  // expected-error {{variable cannot have an unchecked array type}}
-ptr<int[10]> h20(void) {  // expected-error {{return cannot have an unchecked array type}}
-  return global_arr2;
-}
-
-array_ptr<int[10]> h21(int arr[10][10]) { // expected-error {{return cannot have an unchecked array type}} \
-                                          // expected-error {{parameter cannot have an unchecked array type}}
-  return arr;
-}
-
-// h22 is a function that returns a pointer to a 10-element array of integers.
-int (*h22(int arr checked[10][10]))[10] { // expected-error {{return cannot have an unchecked pointer type}}
-  return arr;  // expected-error {{incompatible result type}}
-}
-
-ptr<int[10]> h23(int arr checked[10][10]) { // expected-error {{return cannot have an unchecked array type}}
-  return arr;  // expected-error {{incompatible result type}}
-}
-
-array_ptr<int[10]> h24(int arr checked[10][10]) { // expected-error {{return cannot have an unchecked array type}}
-  return arr;  // expected-error {{incompatible result type}}
-}
-
-// h25 is a function that returns a pointer to 10-element array of integers.
-int (*h25(int arr checked[10][10])) checked[10]{  // expected-error {{return cannot have an unchecked pointer type}}
-  return arr;  // expected-error {{incompatible result type}}
-}
-
-ptr<int checked[10]> h26(int arr checked[10][10]) {
-  return arr;  // ptr<T> = array_ptr<T> OK
-}
-
-array_ptr<int checked[10]> h27(int arr checked[10][10]) {
-  return arr;
-}
-
 // Test for structure members in top-level checked scope
 struct S0 {
   float *data1 : itype(ptr<float>);
@@ -678,7 +491,6 @@ struct S0 {
   float ***data13;// expected-error {{member cannot have an unchecked pointer type}}
   float *data14 : itype(float *); // expected-error {{type must be a checked type}} \
                                   // expected-error {{member cannot have an unchecked pointer type}}
-
 };
 
 typedef struct _S1 {


### PR DESCRIPTION
+  Add test code for variable argument function call in checked block (#251)
  + Variable argument function call is not allowed in checked blocks
  + variadic function call & printf function call is checked
+ Add test code for BOUNDS_CHECKED pragma (#247)
  + For elaborate test BOUNDS_CHECKED pragma with a scope, add test cases
  + For elaborate scope handling, implementation is changed to use annotation token
  By using annotation token, it can recognize scope corresponding to annotation token
+ Restore on-off-switch syntax in pragma BOUNDS_CHECKED
  + #pragma BOUNDS_CHECKED [on-off-switch]
  + on-off-switch = ON/OFF/DEFAULT