### PR TITLE
+ Add test code for function pointers in checked block(checkedc-clang/#272)

### DIFF
--- a/tests/typechecking/checked_scope.c
+++ b/tests/typechecking/checked_scope.c
@@ -1723,14 +1723,7 @@ ptr<int> id_checked_intp(ptr<int> x) { return 0; }
 extern void test_function_pointer(void) checked {
   // address-of (&) operator produces ptr<T> for function type
   ptr<int(int)> fn0 = &id_int;
-  // CHECK: VarDecl {{0x[0-9a-f]+}} fn0 '_Ptr<int (int)>' cinit
-  // CHECK: `-UnaryOperator {{0x[0-9a-f]+}} '_Ptr<int (int)>' prefix '&
-  // CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'int (int)' Function {{0x[0-9a-f]+}} 'id_int' 'int (int)'
-
   ptr<int(int)> fn1 = id_int;
-  // CHECK: VarDecl {{0x[0-9a-f]+}} fn1 '_Ptr<int (int)>' cinit
-  // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<int (int)>' <FunctionToPointerDecay>
-  // CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'int (int)' Function {{0x[0-9a-f]+}} 'id_int' 'int (int)'
 
   int (*fn2)(int) = &id_int;   // expected-error {{variable cannot have an unchecked pointer type}}
   int (*fn3)(int) = id_int;  // expected-error {{variable cannot have an unchecked pointer type}}
@@ -1742,14 +1735,7 @@ extern void test_function_pointer(void) checked {
   ptr<ptr<int>(ptr<int>)> fn7 = id_intp; // expected-error {{incompatible type}}
 
   ptr<ptr<int>(ptr<int>)> fn8 = &id_checked_intp;
-  // CHECK: VarDecl {{0x[0-9a-f]+}} fn8 '_Ptr<ptr<int> (ptr<int>)>' cinit
-  // CHECK: `-UnaryOperator {{0x[0-9a-f]+}} '_Ptr<ptr<int> (ptr<int>)>' prefix '&
-  // CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'ptr<int> (ptr<int>)' Function {{0x[0-9a-f]+}} 'id_checked_intp' 'ptr<int> (ptr<int>)'
-
   ptr<ptr<int>(ptr<int>)> fn9 = id_checked_intp;
-  // CHECK: VarDecl {{0x[0-9a-f]+}} fn9 '_Ptr<ptr<int> (ptr<int>)>' cinit
-  // CHECK: `-ImplicitCastExpr {{0x[0-9a-f]+}} '_Ptr<ptr<int> (ptr<int>)>' <FunctionToPointerDecay>
-  // CHECK:   `-DeclRefExpr {{0x[0-9a-f]+}} 'ptr<int> (ptr<int>)' Function {{0x[0-9a-f]+}} 'id_checked_intp' 'ptr<int> (ptr<int>)'
 
   int val0;
   // address-of (&) operator produces array_ptr<T> except for function type


### PR DESCRIPTION
+ Add test code for function pointers in checked block(checkedc-clang/#272)

  + address-of (&) operator produces checked ptr<T> type
  However, array_ptr<FunctionType> is not proper if address-of operator is applied to function type
  For checked function pointer, it produces ptr type not array_ptr
  + checked -ast-dump output. AST dump output is also added