### PR TITLE
Adding test files for _For_any specifier and type variable declarations.

### DIFF
--- a/tests/parsing/typevariable/forany_parsing.c
+++ b/tests/parsing/typevariable/forany_parsing.c
@@ -1,0 +1,39 @@
+// Tests to make sure _For_any specifier is parsed correctly.
+//
+// More specifically, we are testing for correctness of _For_any specifier.
+// 1) _For_any specifier is correctly parsed along with new type polymorphism.
+// 2) _For_any specifier correctly enters a new scope and function declaration
+//    or definition is registered to a correct scope.
+// For this test file, we expect that there are no errors.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
+// expected-no-diagnostics
+
+// Testing for function declaration with function body, without parameters.
+_For_any(T) T TestDefinitionWithNoParameter() {
+  // Testing the scope created by forany specifier contains function body scope
+  T returnVal;
+  return returnVal;
+}
+
+// Testing for function declaration with function body, with parameters
+_For_any(T, S) T TestDefinitionWithParameter(T at, T bt, S cs) {
+  S newT = at;
+  return newT;
+}
+
+// Testing for function declaration without function body, without parameters.
+_For_any(R) R TestDeclarationWithNoParameter();
+// Testing for function declaration without function body, with parameters
+_For_any(Q) Q TestDeclarationWithParameter(Q aq, Q bq, Q cq);
+
+int callPolymorphicTypes() {
+  void *x, *y, *z;
+  // Testing to make sure function declaration is registered in decl scope
+  // outside of forany scope.
+  TestDefinitionWithNoParameter();
+  TestDefinitionWithParameter(x, y, z);
+  TestDeclarationWithNoParameter();
+  TestDeclarationWithParameter(x, y, z);
+  return 0;
+}

--- a/tests/parsing/typevariable/forany_parsing_error.c
+++ b/tests/parsing/typevariable/forany_parsing_error.c
@@ -1,0 +1,16 @@
+// Tests to make sure _For_any errors are produced correctly.
+//
+// More specifically, we are testing for following errors.
+// 1) _For_any() must have type declaration in parenthesis.
+// 2) Make sure type declaration syntax error is caught.
+// 3) _For_any scope should be confined within function declaration.
+// For this test file, we expect that there are no errors.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
+
+_For_any(R) R foo();
+// Testing scope created by for any specifier is exited successfully.
+R thisShouldProduceError; //expected-error{{unknown type name 'R'}}
+_For_any() void foo2(); // expected-error{{expected type variable identifier}}
+_For_any(R, ) R foo3(); // expected-error{{expected type variable identifier}}
+_For_any(R T) R foo4(); // expected-error{{expected , or )}}


### PR DESCRIPTION
For testing scope, it's incorporated in both forany_parsing.c and forany_parsing_error.c
forany_parsing.c : 
* It tests that you can create a variable of type T, if T is a type variable declared in _For_any. 
* It also tests that creating a new _For_any scope does not break function body scope. More specifically, it makes sure that all the parameters are usable in function body as well as new type variables.
* Also tests that function declaration is added to the right scope, by calling the function in a different function. If the function declaration is registered in _For_any scope, upon exiting function declaration, the function name will not be available.

forany_parsing_error.c:
* Tests to make sure that a type T, declared in _For_any specifier, cannot be used outside of function declaration.