### PR TITLE
Correct Interface Type of free()

### DIFF
--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -53,7 +53,7 @@ void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
 void free(void *pointer : byte_count(1));
 void *malloc(size_t size) : byte_count(size);
-void *realloc(void *pointer  : itype(_Ptr<void>), size_t size) : byte_count(size);
+void *realloc(void *pointer : byte_count(1), size_t size) : byte_count(size);
 
 // TODO: strings
 // char *getenv(const char *n);

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -51,7 +51,7 @@ unsigned long long int strtoull(const char * restrict nptr,
 // TODO: express alignment constraints once where clauses have been added.
 void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
-void free(void *pointer : itype(_Ptr<void>));
+void free(void *pointer : byte_count(1));
 void *malloc(size_t size) : byte_count(size);
 void *realloc(void *pointer  : itype(_Ptr<void>), size_t size) : byte_count(size);
 

--- a/tests/typechecking/malloc_free.c
+++ b/tests/typechecking/malloc_free.c
@@ -1,0 +1,86 @@
+// Feature tests for type checking Checked C bounds-safe interface
+// type annotations.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang -fcheckedc-extension -fsyntax-only -Werror %s
+
+#include <stdchecked.h>
+#include <stdlib_checked.h>
+
+#pragma BOUNDS_CHECKED ON
+
+// Test you can always `free` a `malloc`d unchecked pointer
+void f1(void) unchecked {
+    int *x = malloc(sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `calloc`d unchecked pointer
+void f2(void) unchecked {
+    int *x = calloc(1, sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `realloc`d unchecked pointer
+void f3(void) unchecked {
+    int *x = malloc(sizeof(int));
+    int *y = realloc(x, 2 * sizeof(int));
+    free(y);
+}
+
+// Test you can always `free` a `aligned_alloc`d unchecked pointer
+void f4(void) unchecked {
+    int *x = aligned_alloc(_Alignof(int), sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `malloc`d ptr
+void f11(void) {
+    ptr<int> x = malloc(sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `calloc`d ptr
+void f12(void) {
+    ptr<int> x = calloc(1, sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `realloc`d ptr
+void f13(void) {
+    ptr<int> x = malloc(sizeof(int));
+    ptr<int> y = realloc(x, 2 * sizeof(int));
+    free(y);
+}
+
+// Test you can always `free` a `aligned_alloc`d ptr
+void f14(void) {
+    ptr<int> x = aligned_alloc(_Alignof(int), sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `malloc`d array_ptr
+void f21(void) {
+    array_ptr<int> x : count(4) = malloc(4 * sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `calloc`d array_ptr
+void f22(void) {
+    array_ptr<int> x : count(4) = calloc(4, sizeof(int));
+    free(x);
+}
+
+// Test you can always `free` a `realloc`d array_ptr
+void f23(void) {
+    array_ptr<int> x : count(4) = malloc(4 * sizeof(int));
+    array_ptr<int> y : count(8) = realloc(x, 8 * sizeof(int));
+    free(y);
+}
+
+// Test you can always `free` a `aligned_alloc`d ptr
+void f24(void) {
+    array_ptr<int> x : count(4) = aligned_alloc(_Alignof(int), 4 * sizeof(int));
+    free(x);
+}

--- a/tests/typechecking/malloc_free.c
+++ b/tests/typechecking/malloc_free.c
@@ -79,7 +79,7 @@ void f23(void) {
     free(y);
 }
 
-// Test you can always `free` a `aligned_alloc`d ptr
+// Test you can always `free` a `aligned_alloc`d array_ptr
 void f24(void) {
     array_ptr<int> x : count(4) = aligned_alloc(_Alignof(int), 4 * sizeof(int));
     free(x);


### PR DESCRIPTION
the `free` function is unique as it has to be polymorphic over all three pointer kinds, unchecked pointers, ptrs, and array_ptrs. 

There are several potential interface types for `free`. They are:
1. `void free(void* p);` No interface type. Doesn't work as no implicit casts between checked ptrs and unchecked ptrs)
1. `void free(void* p : itype(_Ptr<void>));` ptr interface type. Doesn't let you pass array_ptrs to `free`.
1. `void free(void* p : itype(_Array_ptr<void>));` array_ptr interface type. Doesn't let you pass ptrs to `free`, for complex (soon-to-be-relaxed) reasons involving banning casts involving checked pointers to void.
1. `void free(void* p : count(1))` relies on knowing the size of void which is potentially undefined (but 1 byte in clang).
1. `void free(void* p : byte_count(1));` Oddly enough, this is the correct type. When you cast a ptr to an array_ptr, there will be a check (usually static) that the pointer can reasonably point to something, and is in range. This says "yeah, we have to point to something, but it can be as little as 1 byte wide". This still requires casting from `Array_ptr<T>` to `array_ptr<void>`.

This changes free to use `byte_count(1)` in its itype. 