### PR TITLE
Fix backward slashes in clang test automation commands.

### DIFF
--- a/tests/dynamic_checking/bounds/deref_opt.c
+++ b/tests/dynamic_checking/bounds/deref_opt.c
@@ -13,41 +13,41 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S\deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3
-// RUN: %t1 pass1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 fail1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3
+// RUN: %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %t1 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %t1 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang -fcheckedc-extension %S\deref.c -o %t2 -DTEST_WRITE -Werror -O3
-// RUN: %t2 pass1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 fail1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t2 -DTEST_WRITE -Werror -O3
+// RUN: %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %t2 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %t2 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %S\deref.c -o %t3 -DTEST_INCREMENT -Werror -O3
-// RUN: %t3 pass1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t3 -DTEST_INCREMENT -Werror -O3
+// RUN: %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %t3 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %t3 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %S\deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
-// RUN: %t4 pass1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S\deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
+// RUN: %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %t4 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %t4 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %t4 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %t4 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
 #import <stdlib.h>
 


### PR DESCRIPTION
The prior commit failed automated testing on Linux because there were backward slashes in clang test automation commands that needed to be forward slashes, causing files to not be found.  This commit fixes that.

Testing:
- Passed automation testing on Linux.
