### PR TITLE
strncmp is broken on Linux

### DIFF
--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -59,7 +59,13 @@ int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
 // int strcmp(const char *src1, const char *src2);
 // int strcoll(const char *src1, const char *src2);
 
-int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
+// TODO: On some linuxes, strncmp is defined using a macro
+// which will break this redeclaration.
+#ifndef strncmp
+int strncmp(const char *src : count(n),
+            const char *s2 : count(n),
+            size_t n);
+#endif
 
 _Unchecked
 size_t strxfrm(char * restrict dest : count(n),


### PR DESCRIPTION
On linux (specifically Ubuntu 14.04), `strncmp` is a macro rather than a declaration once you've included `<string.h>` (it starts as a declaration, then is replaced later on).

This then breaks our redeclaration. So for the moment, let's not redeclare strncmp.