### PR TITLE
Header Fixups from Benchmark Conversion

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -20,6 +20,7 @@ set(files
   time_checked.h
   _builtin_stdio_checked.h
   _builtin_string_checked.h
+  _builtin_common.h
   )
 
 # Hack - compute the CLANG version from the LLVM version.  The

--- a/include/_builtin_common.h
+++ b/include/_builtin_common.h
@@ -19,8 +19,8 @@
 #endif
 
 #if __has_builtin(__builtin_object_size)
-_Unchecked
-size_t __builtin_object_size(const void* obj, int i);
+size_t __builtin_object_size(const void* obj : itype(_Array_ptr<const void>),
+                             int i);
 #endif
 
 #ifdef _undef__has_builtin

--- a/include/_builtin_string_checked.h
+++ b/include/_builtin_string_checked.h
@@ -21,31 +21,27 @@
 #endif
 
 #if __has_builtin(__builtin___memcpy_chk) || defined(__GNUC__)
-_Unchecked
 void *__builtin___memcpy_chk(void * restrict dest : byte_count(n),
                              const void * restrict src : byte_count(n),
                              size_t n,
                              size_t obj_size) : bounds(dest, (_Array_ptr<char>) dest + n);
 #endif
 
-#if __has_builtin(__builtin__memmove_chk) || defined(__GNUC__)
-_Unchecked
-void *__builtin__memmove_chk(void * restrict dest : byte_count(n),
+#if __has_builtin(__builtin___memmove_chk) || defined(__GNUC__)
+void *__builtin___memmove_chk(void * restrict dest : byte_count(n),
                              const void * restrict src : byte_count(n),
                              size_t n,
                              size_t obj_size) : bounds(dest, (_Array_ptr<char>)dest + n);
 #endif
 
-#if __has_builtin(__builtin__memset_chk) || defined(__GNUC__)
-_Unchecked
-void *__builtin__memset_chk(void * s : byte_count(n),
+#if __has_builtin(__builtin___memset_chk) || defined(__GNUC__)
+void *__builtin___memset_chk(void * s : byte_count(n),
                             int c,
                             size_t n,
                             size_t obj_size) : bounds(s, (_Array_ptr<char>) s + n);
 #endif
 
 #if __has_builtin(__builtin___strncat_chk) || defined(__GNUC__)
-_Unchecked
 char *__builtin___strncat_chk(char * restrict dest : count(n),
                               const char * restrict src : count(n),
                               size_t n,
@@ -53,7 +49,6 @@ char *__builtin___strncat_chk(char * restrict dest : count(n),
 #endif
 
 #if __has_builtin(__builtin___strncpy_chk) || defined(__GNUC__)
-_Unchecked
 char *__builtin___strncpy_chk(char * restrict dest : count(n),
                               const char * restrict src : count(n),
                               size_t n,

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -15,6 +15,10 @@
 
 #pragma BOUNDS_CHECKED ON
 
+extern FILE *stdin : itype(_Ptr<FILE>);
+extern FILE *stdout : itype(_Ptr<FILE>);
+extern FILE *stderr : itype(_Ptr<FILE>);
+
 // TODO: handle strings
 // int remove(const char *name);
 // int rename(const char *from, const char *to);
@@ -104,6 +108,7 @@ int vsnprintf(char * restrict s : count(n), size_t n,
 //            va_list arg);
 
 int fgetc(FILE *stream : itype(_Ptr<FILE>));
+int fputc(int c, FILE *stream : itype(_Ptr<FILE>));
 _Unchecked
 char *fgets(char * restrict s : count(n), int n,
             FILE * restrict stream : itype(restrict _Ptr<FILE>)) :


### PR DESCRIPTION
A Variety of changes

- Removing some `_Unchecked` annotations
- Adding interop type to `__builtin_object_size`
- Adding interop types for `stdin` `stdout` and `stderr`
- Adding interop declaration for `fputc`

There will be more changes incoming, as I complete other benchmark conversions. This branch is what I'm using when testing my changes.
