### PR TITLE
Copy Checked C headers to clang system header directory.

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -3,7 +3,7 @@
 # directory for clang so that they can easily be found/used.
 #
 # Checked C does not require runtime system changes, and it would
-# by unnecesarily heavyweight to require people to pick up a new
+# be unnecesarily heavyweight to require people to pick up a new
 # library just to get the Checked C include wrpaper files.
 # So we place the header files with the compiler.
 
@@ -23,7 +23,7 @@ set(files
   )
 
 # Hack - compute the CLANG version from the LLVM version.  The
-# CLANG_VERSION variable is not available at this during the build.
+# CLANG_VERSION variable is not available at this point during the build.
 
 string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" CHECKEDC_CLANG_VERSION
   ${PACKAGE_VERSION})

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,59 @@
+# CMakeList.txt used by the Checked C version of clang/LLVM.
+# This copies the Checked C header files to the system header
+# directory for clang so that they can easily be found/used.
+#
+# Checked C does not require runtime system changes, and it would
+# by unnecesarily heavyweight to require people to pick up a new
+# library just to get the Checked C include wrpaper files.
+# So we place the header files with the compiler.
+
+set(files 
+  fenv_checked.h
+  inttypes_checked.h
+  math_checked.h
+  signal_checked.h
+  stdchecked.h
+  stdio_checked.h
+  stdlib_checked.h
+  string_checked.h
+  threads_checked.h
+  time_checked.h
+  _builtin_stdio_checked.h
+  _builtin_string_checked.h
+  )
+
+# Hack - compute the CLANG version from the LLVM version.  The
+# CLANG_VERSION variable is not available at this during the build.
+
+string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?" CHECKEDC_CLANG_VERSION
+  ${PACKAGE_VERSION})
+
+set(output_dir ${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CHECKEDC_CLANG_VERSION}/include)
+
+set(out_files)
+foreach( f ${files} )
+  set( src ${CMAKE_CURRENT_SOURCE_DIR}/${f} )
+  set( dst ${output_dir}/${f} )
+  add_custom_command(OUTPUT ${dst}
+    DEPENDS ${src}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+    COMMENT "Copying Checked C's ${f}...")
+  list(APPEND out_files ${dst})
+endforeach( f )
+
+add_custom_target(checkedc-headers ALL DEPENDS ${out_files})
+set_target_properties(checkedc-headers PROPERTIES FOLDER "Misc")
+
+install(
+  FILES ${files}
+  COMPONENT checkedc-headers
+  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+  DESTINATION lib${LLVM_LIBDIR_SUFFIX}/clang/${CHECKEDC_CLANG_VERSION}/include)
+
+if (NOT CMAKE_CONFIGURATION_TYPES) # don't add this for IDE's.
+  add_custom_target(install-checkedc-headers
+    DEPENDS checkedc-headers
+    COMMAND "${CMAKE_COMMAND}"
+            -DCMAKE_INSTALL_COMPONENT=checkedc-headers
+            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
+endif()

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -58,6 +58,7 @@ int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
 // int strcmp(const char *src1, const char *src2);
 // int strcoll(const char *src1, const char *src2);
 
+#undef strncmp
 int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
 size_t strxfrm(char * restrict dest : count(n),
                const char * restrict src,

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -58,6 +58,13 @@ int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
 // int strcmp(const char *src1, const char *src2);
 // int strcoll(const char *src1, const char *src2);
 
+// Linux header files declare strncmp and also define a macro for it.
+// Undef the macro so that we can redeclare strncmp.
+//
+// Section 7.1.4 of the C11 standard allows the use of #undef to prevent
+// macros from interfering  with explicit declarations of library functions.
+// It is legal to #undef a macro that isn't defined, so we don't need to
+// conditionalize this.
 #undef strncmp
 int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
 size_t strxfrm(char * restrict dest : count(n),

--- a/samples/2_3_1_add.c
+++ b/samples/2_3_1_add.c
@@ -1,7 +1,7 @@
 // Simple Example of checked arrays, from Section 2.3.1 of the spec
 //
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 void add(int a checked[2][2], int b checked[2][2]) {
   for (int i = 0; i < 2; i++) {

--- a/samples/2_7_checked.c
+++ b/samples/2_7_checked.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, based on code in Section 2.7 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 void update(ptr<int> a, int b checked[5][5]) {
   for (int i = 0; i < 5; i++)

--- a/samples/2_8_append.c
+++ b/samples/2_8_append.c
@@ -1,7 +1,7 @@
 // Simple Example of Checked C, from Section 2.8 of the spec
 
 #include <stddef.h>
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 void append(array_ptr<char> dst : count(dst_count),
             array_ptr<char> src : count(src_count),

--- a/samples/3_11_compare.c
+++ b/samples/3_11_compare.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 2.8 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 /* lexicographic comparison of two arrays of integers */
 int compare(array_ptr<int> x : bounds(x, x_end),

--- a/samples/3_11_sum.c
+++ b/samples/3_11_sum.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 2.8 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 /* sum integers stored between start and end, where end is not included */
 int sum(array_ptr<int> start : bounds(start, end),

--- a/samples/3_2_1_add.c
+++ b/samples/3_2_1_add.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.2.1 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 int add(int a checked[][2][2] : count(len),
         int b checked[][2][2] : count(len),

--- a/samples/3_2_1_find.c
+++ b/samples/3_2_1_find.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.2.1 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 int find(int key, array_ptr<int> a: count(len), int len) {
   for (int i = 0; i < len; i++) {

--- a/samples/3_2_1_sum.c
+++ b/samples/3_2_1_sum.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.2.1 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 int sum(array_ptr<int> start : bounds(start, end), array_ptr<int> end) {
   int result = 0;

--- a/samples/3_2_1_sum_extern.c
+++ b/samples/3_2_1_sum_extern.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.2.1 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 // external-scoped variables that hold a buffer and its length
 int buflen = 0;

--- a/samples/3_2_2_find.c
+++ b/samples/3_2_2_find.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.2.2 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 array_ptr<int> find(int key, 
                     array_ptr<int> a : count(len), 

--- a/samples/3_4_array_ptr.c
+++ b/samples/3_4_array_ptr.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.4 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Original Function
 int deref_orig(array_ptr<int> x : bounds(x, x + c), int c) {

--- a/samples/3_4_ptr.c
+++ b/samples/3_4_ptr.c
@@ -1,6 +1,6 @@
 // Simple Example of Checked C, from Section 3.4 of the spec
 
-#include "../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Original Function
 int deref_orig(ptr<int> x : bounds(x, x + c), int c) {

--- a/tests/dynamic_checking/bounds/deref.c
+++ b/tests/dynamic_checking/bounds/deref.c
@@ -48,7 +48,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 #ifdef TEST_READ
 #define TEST_OP(e1, e2) e1

--- a/tests/dynamic_checking/bounds/deref_dot_member_expr.c
+++ b/tests/dynamic_checking/bounds/deref_dot_member_expr.c
@@ -71,7 +71,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 #ifdef TEST_READ
 #define TEST_OP(e1, e2) e1

--- a/tests/dynamic_checking/bounds/subscript.c
+++ b/tests/dynamic_checking/bounds/subscript.c
@@ -121,7 +121,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 #ifdef POINTER_ARITHMETIC
 #define ACCESS_DIM1(e1, index1) (*(e1 + index1))

--- a/tests/dynamic_checking/bounds/subscript_dot_member_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_dot_member_expr.c
@@ -67,7 +67,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 #ifdef TEST_READ
 #define TEST_OP(e1, e2)

--- a/tests/dynamic_checking/dynamic_check/arith-fail.c
+++ b/tests/dynamic_checking/dynamic_check/arith-fail.c
@@ -11,7 +11,7 @@
 
 #include <signal.h>
 #include <stdlib.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 void f1(int i) {
   // This is expected fail at runtime

--- a/tests/dynamic_checking/dynamic_check/arith-pass.c
+++ b/tests/dynamic_checking/dynamic_check/arith-pass.c
@@ -7,7 +7,7 @@
 
 // expected-no-diagnostics
 
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 void f1(int i) {
   dynamic_check(i < 30);

--- a/tests/dynamic_checking/dynamic_check/simple-fail.c
+++ b/tests/dynamic_checking/dynamic_check/simple-fail.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <signal.h>
 #include <stdlib.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 void handle_error(int err) {
   _Exit(0);

--- a/tests/dynamic_checking/dynamic_check/simple-pass.c
+++ b/tests/dynamic_checking/dynamic_check/simple-pass.c
@@ -8,7 +8,7 @@
 // expected-no-diagnostics
 
 #include <stdbool.h>
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 int main(void) {
   dynamic_check(true);

--- a/tests/parsing/checked_array_types.c
+++ b/tests/parsing/checked_array_types.c
@@ -16,7 +16,7 @@
 // parameter have new checked array types
 //
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void f1(int a checked[], int y) {
 }

--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Top level declarations with different storage classes and
 // storage classes omitted.

--- a/tests/parsing/interop_types.c
+++ b/tests/parsing/interop_types.c
@@ -6,7 +6,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 //
 // parameters with interop type annotations

--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 struct S1 {
   array_ptr<int> arr : count(5);

--- a/tests/parsing/parameter_bounds.c
+++ b/tests/parsing/parameter_bounds.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void f1(array_ptr<int> arr : count(5)) {
 }

--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -3,7 +3,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension -verify-ignore-unexpected=note %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void f1() {
   array_ptr<int> a : count(1) = 0;

--- a/tests/parsing/pointer_types.c
+++ b/tests/parsing/pointer_types.c
@@ -13,7 +13,7 @@
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 // expected-no-diagnostics
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 //
 // parameter have new pointer types

--- a/tests/parsing/rel_align.c
+++ b/tests/parsing/rel_align.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern int cLen;
 extern array_ptr<int> f : byte_count(cLen * sizeof(int));

--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -5,7 +5,7 @@
 //
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Parsing of function declarations
 extern array_ptr<void> alloc(unsigned size) : byte_count(size);

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -5,7 +5,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Check that declarations of automatic variables with Checked C bounds 
 // declarations or _Ptr types always have initializers.

--- a/tests/static_checking/nme_bounds.c
+++ b/tests/static_checking/nme_bounds.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 int f0int(void);
 int* f0ptr(void);

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -3,7 +3,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void f1() {
   array_ptr<int> a : count(1) = 0;

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -7,7 +7,7 @@
 // Test expressions with standard signed and unsigned integers types as
 // arguments to count and byte_count.
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 static int A = 8;
 static long long int B = 8;

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void check_indirection_unchecked(int p[10], const int const_p[10], int y) {
   *p = y;

--- a/tests/typechecking/checked_scope.c
+++ b/tests/typechecking/checked_scope.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Test for checked function specifier.
 // - check if function declaration (return/param) is checked.

--- a/tests/typechecking/checked_scope_pragma.c
+++ b/tests/typechecking/checked_scope_pragma.c
@@ -13,7 +13,7 @@
 // - By default, all structure/union declarations is checked type
 // - To declare function as undeclared, use unchecked function specifier
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 // Test for pragma set/clear/set.
 #pragma BOUNDS_CHECKED ON

--- a/tests/typechecking/function_casts.c
+++ b/tests/typechecking/function_casts.c
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 //
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 int f0(int a) {
   return a;

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -5,7 +5,7 @@
 //
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 //
 //

--- a/tests/typechecking/interop_type_annotations.c
+++ b/tests/typechecking/interop_type_annotations.c
@@ -5,7 +5,7 @@
 //
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 struct S {
   int a;

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 struct S1 {
   ptr<int> m1;

--- a/tests/typechecking/pointer-sized-long-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/function_casts.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 //
 
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 int f0(int a) {
   return a;

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -6,7 +6,7 @@
 
 // RUN: %clang_cc1 -std=c11 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 _Static_assert(sizeof(void*) == sizeof(long long),
   "Pointers and long longs must be the same size");

--- a/tests/typechecking/pointer-sized-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long/function_casts.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -verify %s
 //
 
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 int f0(int a) {
   return a;

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -6,7 +6,7 @@
 
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../../include/stdchecked.h"
+#include <stdchecked.h>
 
 _Static_assert(sizeof(void*) == sizeof(long),
   "Pointers and longs must be the same size");

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void check_indirection_unsafe_ptr(int *p, const int *const_p, int y) {
 	*p = y;

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -5,7 +5,7 @@
 //
 // RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 //---------------------------------------------------------------------------//
 // Declarations of functions with unchecked parameters are compatible with   //

--- a/tests/typechecking/type_check_bounds_cast.c
+++ b/tests/typechecking/type_check_bounds_cast.c
@@ -3,7 +3,7 @@
 //
 // RUN: %clang_cc1 -verify -fcheckedc-extension -verify-ignore-unexpected=note %s
 
-#include "../../include/stdchecked.h"
+#include <stdchecked.h>
 
 extern void f1() {
   array_ptr<int> a : count(1) = 0;


### PR DESCRIPTION
This adds a CMake file for copying the Checked C headers into the
clang system header directory as part of the clang build.  This avoids
people having to copy the Checked C header files to their specific project,
which would be error prone and result in synchronization problems.   This
change also fixes an issue with strncmp on Linux by undefining a problematic
macro.

It is a little clunky to store all of these header files in the clang system
header directory because it includes wrapper files that are not needed
by the compiler.  This seems to be better and simpler than the
alternatives, so we're using it.

This updates all the samples in the Checked C repo to no longer
use the full relative path the stdchecked.h.  We can just rely on
it being picked up as part of the system search path.

This change has matching changes for the Checked C LLVM repo, the
Checked C clang repo, and the Checked C LLVM Test Suite Repo.

Testing:
- Passed automation testing for Linux x64 LNT testing  and Windows
x86 when the testing was pointed at the matching branches in all
the repos.

