### PR TITLE
Remove span type from the language extension design.

### DIFF
--- a/spec/bounds_safety/checkedc.tex
+++ b/spec/bounds_safety/checkedc.tex
@@ -131,8 +131,8 @@
 \mbox{ }\\
 \vspace{2in}
 {\huge Extending C with bounds safety \par}
-{Version 0.6 (January 4, 2017) \par}
-%{Version 0.7 - Draft as of \today \par}
+%{Version 0.6 (January 4, 2017) \par}
+{Version 0.7 - Draft as of \today \par}
 \vspace{0.5in}
 {Checked C Technical Report Number 1 \par}
 \vspace{0.25in}

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -132,12 +132,6 @@ Suppose there is a use of some variable \var{x}.
   \boundsinfer{\var{x}}{\boundsrel{\var{x}}{\var{x} \texttt{+ 1}}{\var{T}}}.
    On the right-hand side, \var{x} is reinterpreted as having \arrayptr\ type.
 \item
-  If \var{x} has type
-  \spanptrT, 
-  \boundsinfer{\var{x}}{\boundsrel{\var{x}\texttt{.lower\_bound}}
-                                  {\var{x}\texttt{.upper\_bound}}
-                                  {\var{T}}}
-\item
   If \var{x} has an array type, the rules depend on whether \var{x}  is a parameter
   variable.  Typechecking in C treats a parameter variable with the type ``array of \var{T}''
    as though it has the type ``pointer to \var{T}''.   It does not enforce 

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -22,7 +22,7 @@ capital letter are reserved for system use, as are identifiers that
 begin with two underscores \cite[Section 7.1.3]{ISO2011}. The following
 new keywords are introduced:
 \begin{verbatim}
-_Array_ptr  _Checked  _Dynamic_check  _Ptr  _Span  _Where  _Unchecked
+_Array_ptr  _Checked  _Dynamic_check  _Ptr  _Where  _Unchecked
 \end{verbatim}
 
 It is desirable to have all-lowercase versions of the
@@ -37,7 +37,7 @@ the implementations of standard header files need to be modified to
 not use identifiers that conflict with these keywords.
 The all-lowercase versions of the keywords are:
 \begin{verbatim}
-array_ptr  checked  dynamic_check  ptr  where  span  unchecked
+array_ptr  checked  dynamic_check  ptr  where  unchecked
 \end{verbatim}
 
 The pattern of using an identifier reserved for system use coupled with
@@ -50,7 +50,7 @@ lowercase versions of the keywords.  It is assumed
 that \keyword{checkedc.h} is included before examples.
 
 \section{New kinds of pointer types}
-Three new checked pointer types are added to C. Each pointer type can be
+Two new checked pointer types are added to C. Each pointer type can be
 used in place of `\texttt{*}':
 \begin{enumerate}
 \item
@@ -73,11 +73,6 @@ used in place of `\texttt{*}':
   bounds are checked at runtime if necessary. Pointer arithmetic can be
   done on these pointer types. The resulting pointers do not need to be
   in bounds.
-\item
-  \spanptrT: this
-  is a pointer that dynamically carries its bounds information with it.
-  These pointers follow the same rules as
-  \arrayptrT .
 \end{enumerate}
 
 Unchecked C pointer types that use `\texttt{*}' and are unchecked in their
@@ -98,23 +93,11 @@ do not provide checking that memory for objects is being managed
 properly. For example, they can still be used to access memory for objects after
 the objects have been deallocated.
 
-The \spanptr\ pointer type is similar to the proposed \spanptr\ type for 
-the C++ Standard Library \cite{Macintosh2016}.   There is an important
-difference between the types, though.  In this design, \spanptr\
-values carry lower and upper bounds.  In the proposed C++ design,
-\spanptr\ values carry counts of elements.  The C++ proposal does not
-support decrementing the \spanptr.  While the name \spanptr\ is new,
-the idea itself dates back to the early days of computer science.
-A \spanptr\ is an instance of a  dope vector, which is a data structure 
-that describes the shape of an array.  Dope vectors were used in
-implementations of ALGOL60 \cite{Sattley1961}.
-
 Here are  examples of declarations using pointer types.   These declare variables that
 are all pointers to integers:
 \begin{verbatim}
 int *p;
 ptr<int> q;
-span<int> r;
 array_ptr<int> s;
 \end{verbatim}
 
@@ -125,8 +108,7 @@ of pointers to constant integers:
 \begin{verbatim}
 const int *p;
 ptr<const int> q;
-span<const int> r;
-array_ptr<const int> s;
+array_ptr<const int> r;
 \end{verbatim}
 A pointer to a constant integer cannot be used to modify the value of
 the integer.
@@ -136,8 +118,7 @@ Here are examples of constant pointers to modifiable integers:
 int x;
 int *const p = &x;
 const ptr<int> q = &x;
-const span<int> r = &x;
-const array_ptr<int> s = &x;
+const array_ptr<int> r = &x;
 \end{verbatim}
 In this case, the pointers cannot be modified after they are defined, but 
 the integer that they point to can be modified.   The checked pointer declarations 
@@ -146,8 +127,8 @@ must be placed after the \verb+*+.   The checked pointer declarations are all an
 to \verb+const double y = 5.0;+ declaring a  variable \verb+y+ that is \keyword{const}.
 In the declaration of \keyword{y}, \keyword{double} specifies a type.
 The \keyword{const} keyword is placed before it to declare that
-the variable in the declaration is \keyword{const}.  In the examples, \ptrint,
-\spanptrint, and \arrayptrint\ all specify types too.
+the variable in the declaration is \keyword{const}.  In the examples, \ptrint
+and \arrayptrint\ all specify types too.
 
 The checked pointer types follow the same rules that apply to modifiers for
 unchecked pointer types.  For example, a variable that is a pointer to a
@@ -285,14 +266,10 @@ The following operations involving pointer-typed values are allowed:
 \begin{itemize}
 \item
   Indirection: the \texttt{*} operator can be applied to a value of type
-  \var{T} \texttt{*},
-  \ptrT,
-  \arrayptrT, or
-  \spanptrT. It
-  produces a value of type \var{T}.
+  \var{T} \texttt{*}, \ptrT, or \arrayptrT. It produces a value of type \var{T}.
 \item
   Array reference: the \texttt{[]} operator can be applied to a
-  value of type \var{T} \texttt{*}, \arrayptrT, or \spanptrT. It
+  value of type \var{T} \texttt{*} or \arrayptrT. It
   cannot be applied to a value of type \ptrT.
   \texttt{\var{e1}[\var{e2}]} is equivalent to
   \texttt{*(\var{e1} + \var{e2})}
@@ -300,7 +277,7 @@ The following operations involving pointer-typed values are allowed:
   Assignment: two pointers of the same type can be assigned.
 \item
   Adding or subtracting a pointer type and an integer. This is allowed
-  for \var{T} \texttt{*}, \arrayptrT, and \spanptrT\ types.
+  for \var{T} \texttt{*} and \arrayptrT types.
 \item
   Pointers to objects of the same type can be compared for equality or
   inequality. The pointers do not have to be the same kind of pointer.
@@ -342,8 +319,7 @@ of type \var{T}, the following rules apply:
 \begin{itemize}
 \item
   If the operator occurs in a checked block, the address-of operator
-  produces a value of type
-  \ptrT
+  produces a value of type \arrayptrT.
 \item
   Otherwise, the address-of operator produces a value of type \var{T}
   \texttt{*}.
@@ -385,71 +361,10 @@ variables from being modifiable.
 
 Variables and members of variables with checked pointer types must be initialized
 before they are used.  For \arrayptr s, this is checked as part of checking
-the validity of bounds.  For \ptr s and \spanptr s, this is checked
+the validity of bounds.  For \ptr s, this is checked
 using a separate analysis.   A use includes taking the address of a variable
 or member of a variable.  It is often unclear when the resulting pointer is used,
 so the variable must be initialized when its address is taken.
-
-\subsection{\texttt{Span<}\textit{T}\texttt{>} specific operations}
-
-A \spanptrT\
-pointer carries three values with it: the memory location that will be
-accessed by dereferencing the
-\spanptrT, a lower
-bound on the memory that can be accessed via the current pointer value,
-and an upper bound on accessible memory. Those values can be accessed
-using the \texttt{.} operator combined with the special field names
-\texttt{current}, \texttt{lower\_bound}, and \texttt{upper\_bound}. The
-resulting values have the type
-\arrayptrT. The
-special field names can only be read and cannot be modified by
-assignments.
-
-\begin{verbatim}
-span<int> p = ...
-array_ptr<int> low = p.lower_bound;
-array_ptr<int> high = p.upper_bound;
-array_ptr<int> current = p.current;
-\end{verbatim}
-
-A \spanptrT\ value
-is created by casting a value of another pointer type to the
-\spanptrT type. A
-value of another pointer type may be converted implicitly to an
-\spanptrT\ in
-situations where an
-\spanptrT\ value is
-expected, the referent type of the other pointer type is \var{T}, and
-the bounds of the value can be determined automatically.
-
-For example, a variable of array type can be converted automatically to
-a \spanptr. First, the array type will be converted to a
-pointer type of either \var{T} \texttt{*} or
-\arrayptrT , depending
-on whether the array type is checked or unchecked. This pointer type
-will then be converted to an
-\spanptrT. The
-bounds of a variable of array type are easily determined at compile
-time, so the pointer type will then be converted to an
-\spanptrT:
-
-\begin{verbatim}
-int x[10]
-span<int> p = x; 
-// p.current = x; p.lower_bound = x; p.upper_bound = x + 10;
-
-\end{verbatim}
-
-Similarly, an \arrayptr\ value with declared bounds can be
-converted to a \spanptr\ value:
-
-\begin{verbatim}
-array_ptr<int> src = ...
-span<int> p = src;
-\end{verbatim}
-
-The full rules for casting to a \spanptr\ type are covered
-in Section~\ref{section:pointer-casting}.
 
 \section{Pointer arithmetic error conditions}
 \label{section:pointer-arithmetic-errors}
@@ -683,10 +598,10 @@ overflow. The checks are also inexpensive on superscalar processors:
 they can be placed so that they are statically predicted by 
 processors to never fail.
 
-\section{Relative alignment of \arrayptr\ and \spanptr\ values}
+\section{Relative alignment of \arrayptr\ values}
 \label{section:relative-alignment}
 
-\arrayptrT\ and \spanptrT\ pointers provide
+\arrayptrT\ pointers provide
 pointer arithmetic on arrays. The bounds for these pointers usually
 describe a range of memory that is exactly the size of some array of \var{T}.
 The pointers point to an element of the array. In other words, the lower
@@ -704,7 +619,7 @@ relative alignment type can be overridden by specifying it explicitly as
 part of the bounds.  This is described in 
 Section~\ref{section:representing-relative-alignment}.
 This can be used for bounds for the results of pointers casts and 
-for  \arrayptrvoid\ and \spanptrvoid\ pointers. The type
+for  \arrayptrvoid\ pointers. The type
 \texttt{void} has no defined size, so the default relative alignment is
 undefined for \texttt{void}.
 

--- a/spec/bounds_safety/design-alternatives.tex
+++ b/spec/bounds_safety/design-alternatives.tex
@@ -48,6 +48,98 @@ lines instead. The resulting declarations would be
 declarators are fine: \texttt{int *pj, *pi;} becomes
 \texttt{\ptrint\ pi, pj;}.
 
+\section{Span pointer types}
+\label{section:span-design}
+
+We considered introducing a type called \spanptr\ for pointer types that carry their bounds with
+them dynamically.  We decided to postpone this for now because \spanptr\ is a type that
+seems appropriate to be defined in a library. The \spanptr\ type can be implemented using
+\arrayptr\ types, but not {\it vice versa}.   The main issue is that C does not provide support
+for generic types.
+Indeed, in C++, which has templates, a \spanptr\ type has already been proposed for the C++
+Standard Library \cite{Macintosh2016}.
+While the name \spanptr\ is new,
+the idea of a span type itself dates back to the early days of computer science.
+A \spanptr\ is an instance of a  dope vector, which is a data structure
+that describes the shape of an array.  Dope vectors were used in
+implementations of ALGOL60 \cite{Sattley1961}.
+
+In our proposal, a \spanptrT\ pointer would carry three values with it: the memory location that
+will be accessed by dereferencing the \spanptrT, a lower
+bound on the memory that can be accessed via the current pointer value,
+and an upper bound on accessible memory. Those values can be accessed
+using the \texttt{.} operator combined with the special field names
+\texttt{current}, \texttt{lower\_bound}, and \texttt{upper\_bound}. The
+resulting values have the type
+\arrayptrT. The
+special field names can only be read and cannot be modified by
+assignments.
+
+\begin{verbatim}
+span<int> p = ...
+array_ptr<int> low = p.lower_bound;
+array_ptr<int> high = p.upper_bound;
+array_ptr<int> current = p.current;
+\end{verbatim}
+
+The operations on a \spanptr\ would be similar to those on \arrayptr, except that
+the dynamic bounds values would be used:
+\begin{itemize}
+\item  Indirection: the \texttt{*} operator could be applied also to a value of type \spanptrT.
+It would produce a value of type \var{T}
+\item
+ Array reference: the \texttt{[]} operator could be applied also to a
+  value of type \spanptrT.    \texttt{\var{e1}[\var{e2}]} is equivalent to
+  \texttt{*(\var{e1} + \var{e2})}
+\item Pointer arithmetic: adding or subtracting a value of \spanptr\ pointer type and an integer
+      would be allowed. Pointer arithmetic overflow would be considered a runtime error.
+\end{itemize}
+
+A \spanptrT\ value would be created by casting a value of another pointer type to the
+\spanptrT\ type. A
+value of another pointer type could be converted implicitly to an
+\spanptrT\ in
+situations where a
+\spanptrT\ value is
+expected, the referent type of the other pointer type is \var{T}, and
+the bounds of the value can be determined automatically.
+
+For example, a variable of array type could be converted automatically to
+a \spanptr. First, the array type would be converted to a
+pointer type of either \var{T} \texttt{*} or
+\arrayptrT , depending
+on whether the array type is checked or unchecked. This pointer type
+would then be converted to an
+\spanptrT. The
+bounds of a variable of array type are easily determined at compile
+time, so the pointer type would then be converted to an
+\spanptrT:
+
+\begin{verbatim}
+int x[10]
+span<int> p = x;
+// p.current = x; p.lower_bound = x; p.upper_bound = x + 10;
+
+\end{verbatim}
+
+Similarly, an \arrayptr\ value with declared bounds can be
+converted implicitly to a \spanptr\ value:
+
+\begin{verbatim}
+array_ptr<int> src = ...
+span<int> p = src;
+\end{verbatim}
+
+The operators for casting in Section~\ref{section:pointer-casting} would be expanded
+to have rules that treat \spanptr\ values similarly to \arrayptr\ values.
+
+Having \spanptr\ values carry lower bounds is an important difference between our
+proposal and the C++ proposal.   In the proposed C++ design, \spanptr\ values
+carry counts of elements.  The C++ proposal does not
+support decrementing the \spanptr.   For symmetry with \arrayptr, we think it
+would be important in the Checked C extension that \spanptr\ values carry lower bounds.
+
+
 \section{Removing relative alignment}
 \label{section:design-alternatives:always-unaligned}
 
@@ -586,4 +678,5 @@ feature for C code bases.  The runtime benefit of eliminating non-null
 checks in pointer arithmetic is likely small.  Following the principal of 
 minimality, we have rejected the design choice of adding \texttt{object\_bounds} 
 for now. 
+
 

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -53,7 +53,7 @@ pointer type is valid when the following rules hold:
 \item If the destination pointer is a \ptrT\ type, the range of 
 memory that can be accessed beginning at the source pointer is
 large enough to hold a value of type \var{T}.
-\item If the destination pointer is an \arrayptrT\ or \spanptrT\ type,
+\item If the destination pointer is an \arrayptrT\ type,
 the bounds for the destination pointer are equal to or within the range of
 the memory accessible through the source pointer.
 \end{itemize}
@@ -146,10 +146,6 @@ used instead.
 \end{itemize}
 \item \arrayptrT: No new rules are needed.   The rules in
 Chapter~\ref{chapter:checking-bounds} already cover this case.
-\item \spanptrT: It must be provable statically that \var{e}
-and \bounds{\var{lb}}{\var{ub}} meet the relative alignment requirements of
-the destination \spanptr\ type.  At runtime, a new value of
-type \spanptrT\ with the value of \var{e} and \bounds{\var{lb}}{\var{ub}} will be created.
 \item \texttt{\var{T} *}: If the source type \var{S} is
 \begin{itemize}
 \item \ptrT, the checking succeeds. This handles the case where \var{T}
@@ -187,11 +183,10 @@ have it. It takes 1 to 3 arguments, depending on the kind of conversion being do
   converts \var{e1} to either a \ptr\ or * type.
 \item
   \dynamicboundscastinst{\var{T}}{(\var{e1},
-  \var{e2})} converts \var{e1} to an \arrayptr\ or
-  \spanptr\ type with bounds \boundscount{\var{e2}}.  
+  \var{e2})} converts \var{e1} to an \arrayptr\ type with bounds \boundscount{\var{e2}}.
 \item
   \dynamicboundscastinst{\var{T}}{(\var{e1},\var{e2},\var{e3})} converts \var{e1} to an
-  \arrayptr\ or \spanptr\ type with bounds
+  \arrayptr\ type with bounds
   \bounds{\var{e2}}{\var{e3}}.  \dynamicboundscastinst{\var{T}, \var{A}}
   {(\var{e1},\var{e2},\var{e3})}
    optionally changes the relative alignment of the bounds to \var{A}.
@@ -233,12 +228,11 @@ without verification:
 \begin{itemize}
 \item
   \assumeboundscastinst{\var{T}}{(\var{e1},\var{e2})}
-  converts \var{e1} to an \arrayptr\ or
-  \spanptr\ type with \boundscount{\var{e2}}
+  converts \var{e1} to an \arrayptr\ type with \boundscount{\var{e2}}
 \item
   \assumeboundscastinst{\var{T}}{(\var{e1},\var{e2},\var{e3})}
   converts \var{e1} to an
-  \arrayptr\ or \spanptr\ type with \bounds{\var{e2}}{\var{e3}}.
+  \arrayptr\ type with \bounds{\var{e2}}{\var{e3}}.
   It must be statically provable that \var{e1}, \var{e2} and \var{e3}
   are relatively aligned for \var{T} (or the optional
   relative alignment parameter instead, if there is one).
@@ -253,7 +247,7 @@ to check at compile-time.
 
 A subtle point about the C cast operator and \dynamicboundscast\
 are that they allow {\em bounds-safe casts} of an expression
-\var{e} of unchecked pointer type to a \spanptr\ or
+\var{e} of unchecked pointer type to an
 \arrayptr\ type. This is provided that the bounds for \var{e}
 can be determined. Only a few kinds of expressions with unchecked pointer
 types have bounds that can be determined: address-of expressions

--- a/spec/bounds_safety/introduction.tex
+++ b/spec/bounds_safety/introduction.tex
@@ -472,7 +472,8 @@ and Chapters~\ref{chapter:related-work} and \ref{chapter:design-alternatives}.
 
 This design has benefited from many discussions with Weidong Cui, Gabriel Dos Reis, 
 Chris Hawblitzel, Galen Hunt, Shuvendu Lahiri, and Reuben Olinsky.  The design has
-benefited also from feedback from Michael Hicks, Wonsub Kim, Greg Morrisett, Jonghyun
-Park, and Andrew Ruef. We thank them for their contributions to the design.
+benefited also from feedback from Sam Elliott, Michael Hicks, Wonsub Kim, Greg
+Morrisett, Jonghyun Park, and Andrew Ruef. We thank them for their contributions to
+the design.
 
 

--- a/spec/bounds_safety/introduction.tex
+++ b/spec/bounds_safety/introduction.tex
@@ -62,11 +62,10 @@ Checked C addresses the bounds checking problem for C by:
 \item
   Introducing different pointer types to capture the different ways in
   which pointers are used. The unchecked C pointer type \texttt{*} is kept
-  and three new {\it checked} pointer types are added: one for pointers that
-  are never used in pointer arithmetic and do not need bounds checking (\ptr),
-  one for \emph{array pointer types} that are involved in pointer
-  arithmetic and need bounds checking (\arrayptr), and one for pointer types
-  that carry their bounds with them dynamically (\spanptr).
+  and two new {\it checked} pointer types are added: one for pointers that
+  are never used in pointer arithmetic and do not need bounds checking (\ptr)
+  and one for \emph{array pointer types} that are involved in pointer
+  arithmetic and need bounds checking (\arrayptr).
 \item
   For array pointer types (\arrayptr), in keeping with the low-level
   nature of C,  bounds checking is placed under programmer control. 
@@ -145,14 +144,14 @@ write this knowledge down, to formalize existing practices, such as
 array pointer parameters being paired with length parameters, and to
 check this information.
 
-To simplify bounds and reasoning about bounds, for \spanptr\
-and \arrayptr\ types, pointer arithmetic overflow for these
+To simplify bounds and reasoning about bounds for
+\arrayptr\ types, pointer arithmetic overflow for \arrayptr\
 types is considered a runtime error. Pointer arithmetic involving a null
-pointer for these types is also a runtime error.
+pointer for \arrayptr\ types is also a runtime error.
 
 Efficiency is addressed by extending the static checking so that it can
 guarantee that specific bounds checks will always succeed at runtime for
-\arrayptr\ and \spanptr\ types. The static checking
+\arrayptr\ . The static checking
 supports the scenario of simple control-flow enclosing the bounds check
 guaranteeing that the bounds check will succeed. For example, a for-loop
 may iterate only over values within the declared bounds of an
@@ -473,8 +472,7 @@ and Chapters~\ref{chapter:related-work} and \ref{chapter:design-alternatives}.
 
 This design has benefited from many discussions with Weidong Cui, Gabriel Dos Reis, 
 Chris Hawblitzel, Galen Hunt, Shuvendu Lahiri, and Reuben Olinsky.  The design has
-benefited also from feedback from Sam Elliott, Michael Hicks, Wonsub Kim, Greg
-Morrisett, Jonghyun Park, and Andrew Ruef. We thank them for their contributions to
-the design.
+benefited also from feedback from Michael Hicks, Wonsub Kim, Greg Morrisett, Jonghyun
+Park, and Andrew Ruef. We thank them for their contributions to the design.
 
 

--- a/spec/bounds_safety/open-issues.tex
+++ b/spec/bounds_safety/open-issues.tex
@@ -10,12 +10,6 @@ This chapter discusses work that needs to be done and open issues.
 This section describes work that should be done soon because it is
 needed for completeness or to simplify writing code:
 \begin{itemize}
-\item
-  Function pointers: the \keyword{where} clauses must become part of the signature
-  of the function.  In addition, we need to define the 
-  rules for conversion of function pointers.
-\item The definition of \spanptrT\ needs to be extended to include
-      relative alignment.
 \item For structures, add wording that allows a single statement  
 to update a variable member whose member bounds is expected to hold after
 the statement.  Also add wording to allow a bundle block to do this.

--- a/spec/bounds_safety/related-work.tex
+++ b/spec/bounds_safety/related-work.tex
@@ -744,7 +744,8 @@ arithmetic on unchecked C types.   In contrast, Checked C supersets C. This
 makes it possible to use Checked C extensions incrementally, while Cyclone
 requires that a program to be converted in its entirety.  Cyclone changes the representation of pointer types that allow arithmetic.  It introduces a new 
 pointer type that carries bounds information with it, similar to the \spanptr\
-type in Checked C. This causes compatibility problems when interoperating with existing 
+type described in Section~\ref{section:span-design} that we considered adding to Checked C.
+This causes  compatibility problems when interoperating with existing
 code.   Checked C allows programmers to declare bounds information separately from pointers using \arrayptr\ types.
 Cyclone also changes memory management in C.  It extends C with regions
 to allow arena-based memory management.  Checked C is addressing the

--- a/spec/bounds_safety/simple-invariants.tex
+++ b/spec/bounds_safety/simple-invariants.tex
@@ -265,8 +265,8 @@ If \texttt{\var{e4} <= \var{e2}}, \var{e4} can be substituted for
 The rules used to check facts include the identities \texttt{\var{x} < \var{x} + \var{k}}
 for positive \var{k} and \texttt{\var{x} + \var{k} < \var{k}} for
 negative \var{k}, where \var{k} is a
-constant and \var{x} is a variable that has a new pointer type (\ptr,
-\spanptr, or \arrayptr). These identities are true
+constant and \var{x} is a variable that has a new pointer type (\ptr or \arrayptr).
+qThese identities are true
 because pointer arithmetic overflow is defined as a runtime error for
 new pointer types. This guarantees that adding \var{x} and \var{k} produces either
 an in-range value or a runtime error (no value).

--- a/spec/bounds_safety/simple-invariants.tex
+++ b/spec/bounds_safety/simple-invariants.tex
@@ -266,7 +266,7 @@ The rules used to check facts include the identities \texttt{\var{x} < \var{x} +
 for positive \var{k} and \texttt{\var{x} + \var{k} < \var{k}} for
 negative \var{k}, where \var{k} is a
 constant and \var{x} is a variable that has a new pointer type (\ptr or \arrayptr).
-qThese identities are true
+These identities are true
 because pointer arithmetic overflow is defined as a runtime error for
 new pointer types. This guarantees that adding \var{x} and \var{k} produces either
 an in-range value or a runtime error (no value).

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -795,9 +795,6 @@ expressions:
   Logical AND (\texttt{\&\&}) and logical OR (\texttt{||}) expressions
 \item
   Conditional expressions
-\item
-  Access to special members of \spanptr\ types
-  (\texttt{current}, \texttt{lower\_bound}, and \texttt{upper\_bound})
 \end{compactitem}
 
 They also include expressions that access members of types or memory:


### PR DESCRIPTION
The span type seems like a type that is better suited for a library than a core
language extension. In C++, which has templates, there is already a proposal
for adding a span-like type to the C++ Standard Library.  Remove the span
type for the language extension design and move it to the design alternatives
section.

To be clear, we are postponing adding the span type to the language extension
design (and the clang implementation as well).   We may decide to add it in
the future, especially because implicit conversions involving library types
and pointers can be messy.  However, for now,  it can wait until the need
becomes clearer.

This commit also changes the version description to "Version 0.7 - Draft" and
changes the returned by the address-of operator in checked block from ptr
to array_ptr.