### PR TITLE
Change function declaration to be prototyped.

### DIFF
--- a/tests/parsing/typevariable/forany_parsing.c
+++ b/tests/parsing/typevariable/forany_parsing.c
@@ -31,9 +31,9 @@ int callPolymorphicTypes() {
   void *x, *y, *z;
   // Testing to make sure function declaration is registered in decl scope
   // outside of forany scope.
-  TestDefinitionWithNoParameter();
-  TestDefinitionWithParameter(x, y, z);
-  TestDeclarationWithNoParameter();
-  TestDeclarationWithParameter(x, y, z);
+  TestDefinitionWithNoParameter<void *>();
+  TestDefinitionWithParameter<void *, void *>(x, y, z);
+  TestDeclarationWithNoParameter<void *>();
+  TestDeclarationWithParameter<void *>(x, y, z);
   return 0;
 }

--- a/tests/parsing/typevariable/forany_parsing.c
+++ b/tests/parsing/typevariable/forany_parsing.c
@@ -10,7 +10,7 @@
 // expected-no-diagnostics
 
 // Testing for function declaration with function body, without parameters.
-_For_any(T) T TestDefinitionWithNoParameter() {
+_For_any(T) T TestDefinitionWithNoParameter(void) {
   // Testing the scope created by forany specifier contains function body scope
   T returnVal;
   return returnVal;
@@ -23,7 +23,7 @@ _For_any(T, S) T TestDefinitionWithParameter(T at, T bt, S cs) {
 }
 
 // Testing for function declaration without function body, without parameters.
-_For_any(R) R TestDeclarationWithNoParameter();
+_For_any(R) R TestDeclarationWithNoParameter(void);
 // Testing for function declaration without function body, with parameters
 _For_any(Q) Q TestDeclarationWithParameter(Q aq, Q bq, Q cq);
 

--- a/tests/parsing/typevariable/forany_parsing.c
+++ b/tests/parsing/typevariable/forany_parsing.c
@@ -1,0 +1,39 @@
+// Tests to make sure _For_any specifier is parsed correctly.
+//
+// More specifically, we are testing for correctness of _For_any specifier.
+// 1) _For_any specifier is correctly parsed along with new type polymorphism.
+// 2) _For_any specifier correctly enters a new scope and function declaration
+//    or definition is registered to a correct scope.
+// For this test file, we expect that there are no errors.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
+// expected-no-diagnostics
+
+// Testing for function declaration with function body, without parameters.
+_For_any(T) T TestDefinitionWithNoParameter() {
+  // Testing the scope created by forany specifier contains function body scope
+  T returnVal;
+  return returnVal;
+}
+
+// Testing for function declaration with function body, with parameters
+_For_any(T, S) T TestDefinitionWithParameter(T at, T bt, S cs) {
+  S newT = at;
+  return newT;
+}
+
+// Testing for function declaration without function body, without parameters.
+_For_any(R) R TestDeclarationWithNoParameter();
+// Testing for function declaration without function body, with parameters
+_For_any(Q) Q TestDeclarationWithParameter(Q aq, Q bq, Q cq);
+
+int callPolymorphicTypes() {
+  void *x, *y, *z;
+  // Testing to make sure function declaration is registered in decl scope
+  // outside of forany scope.
+  TestDefinitionWithNoParameter();
+  TestDefinitionWithParameter(x, y, z);
+  TestDeclarationWithNoParameter();
+  TestDeclarationWithParameter(x, y, z);
+  return 0;
+}

--- a/tests/parsing/typevariable/forany_parsing_error.c
+++ b/tests/parsing/typevariable/forany_parsing_error.c
@@ -8,9 +8,9 @@
 //
 // RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
 
-_For_any(R) R foo();
+_For_any(R) R foo(void);
 // Testing scope created by for any specifier is exited successfully.
 R thisShouldProduceError; //expected-error{{unknown type name 'R'}}
-_For_any() void foo2(); // expected-error{{expected type variable identifier}}
-_For_any(R, ) R foo3(); // expected-error{{expected type variable identifier}}
-_For_any(R T) R foo4(); // expected-error{{expected , or )}}
+_For_any() void foo2(void); // expected-error{{expected type variable identifier}}
+_For_any(R, ) R foo3(void); // expected-error{{expected type variable identifier}}
+_For_any(R T) R foo4(void); // expected-error{{expected , or )}}

--- a/tests/parsing/typevariable/forany_parsing_error.c
+++ b/tests/parsing/typevariable/forany_parsing_error.c
@@ -1,0 +1,16 @@
+// Tests to make sure _For_any errors are produced correctly.
+//
+// More specifically, we are testing for following errors.
+// 1) _For_any() must have type declaration in parenthesis.
+// 2) Make sure type declaration syntax error is caught.
+// 3) _For_any scope should be confined within function declaration.
+// For this test file, we expect that there are no errors.
+//
+// RUN: %clang_cc1 -fcheckedc-extension -S -emit-llvm -verify %s
+
+_For_any(R) R foo();
+// Testing scope created by for any specifier is exited successfully.
+R thisShouldProduceError; //expected-error{{unknown type name 'R'}}
+_For_any() void foo2(); // expected-error{{expected type variable identifier}}
+_For_any(R, ) R foo3(); // expected-error{{expected type variable identifier}}
+_For_any(R T) R foo4(); // expected-error{{expected , or )}}


### PR DESCRIPTION
With the introduction of type variable types in clang, it is important to make sure that generic functions are a FunctionProtoType. We did not allow generic functions to be FunctionNoProtoType. In order for the tests to work correctly, I had to add "void" in () if there are no parameters.