### PR TITLE
Add test code for bounds cast expression (#286)

### DIFF
--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -130,3 +130,19 @@ extern void f13() {
   p = _Dynamic_bounds_cast<int *, rel_align_value(1)>(q);
   p = _Dynamic_bounds_cast<int *, rel_align(int)>(q);
 }
+
+extern void f14(array_ptr<int> arr : count(5)) {
+  int p[10];
+  array_ptr<int> x : count(10) = 0;
+  array_ptr<int> q : count(10) = 0;
+  int len = 5;
+  static array_ptr<int> cache1 : count(5);
+
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, count(10));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(p, p + 10));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(cache1 - 2, cache1 + 3));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr, arr + len));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr)); // expected-error {{expected ','}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(x, count(3 + 2));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(x, count(len));
+}

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -83,8 +83,8 @@ checked int *f5(int *p, ptr<int> q, array_ptr<int> r, array_ptr<int> s: count(2)
   return 0;
 }
 
-extern int h5(void) {
-  int k = 0;
+extern array_ptr<int> h5(void) {
+  array_ptr<int> k = 0;
   return k;
 }
 
@@ -156,3 +156,28 @@ extern void f18(int i) {
   q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
   p = _Assume_bounds_cast<int *>(r);
 }
+
+extern float h6(void) {
+  float k = 0;
+  return k;
+}
+
+extern void f19(){
+  int p[10];
+  int a : bounds(p, p+1) = 0;    
+  float b;
+  array_ptr<int> x : count(10) = 0;
+
+  p = _Dynamic_bounds_cast<int *>(h6); // expected-error {{to have a pointer}}
+  p = _Dynamic_bounds_cast<int *>(h6, 2); // expected-error {{to have a pointer}}
+  p = _Dynamic_bounds_cast<int *>(h6, p, p + 1); // expected-error {{to have a pointer}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(a, 10);
+  x = _Dynamic_bounds_cast<int *>(b); // expected-error {{to have a pointer}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(b, 1); // expected-error {{to have a pointer}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(b, p, p + 1); // expected-error {{to have a pointer}}
+
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, b); // expected-error {{invalid argument type}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, p, 1); // expected-error {{expected expression with}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, p, p + 1);
+}
+


### PR DESCRIPTION
 . Add syntax check for *_bounds cast expression with bounds expressions.
   ex)
   array_ptr<int> x : count(10)
       = _Dynamic_bounds_cast<array_ptr<int>>(x, count(10));
   array_ptr<int> x : count(10)
       = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(a, b));
 . Add test code to check whether E1 is pointer type or integral type.