### PR TITLE
Update tests involving void pointers.

### DIFF
--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -734,8 +734,7 @@ extern void check_call_void(void) {
   // Expected to not typecheck
   f1_void(r, val);    // expected-error {{incompatible type}}
                       // param void *, arg int checked[10] not OK
-  f2_void(r, val);    // expected-error {{incompatible type}}
-                      // param ptr<void>, arg int checked[10] not OK
+  f2_void(r, val);    // param ptr<void>, arg int checked[10] OK
 
   // Try passing void pointers to functions expected array types
   // f1(int *, int)

--- a/tests/typechecking/function_casts.c
+++ b/tests/typechecking/function_casts.c
@@ -1,7 +1,7 @@
 // Unit tests for typechecking new Checked C function pointers
 //
 // The following line is for the LLVM test harness:
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -fcheckedc-extension -verify -verify-ignore-unexpected=note %s
 //
 
 #include <stdchecked.h>
@@ -37,6 +37,17 @@ ptr<int(int)> allowed_convert6 = ***f0;
 // Arbitrary Data is definitely not allowed
 ptr<int(int)> bad_convert1 = (int(*)(int))0xdeadbeef; // expected-error {{can only cast function names or null pointers to checked function pointer type '_Ptr<int (int)>'}}
 ptr<int(int)> bad_convert2 = (int(*)(int))g0;         // expected-error {{cast to checked function pointer type '_Ptr<int (int)>' from incompatible type 'float (float)'}}
+
+// Conversions of checked function pointers to/from void pointers are not allowed;
+void * void_unchecked_ptr1 = 0;
+ptr<void> void_ptr1 = 0;
+array_ptr<void> void_array_ptr1 = 0;
+
+ptr<int(int)> bad_convert3 = void_unchecked_ptr1; // expected-error {{incompatible type}}
+ptr<int(int)> bad_convert4 = void_ptr1;           // expected-error {{incompatible type}}
+ptr<int(int)> bad_convert5 = void_array_ptr1;     // expected-error {{incompatible type}}
+ptr<void> void_ptr2 = f0;                         // expected-error {{incompatible type}}
+array_ptr<void> void_array_ptr2 = f0;             // expected-error {{incompatible type}}
 
 // Now locally within a function body
 void local_convert(int(*f1)(int), ptr<int(int)> f2) {
@@ -89,6 +100,17 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   ptr<int(int)> bad_convert3 = *bad_f0;                 // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
   ptr<int(int)> bad_convert4 = ***bad_f0;               // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
 
+  // Conversions of checked function pointers to/from void pointers are not allowed;
+  void * void_unchecked_ptr1 = 0;
+  ptr<void> void_ptr1 = 0;
+  array_ptr<void> void_array_ptr1 = 0;
+
+  ptr<int(int)> bad_convert5 = void_unchecked_ptr1; // expected-error {{incompatible type}}
+  ptr<int(int)> bad_convert6 = void_ptr1;           // expected-error {{incompatible type}}
+  ptr<int(int)> bad_convert7 = void_array_ptr1;     // expected-error {{incompatible type}}
+  ptr<void> void_ptr2 = f0;                         // expected-error {{incompatible type}}
+  array_ptr<void> void_array_ptr2 = f0;             // expected-error {{incompatible type}}
+
   //
   // Casts in a Call
   //
@@ -126,6 +148,9 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   takes_safe(bad_f0);                  // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
   takes_safe(*bad_f0);                 // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
   takes_safe(***bad_f0);               // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
+
+  takes_safe(void_ptr1);        // expected-error {{incompatible type}}
+  takes_safe(void_array_ptr1);  // expected-error {{incompatible type}}
 
   //
   // Explicit User Casts
@@ -173,6 +198,8 @@ void local_convert(int(*f1)(int), ptr<int(int)> f2) {
   ptr<int(int)> bad_cast_2 = (ptr<int(int)>)(bad_f0);                  // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
   ptr<int(int)> bad_cast_3 = (ptr<int(int)>)(*bad_f0);                 // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
   ptr<int(int)> bad_cast_4 = (ptr<int(int)>)(***bad_f0);               // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
+  ptr<int(int)> bad_cast_5 = (ptr<int(int)>)(void_ptr1);               // expected-error {{cast to checked function pointer type '_Ptr<int (int)>' from incompatible checked pointer type '_Ptr<void>'}}
+  ptr<int(int)> bad_cast_6 = (ptr<int(int)>)(void_array_ptr1);         // expected-error {{cannot guarantee operand of cast to checked function pointer type '_Ptr<int (int)>' is a function pointer}}
 
   //
   // Weird Casts

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -228,16 +228,21 @@ void g4(array_ptr<float> ap : count(len), int len) {
 
 void g5(ptr<int> p) {
   f1_void(p);
+  f3_void(p, 1);
+  f4_void(p, sizeof(int));
 }
 
 void g6(array_ptr<int> ap : count(len), int len) {
+  if (len >= 1)
+    f1_void(ap);
   f3_void(ap, len);
-  f4_void(ap, len);
+  f4_void(ap, len * sizeof(int));
 }
 
 void g7(ptr<void> p) {
   f1(p); // expected-error {{incompatible type}}
   f1_void(p);
+  f4_void(p, 1);
 }
 
 void g8(array_ptr<void> ap : byte_count(len), int len) {

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -834,7 +834,7 @@ extern void check_call_void(void) {
     float fval = 0.0;
     int *p = 0;
     ptr<int> q = 0;
-    array_ptr<int> r = 0;
+    array_ptr<int> r : count(1) = 0;
 
     // TODO: s will need bounds information
     void *s = 0;
@@ -857,10 +857,8 @@ extern void check_call_void(void) {
                         // param void *, arg ptr<int> not OK
     f1_void(r, val);    // expected-error {{incompatible type}}
                         // param void *, arg array_ptr<int> not OK
-    f2_void(r, val);    // expected-error {{incompatible type}}
-                        // param ptr<void>, arg array_ptr<int> not OK
-    f3_void(q, val);    // expected-error {{incompatible type}}
-                        // param array_ptr<void>, arg ptr<int> not OK
+    f2_void(r, val);    // param ptr<void>, arg array_ptr<int> OK
+    f3_void(q, val);    // param array_ptr<void>, arg ptr<int> OK
 
     // Test different kinds of pointers where the parameter type is a pointer to void and the
     // referent type is a pointer to void
@@ -868,7 +866,7 @@ extern void check_call_void(void) {
     f2_void((void *) &val, val);  // param ptr<void>, arg void * OK
     f2_void(t, val);  // param ptr<void>, arg ptr<void OK
     f3_void(s, val);  // param array_ptr<void>, arg void * OK.
-    f3_void(u, val);  // param array_ptr<void< arg array_ptr<void OK.
+    f3_void(u, val);  // param array_ptr<void> arg array_ptr<void> OK.
 
     f1_void(t, val);  // expected-error {{incompatible type}}
     f1_void(u, val);  // expected-error {{incompatible type}}


### PR DESCRIPTION
- Update tests to allow conversions from any kind of checked pointer to
  any kind of checked void pointer (ptr<void> and array_ptr<void>).
- Test that implicit conversions between void pointers and checked function
  pointers are not allowed.  This is a common C extension that should
  not be allowed for checked function pointers.