### PR TITLE
Stop generating LLVM IR as part of testing forany_parsing.

### DIFF
--- a/tests/parsing/typevariable/forany_parsing.c
+++ b/tests/parsing/typevariable/forany_parsing.c
@@ -6,7 +6,7 @@
 //    or definition is registered to a correct scope.
 // For this test file, we expect that there are no errors.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
 // expected-no-diagnostics
 
 // Testing for function declaration with function body, without parameters.

--- a/tests/parsing/typevariable/forany_parsing_error.c
+++ b/tests/parsing/typevariable/forany_parsing_error.c
@@ -6,7 +6,7 @@
 // 3) _For_any scope should be confined within function declaration.
 // For this test file, we expect that there are no errors.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
+// RUN: %clang_cc1 -fcheckedc-extension -verify %s
 
 _For_any(R) R foo();
 // Testing scope created by for any specifier is exited successfully.


### PR DESCRIPTION
For_any parsing is generating LLVM IR files as part of test runs.  This causes automation testing to fail because it creates the file in a source directory.   The next automation run fails because it finds a file with no RUN line in it in the test directory.  The fix is to not generate LLVM IR files.
