### PR TITLE
Add variant of array_ptr for pointers to null-terminated arrays.

### DIFF
--- a/spec/bounds_safety/checkedc.tex
+++ b/spec/bounds_safety/checkedc.tex
@@ -82,6 +82,7 @@
 \newcommand{\ntarrayptrinst}[1]{\texttt{nt\_array\_ptr<#1>}}
 \newcommand{\ntarrayptrT}{\ntarrayptrinst{\var{T}}}
 \newcommand{\ntarrayptrchar}{\ntarrayptrinst{\texttt{char}}}
+\newcommand{\ntarrayptrvoid}{\ntarrayptrinst{\texttt{void}}}
 
 % use the name spanptr because span is already a command
 % in tex

--- a/spec/bounds_safety/checkedc.tex
+++ b/spec/bounds_safety/checkedc.tex
@@ -78,6 +78,11 @@
 \newcommand{\arrayptrint}{\arrayptrinst{\texttt{int}}}
 \newcommand{\arrayptrvoid}{\arrayptrinst{\texttt{void}}}
 
+\newcommand{\ntarrayptr}{\texttt{nt\_array\_ptr}}
+\newcommand{\ntarrayptrinst}[1]{\texttt{nt\_array\_ptr<#1>}}
+\newcommand{\ntarrayptrT}{\ntarrayptrinst{\var{T}}}
+\newcommand{\ntarrayptrchar}{\ntarrayptrinst{\texttt{char}}}
+
 % use the name spanptr because span is already a command
 % in tex
 \newcommand{\spanptr}{\texttt{span}}

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -52,7 +52,7 @@ lowercase versions of the keywords.  It is assumed
 that \keyword{checkedc.h} is included before examples.
 
 \section{New kinds of pointer types}
-New pointer types are added to C. Each pointer type can be
+Three new checked pointer types are added to C. Each pointer type can be
 used in place of `\texttt{*}':
 \begin{enumerate}
 \item
@@ -75,6 +75,9 @@ used in place of `\texttt{*}':
   bounds are checked at runtime if necessary. Pointer arithmetic can be
   done on these pointer types. The resulting pointers do not need to be
   in bounds.
+\item
+ \ntarrayptrT: this is a variant of \arrayptrT\ for null-terminated
+ arrays.  It is described in Section~\ref{section:nullterm-types}
 \end{enumerate}
 
 Unchecked C pointer types that use `\texttt{*}' and are unchecked in their
@@ -264,30 +267,41 @@ t2 x checked[10];  // error: mismatched checked properties
 \section{New types for null-terminated arrays}
 \label{section:nullterm-types}
 
-C has the notion of a null-terminated array.  This is a sequence of elements
-in memory that ends with a null terminator value.  We add a new type 
+C programmers are familiar with the concept of
+a null-terminated array.  This is a sequence of elements
+in memory that ends with a null terminator value.  We add a new type
 \ntarrayptrT\
 to represent pointers to these kinds of arrays.  We divide
 these arrays into two parts: a prefix with known bounds and
 a sequence of additional elements that ends
 with a null terminator.  The element type \var{T} of an \ntarrayptrT\ must be
 an integral or pointer type.   \ntarrayptrT\ extends \arrayptrT: the
-prefix is treated the same as if an \arrayptrT pointed to it.
+prefix is treated the same as if an \arrayptrT\ pointed to it.
+An \ntarrayptrT\ value can be converted to an \arrayptrT\ value
+with the same bounds.
 
 A programmer may declare bounds for an \ntarrayptr\ variable.
 If no bounds are declared, the prefix with known bounds is
 assumed to be a 0-element array.  In that case, the
-programmer is working directly with the sequence.  In
-fact, the common case for \ntarrayptr\ variables is that
-no bounds are declared.   Here is a declaration of a function that
-takes a null-terminated 
-character of arrays and counts it length:
+programmer is working directly with the sequence.
+The common case for \ntarrayptr\ variables is that
+no bounds are declared.
+
+Here is a declaration of a function that takes a null-terminated
+character of arrays and counts its length:
 \begin{verbatim}
 int compute_length(nt_array_ptr<char> s);
 \end{verbatim}
 
+% We haven't introduced checked scopes yet - need to put thissomehwere
+% else.
+%Conversion of \arrayptrT\ values to \ntarrayptrT\ values is
+%not allowed in checked code because it may be possible
+%to overwrite the null terminator value via the \arrayptrT\ value
+% or another \arrayptrT\ value.
+
 Modifiers can be applied to the reference type of
-an \ntarrayptr, just as they can be applied to the
+an \ntarrayptr, in the same way that they can be applied to the
 referent type of an \arrayptr.
 The function \verb+compute_length+
 should not modify the contents of a string. Here
@@ -295,32 +309,32 @@ is a version that uses \verb+const+ to declare that:
 \begin{verbatim}
 int compute_length(nt_array_ptrconst char> s);
 \end{verbatim}
-When values of \ntarrayptrT\ are use to read or write memory,
-they follow the same rules as \arrayptrT, except that bounds
+When values of \ntarrayptrT\ type are use to read or write memory,
+they follow the same rules as values of \arrayptrT\ type, except that bounds
 checking is extended to allow access to the first element
 of the sequence. It can always be read so that it can be
 determined whether it contains a null terminator.
 It can be written too,
 provided that it does not contain a null terminator.
 
-\ntarrayptr\ differs in some important ways from 
+\ntarrayptr\ differs in some important ways from
 \arrayptr. Even without a bounds declaration,
 there is guaranteed to be least one element of memory
 that is accessible.   For example, \verb+compute_length+
 can always read the character pointed to by \verb+s+, provided that
 \verb+s+ is not null.
 
-Just as \arrayptr\ has checked arrays, \ntarrayptr\ has
-checked null-terminated arrays.  These are useful
-for declaring  checked types for string constants. 
+Just as there are new checked array types for \arrayptr s,
+there are new checked null-terminated array types for \ntarrayptr s.
+These are useful for declaring  checked types for string constants.
 Null-terminated array types are declared using the
-\keyword{nt\_checked} instead of \keyword{checked} before
-the array dimensions:
+\keyword{nt\_checked} keyword before the array dimensions,
+instead of the \keyword{checked} keyword:
 \begin{verbatim}
 int arr nt_checked[10];
 \end{verbatim}
-\verb+nt_checked+ declares an array that is followed by a null 
-terminator.  The null terminator is {\em not} included in the 
+\verb+nt_checked+ declares an array that is followed by a null
+terminator.  The null terminator is {\em not} included in the
 the dimension size.
 
 Here is an example of a declaration of a checked null-terminated
@@ -330,11 +344,18 @@ char s nt_checked[5] = "hello";
 \end{verbatim}
 
 A \keyword{nt\_checked} array with a dimension \var{d} converts
-to a \ntarrayptr with \var{d} elements.   This means that programs
-can still read the element containing the null terminator.  However, 
-attempting to overwrite it is a runtime error.  The \verb+sizesof+
+to an \ntarrayptr\ with \var{d} elements.   This means that programs
+can still read the element containing the null terminator.  However,
+attempting to overwrite it is a runtime error.  The \verb+sizeof+
 operator applied to a null-terminated array includes the null
 terminator in the size computation.
+
+Because \ntarrayptr\ extends \arrayptr, the discussion and rules for
+\arrayptr\ in the rest of the specification usually apply to \ntarrayptr\
+too.  Most mentions of \arrayptr\ can usually be read as
+``\arrayptr\ or \ntarrayptr.''.  We omit the ``or \ntarrayptr'' clause
+for brevity. We discuss \ntarrayptr\ only when there is a difference between
+it and \arrayptr.
 
 \section{Operations involving pointer types}
 
@@ -343,11 +364,10 @@ The following operations involving pointer-typed values are allowed:
 \begin{itemize}
 \item
   Indirection: the \texttt{*} operator can be applied to a value of type
-  \var{T} \texttt{*}, \ptrT, \arrayptrT, or \ntarrayptrT.  It produces a
-  value of type \var{T}.
+  \var{T} \texttt{*}, \ptrT, or \arrayptrT. It produces a value of type \var{T}.
 \item
   Array reference: the \texttt{[]} operator can be applied to a
-  value of type \var{T} \texttt{*}, \arrayptrT, or \ntarrayptrT. It
+  value of type \var{T} \texttt{*} or \arrayptrT. It
   cannot be applied to a value of type \ptrT.
   \texttt{\var{e1}[\var{e2}]} is equivalent to
   \texttt{*(\var{e1} + \var{e2})}
@@ -355,7 +375,7 @@ The following operations involving pointer-typed values are allowed:
   Assignment: two pointers of the same type can be assigned.
 \item
   Adding or subtracting a pointer type and an integer. This is allowed
-  for \var{T} \texttt{*}, \arrayptrT, and \ntarrayptrT\ types.
+  for \var{T} \texttt{*} and \arrayptrT\ types.
 \item
   Pointers to objects of the same type can be compared for equality or
   inequality. The pointers do not have to be the same kind of pointer.
@@ -408,7 +428,7 @@ of type \var{T}, the following rules apply:
 If the type of an expression is ``checked array of
 \var{T}'', the type of the expression is altered to be
 \arrayptrT.  If the type of an expression is ``checked null-terminated
-array of \var{T}'', the type of the expression is altered to 
+array of \var{T}'', the type of the expression is altered to
 be \ntarrayptrT.
 
 Following existing C language rules, this alteration does not happen if
@@ -499,7 +519,7 @@ minimum value of a signed integer that can be added to an address shall
 be given by \texttt{INTPTR\_MIN}.
 
 For the new
-\arrayptrT\ and \ntarrayptrT\ pointer
+\arrayptrT\ pointer
 types, there are distinct operations for addition and subtraction of
 pointers by signed and unsigned integers. The operations behave
 similarly, but have different overflow conditions for scaling because
@@ -520,7 +540,7 @@ the ranges of signed integers and unsigned integers are different.
   shall produce a runtime error.
 \item
   \var{p} \texttt{+} \var{i}, where \var{p} is an
-  \arrayptrT\ or \ntarrayptrT\ pointer
+  \arrayptrT\ pointer
   and \var{i} is an integer. The integer \var{i} shall be scaled by
   \sizeof{\var{T}}, producing an integer \var{j}. The
   pointer \var{p} will be interpreted as an unsigned integer. The mathematical
@@ -529,7 +549,7 @@ the ranges of signed integers and unsigned integers are different.
   produce a runtime error.
 \item
   \var{i} \texttt{+} \var{p}, where \var{p} is an
-  \arrayptrT\ or \ntarrayptrT\ pointer
+  \arrayptrT\ pointer
   and \var{i} is an integer, shall be defined as \var{p} \texttt{+}
   \var{i}.
 \item
@@ -543,7 +563,7 @@ the ranges of signed integers and unsigned integers are different.
   operation shall produce a runtime error.
 \item
   \var{p} \texttt{-} \var{q}, where \var{p} and \var{q} are
-  \arrayptrT\ or \ntarrayptrT\
+  \arrayptrT\
   pointers. The two pointers will be interpreted as unsigned integers
   and the mathematical value \var{p} - \var{q} shall be computed,
   producing an integer \var{j}. If \var{j} is out of range for signed

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -52,7 +52,7 @@ lowercase versions of the keywords.  It is assumed
 that \keyword{checkedc.h} is included before examples.
 
 \section{New kinds of pointer types}
-Three new checked pointer types are added to C. Each pointer type can be
+New pointer types are added to C. Each pointer type can be
 used in place of `\texttt{*}':
 \begin{enumerate}
 \item
@@ -75,22 +75,6 @@ used in place of `\texttt{*}':
   bounds are checked at runtime if necessary. Pointer arithmetic can be
   done on these pointer types. The resulting pointers do not need to be
   in bounds.
-\item
-  \ntarrayptrT: this is an extension of \arrayptrT for
-  null-terminated arrays.  A variable of type \ntarrayptrT
-  points to an array that is followed by a sequence of
-  additional elements that ends with a null terminator.  The element type
-  \var{T} of an \ntarrayptrT must be an integral or pointer type.
-  The common case is that no bounds are declared for an \ntarrayptr\
-  variable.  In that case, the array is assumed to be a 0-element
-  array and the programmer is working directly with the sequence.
-  A programmer may declare bounds for an \ntarrayptr\ variable, though.
-  When values of \ntarrayptrT\ are use to read or write memory,
-  they follow the same rules as \arrayptrT, except that bounds
-  checking is extended to treat the element just past the end
-  of the array specially.  This is the first element of the
-  sequence; it can always be read and it can be written too,
-  provided that it does not contain a null terminator.
 \end{enumerate}
 
 Unchecked C pointer types that use `\texttt{*}' and are unchecked in their
@@ -119,12 +103,6 @@ ptr<int> q;
 array_ptr<int> s;
 \end{verbatim}
 
-This declares a function that takes a null-terminated character of arrays
-and counts it length:
-\begin{verbatim}
-int compute_length(nt_array_ptr<char> s);
-\end{verbatim}
-
 The new checked pointer types can have \keyword{const} and \keyword{volatile}
 modifiers, just like unchecked pointer types.   They can be applied to the type
 of the object to which the pointers points or to the pointer itself.  Here are examples
@@ -136,13 +114,6 @@ array_ptr<const int> r;
 \end{verbatim}
 A pointer to a constant integer cannot be used to modify the value of
 the integer.
-
-The function \verb+compute_length+ should not modify the contents of
-a string, so its parameter can be declared to be a pointer to constant
-characters:
-\begin{verbatim}
-int compute_length(nt_array_ptrconst char> s);
-\end{verbatim}
 
 Here are examples of constant pointers to modifiable integers:
 \begin{verbatim}
@@ -290,6 +261,81 @@ typedef int t2[10];
 t2 x checked[10];  // error: mismatched checked properties
 \end{verbatim}
 
+\section{New types for null-terminated arrays}
+\label{section:nullterm-types}
+
+C has the notion of a null-terminated array.  This is a sequence of elements
+in memory that ends with a null terminator value.  We add a new type 
+\ntarrayptrT\
+to represent pointers to these kinds of arrays.  We divide
+these arrays into two parts: a prefix with known bounds and
+a sequence of additional elements that ends
+with a null terminator.  The element type \var{T} of an \ntarrayptrT\ must be
+an integral or pointer type.   \ntarrayptrT\ extends \arrayptrT: the
+prefix is treated the same as if an \arrayptrT pointed to it.
+
+A programmer may declare bounds for an \ntarrayptr\ variable.
+If no bounds are declared, the prefix with known bounds is
+assumed to be a 0-element array.  In that case, the
+programmer is working directly with the sequence.  In
+fact, the common case for \ntarrayptr\ variables is that
+no bounds are declared.   Here is a declaration of a function that
+takes a null-terminated 
+character of arrays and counts it length:
+\begin{verbatim}
+int compute_length(nt_array_ptr<char> s);
+\end{verbatim}
+
+Modifiers can be applied to the reference type of
+an \ntarrayptr, just as they can be applied to the
+referent type of an \arrayptr.
+The function \verb+compute_length+
+should not modify the contents of a string. Here
+is a version that uses \verb+const+ to declare that:
+\begin{verbatim}
+int compute_length(nt_array_ptrconst char> s);
+\end{verbatim}
+When values of \ntarrayptrT\ are use to read or write memory,
+they follow the same rules as \arrayptrT, except that bounds
+checking is extended to allow access to the first element
+of the sequence. It can always be read so that it can be
+determined whether it contains a null terminator.
+It can be written too,
+provided that it does not contain a null terminator.
+
+\ntarrayptr\ differs in some important ways from 
+\arrayptr. Even without a bounds declaration,
+there is guaranteed to be least one element of memory
+that is accessible.   For example, \verb+compute_length+
+can always read the character pointed to by \verb+s+, provided that
+\verb+s+ is not null.
+
+Just as \arrayptr\ has checked arrays, \ntarrayptr\ has
+checked null-terminated arrays.  These are useful
+for declaring  checked types for string constants. 
+Null-terminated array types are declared using the
+\keyword{nt\_checked} instead of \keyword{checked} before
+the array dimensions:
+\begin{verbatim}
+int arr nt_checked[10];
+\end{verbatim}
+\verb+nt_checked+ declares an array that is followed by a null 
+terminator.  The null terminator is {\em not} included in the 
+the dimension size.
+
+Here is an example of a declaration of a checked null-terminated
+array type for a string constant:
+\begin{verbatim}
+char s nt_checked[5] = "hello";
+\end{verbatim}
+
+A \keyword{nt\_checked} array with a dimension \var{d} converts
+to a \ntarrayptr with \var{d} elements.   This means that programs
+can still read the element containing the null terminator.  However, 
+attempting to overwrite it is a runtime error.  The \verb+sizesof+
+operator applied to a null-terminated array includes the null
+terminator in the size computation.
+
 \section{Operations involving pointer types}
 
 The following operations involving pointer-typed values are allowed:
@@ -297,10 +343,11 @@ The following operations involving pointer-typed values are allowed:
 \begin{itemize}
 \item
   Indirection: the \texttt{*} operator can be applied to a value of type
-  \var{T} \texttt{*}, \ptrT, or \arrayptrT. It produces a value of type \var{T}.
+  \var{T} \texttt{*}, \ptrT, \arrayptrT, or \ntarrayptrT.  It produces a
+  value of type \var{T}.
 \item
   Array reference: the \texttt{[]} operator can be applied to a
-  value of type \var{T} \texttt{*} or \arrayptrT. It
+  value of type \var{T} \texttt{*}, \arrayptrT, or \ntarrayptrT. It
   cannot be applied to a value of type \ptrT.
   \texttt{\var{e1}[\var{e2}]} is equivalent to
   \texttt{*(\var{e1} + \var{e2})}
@@ -308,7 +355,7 @@ The following operations involving pointer-typed values are allowed:
   Assignment: two pointers of the same type can be assigned.
 \item
   Adding or subtracting a pointer type and an integer. This is allowed
-  for \var{T} \texttt{*} and \arrayptrT types.
+  for \var{T} \texttt{*}, \arrayptrT, and \ntarrayptrT\ types.
 \item
   Pointers to objects of the same type can be compared for equality or
   inequality. The pointers do not have to be the same kind of pointer.
@@ -356,27 +403,13 @@ of type \var{T}, the following rules apply:
   \texttt{*}.
 \end{itemize}
 
-If the \texttt{\&} operator is applied to an lvalue expression that is a
-dereference of a pointer or an array that has bounds checking, the
-bounds check will be done when the address is taken. This guarantees
-that it is valid to dereference the pointer that results from the
-address-of operator. For example, in the following code, bounds checks
-will be done at \texttt{\&a[i]} and \texttt{\&b[0]}.
-
-\begin{verbatim}
-int a checked[10];
-array_ptr<int> b;
-int i;
-...
-ptr<int> y = &a[i];
-ptr<int> z = &b[0];
-\end{verbatim}
-
 \subsection{Rules for conversion of checked array types to pointer types}
 
-If the type of an expression or a subexpression is ``checked array of
+If the type of an expression is ``checked array of
 \var{T}'', the type of the expression is altered to be
-\arrayptrT.
+\arrayptrT.  If the type of an expression is ``checked null-terminated
+array of \var{T}'', the type of the expression is altered to 
+be \ntarrayptrT.
 
 Following existing C language rules, this alteration does not happen if
 the expression is an operand of an address-of operator, \texttt{++},
@@ -385,7 +418,7 @@ operator or the `\texttt{.}' operator. The prohibition against this
 conversion occurring for operands of the address-of operator gives the
 results of the operator a more precise type. For sizeof, it also results
 in a more precise answer. The prohibitions against it for \texttt{++}, and
-\texttt{--} operands and the left operand of an assignment operato keeps array
+\texttt{--} operands and the left operand of an assignment operator keeps array
 variables from being modifiable.
 
 \subsection{Variable and member initialization}
@@ -466,7 +499,7 @@ minimum value of a signed integer that can be added to an address shall
 be given by \texttt{INTPTR\_MIN}.
 
 For the new
-\arrayptrT\ pointer
+\arrayptrT\ and \ntarrayptrT\ pointer
 types, there are distinct operations for addition and subtraction of
 pointers by signed and unsigned integers. The operations behave
 similarly, but have different overflow conditions for scaling because
@@ -487,7 +520,7 @@ the ranges of signed integers and unsigned integers are different.
   shall produce a runtime error.
 \item
   \var{p} \texttt{+} \var{i}, where \var{p} is an
-  \arrayptrT\ pointer
+  \arrayptrT\ or \ntarrayptrT\ pointer
   and \var{i} is an integer. The integer \var{i} shall be scaled by
   \sizeof{\var{T}}, producing an integer \var{j}. The
   pointer \var{p} will be interpreted as an unsigned integer. The mathematical
@@ -496,7 +529,7 @@ the ranges of signed integers and unsigned integers are different.
   produce a runtime error.
 \item
   \var{i} \texttt{+} \var{p}, where \var{p} is an
-  \arrayptrT\ pointer
+  \arrayptrT\ or \ntarrayptrT\ pointer
   and \var{i} is an integer, shall be defined as \var{p} \texttt{+}
   \var{i}.
 \item
@@ -510,7 +543,7 @@ the ranges of signed integers and unsigned integers are different.
   operation shall produce a runtime error.
 \item
   \var{p} \texttt{-} \var{q}, where \var{p} and \var{q} are
-  \arrayptrT\
+  \arrayptrT\ or \ntarrayptrT\
   pointers. The two pointers will be interpreted as unsigned integers
   and the mathematical value \var{p} - \var{q} shall be computed,
   producing an integer \var{j}. If \var{j} is out of range for signed
@@ -1192,7 +1225,7 @@ signed integer overflow:
 \end{itemize}
 
 In the case of a runtime error, program execution cannot continue in a
-way the uses the value of the expression that produced the error.
+way that uses the value of the expression that produced the error.
 
 For programs with expressions and initializers with undefined meanings,
 those programs must be rejected at translation-time. 

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -295,9 +295,10 @@ than expected and it may make it difficult to understand
 failures.
 To avoid these problems, we require that memory accesses
 using inferred bounds be provably in-range at compile time.
-To make it provable, pointer arithmetic is limited to
-pointer variables plus constant offsets.  This is enough
-to handle simple cases such as:
+At a minimum, the proof system should support local
+reasoning about widened bounds involving pointer
+variables with constant offsets.
+This is enough to handle simple cases such as:
 \begin{verbatim}
 nt_array_ptr<char> p = ...
 if (*p == 'a')
@@ -317,7 +318,7 @@ array of characters and counts its length:
 int compute_length(nt_array_ptr<char> s);
 \end{verbatim}
 
-% We haven't introduced checked scopes yet - need to put thissomehwere
+% We haven't introduced checked scopes yet - need to put this somehwere
 % else.
 %Conversion of \arrayptrT\ values to \ntarrayptrT\ values is
 %not allowed in checked code because it may be possible
@@ -331,7 +332,7 @@ The function \verb+compute_length+
 should not modify the contents of a string. Here
 is a version that uses \verb+const+ to declare that:
 \begin{verbatim}
-int compute_length(nt_array_ptrconst char> s);
+int compute_length(nt_array_ptr<const char> s);
 \end{verbatim}
 
 Just as there are new checked array types for \arrayptr s,

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -272,23 +272,47 @@ a null-terminated array.  This is a sequence of elements
 in memory that ends with a null terminator value.  We add a new type
 \ntarrayptrT\
 to represent pointers to these kinds of arrays.  We divide
-these arrays into two parts: a prefix with known bounds and
+these arrays into two parts: a prefix with bounds and
 a sequence of additional elements that ends
-with a null terminator.  The element type \var{T} of an \ntarrayptrT\ must be
+with a null terminator.  The initial elements of the 
+sequence can be read, providing that preceding elements
+are not the null terminator.  The bounds can be 
+{\em widened} based on the number of elements read.
+
+A programmer may declare bounds for an \ntarrayptr\ variable.  If bounds
+are declared, they are used to check that accesses to memory are in range
+at runtime.
+
+If no bounds are declared, the bounds are inferred.  At variable declarations,
+the declared bounds are for arrays with 0 elements.  At variable uses, 
+the bounds are determined using a program analysis that widens
+bounds based on control-flow.
+The bounds are then used to check memory accesses.
+A problem with using an analysis to determine bounds
+is that the bounds are not written down in the program. 
+This may lead to unexpected failures if the bounds are narrower
+than expected and it may make it difficult to understand
+failures.
+To avoid these problems, we require that memory accesses
+using inferred bounds be provably in-range at compile time.
+To make it provable, pointer arithmetic is limited to
+pointer variables plus constant offsets.  This is enough
+to handle simple cases such as:
+\begin{verbatim}
+nt_array_ptr<char> p = ...
+if (*p == 'a')
+ if (*(p + 1) == 'b')
+   if (*(p + 2) == 'c')
+\end{verbatim}
+   
+The element type \var{T} of an \ntarrayptrT\ must be
 an integral or pointer type.   \ntarrayptrT\ extends \arrayptrT: the
-prefix is treated the same as if an \arrayptrT\ pointed to it.
-An \ntarrayptrT\ value can be converted to an \arrayptrT\ value
+prefix with bounds is treated the same as if an \arrayptrT\ pointed 
+to it. An \ntarrayptrT\ value can be converted to an \arrayptrT\ value
 with the same bounds.
 
-A programmer may declare bounds for an \ntarrayptr\ variable.
-If no bounds are declared, the prefix with known bounds is
-assumed to be a 0-element array.  In that case, the
-programmer is working directly with the sequence.
-The common case for \ntarrayptr\ variables is that
-no bounds are declared.
-
 Here is a declaration of a function that takes a null-terminated
-character of arrays and counts its length:
+array of characters and counts its length:
 \begin{verbatim}
 int compute_length(nt_array_ptr<char> s);
 \end{verbatim}
@@ -309,20 +333,6 @@ is a version that uses \verb+const+ to declare that:
 \begin{verbatim}
 int compute_length(nt_array_ptrconst char> s);
 \end{verbatim}
-When values of \ntarrayptrT\ type are use to read or write memory,
-they follow the same rules as values of \arrayptrT\ type, except that bounds
-checking is extended to allow access to the first element
-of the sequence. It can always be read so that it can be
-determined whether it contains a null terminator.
-It can be written too,
-provided that it does not contain a null terminator.
-
-\ntarrayptr\ differs in some important ways from
-\arrayptr. Even without a bounds declaration,
-there is guaranteed to be least one element of memory
-that is accessible.   For example, \verb+compute_length+
-can always read the character pointed to by \verb+s+, provided that
-\verb+s+ is not null.
 
 Just as there are new checked array types for \arrayptr s,
 there are new checked null-terminated array types for \ntarrayptr s.
@@ -336,26 +346,25 @@ int arr nt_checked[10];
 \verb+nt_checked+ declares an array that is followed by a null
 terminator.  The null terminator is {\em not} included in the
 the dimension size.
-
 Here is an example of a declaration of a checked null-terminated
 array type for a string constant:
 \begin{verbatim}
 char s nt_checked[5] = "hello";
 \end{verbatim}
 
-A \keyword{nt\_checked} array with a dimension \var{d} converts
+An \keyword{nt\_checked} array with a dimension \var{d} converts
 to an \ntarrayptr\ with \var{d} elements.   This means that programs
 can still read the element containing the null terminator.  However,
 attempting to overwrite it is a runtime error.  The \verb+sizeof+
 operator applied to a null-terminated array includes the null
 terminator in the size computation.
 
+\subsection{\ntarrayptr\ usually follows the rules for \arrayptr}
 Because \ntarrayptr\ extends \arrayptr, the discussion and rules for
 \arrayptr\ in the rest of the specification usually apply to \ntarrayptr\
 too.  Most mentions of \arrayptr\ can usually be read as
-``\arrayptr\ or \ntarrayptr.''.  We omit the ``or \ntarrayptr'' clause
-for brevity. We discuss \ntarrayptr\ only when there is a difference between
-it and \arrayptr.
+``\arrayptr\ or \ntarrayptr.''.  We discuss \ntarrayptr\ only when
+there is a difference between it and \arrayptr.
 
 \section{Operations involving pointer types}
 

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -22,7 +22,8 @@ capital letter are reserved for system use, as are identifiers that
 begin with two underscores \cite[Section 7.1.3]{ISO2011}. The following
 new keywords are introduced:
 \begin{verbatim}
-_Array_ptr  _Checked  _Dynamic_check  _Ptr  _Where  _Unchecked
+_Array_ptr  _Checked  _Dynamic_check  _Nt_Array_ptr  _Nt_checked  _Ptr
+_Where  _Unchecked
 \end{verbatim}
 
 It is desirable to have all-lowercase versions of the
@@ -37,7 +38,8 @@ the implementations of standard header files need to be modified to
 not use identifiers that conflict with these keywords.
 The all-lowercase versions of the keywords are:
 \begin{verbatim}
-array_ptr  checked  dynamic_check  ptr  where  unchecked
+array_ptr  checked  dynamic_check  nt_array_ptr  nt_checked  ptr
+where  unchecked
 \end{verbatim}
 
 The pattern of using an identifier reserved for system use coupled with
@@ -50,7 +52,7 @@ lowercase versions of the keywords.  It is assumed
 that \keyword{checkedc.h} is included before examples.
 
 \section{New kinds of pointer types}
-Two new checked pointer types are added to C. Each pointer type can be
+Three new checked pointer types are added to C. Each pointer type can be
 used in place of `\texttt{*}':
 \begin{enumerate}
 \item
@@ -73,6 +75,22 @@ used in place of `\texttt{*}':
   bounds are checked at runtime if necessary. Pointer arithmetic can be
   done on these pointer types. The resulting pointers do not need to be
   in bounds.
+\item
+  \ntarrayptrT: this is an extension of \arrayptrT for
+  null-terminated arrays.  A variable of type \ntarrayptrT
+  points to an array that is followed by a sequence of
+  additional elements that ends with a null terminator.  The element type
+  \var{T} of an \ntarrayptrT must be an integral or pointer type.
+  The common case is that no bounds are declared for an \ntarrayptr\
+  variable.  In that case, the array is assumed to be a 0-element
+  array and the programmer is working directly with the sequence.
+  A programmer may declare bounds for an \ntarrayptr\ variable, though.
+  When values of \ntarrayptrT\ are use to read or write memory,
+  they follow the same rules as \arrayptrT, except that bounds
+  checking is extended to treat the element just past the end
+  of the array specially.  This is the first element of the
+  sequence; it can always be read and it can be written too,
+  provided that it does not contain a null terminator.
 \end{enumerate}
 
 Unchecked C pointer types that use `\texttt{*}' and are unchecked in their
@@ -101,6 +119,12 @@ ptr<int> q;
 array_ptr<int> s;
 \end{verbatim}
 
+This declares a function that takes a null-terminated character of arrays
+and counts it length:
+\begin{verbatim}
+int compute_length(nt_array_ptr<char> s);
+\end{verbatim}
+
 The new checked pointer types can have \keyword{const} and \keyword{volatile}
 modifiers, just like unchecked pointer types.   They can be applied to the type
 of the object to which the pointers points or to the pointer itself.  Here are examples
@@ -112,6 +136,13 @@ array_ptr<const int> r;
 \end{verbatim}
 A pointer to a constant integer cannot be used to modify the value of
 the integer.
+
+The function \verb+compute_length+ should not modify the contents of
+a string, so its parameter can be declared to be a pointer to constant
+characters:
+\begin{verbatim}
+int compute_length(nt_array_ptrconst char> s);
+\end{verbatim}
 
 Here are examples of constant pointers to modifiable integers:
 \begin{verbatim}

--- a/spec/bounds_safety/introduction.tex
+++ b/spec/bounds_safety/introduction.tex
@@ -62,10 +62,12 @@ Checked C addresses the bounds checking problem for C by:
 \item
   Introducing different pointer types to capture the different ways in
   which pointers are used. The unchecked C pointer type \texttt{*} is kept
-  and two new {\it checked} pointer types are added: one for pointers that
-  are never used in pointer arithmetic and do not need bounds checking (\ptr)
-  and one for \emph{array pointer types} that are involved in pointer
-  arithmetic and need bounds checking (\arrayptr).
+  and three new {\it checked} pointer types are added: one for pointers
+  that are never used in pointer arithmetic and do not need bounds
+  checking (\ptr),  one for \emph{array pointer types} that are involved
+  in pointer arithmetic and need bounds checking (\arrayptr), and one
+  for \emph{array pointer types where the array is null-terminated}
+  (\ntarrayptr).
 \item
   For array pointer types (\arrayptr), in keeping with the low-level
   nature of C,  bounds checking is placed under programmer control. 
@@ -80,19 +82,30 @@ Checked C addresses the bounds checking problem for C by:
   bounds information properly. The bounds are used at runtime to enforce
   bounds safety, if necessary.
 \item
+  Null-terminated array types (\ntarrayptr) extend 
+  array pointer types.  An \ntarrayptr\ variable points to
+  an array that is followed in memory by a sequence of elements
+  that ends with a null terminator.  The runtime bounds checking
+  and the static checking are extended to handle the sequence.
+  This allows C string-processing code to be bounds checked.
+\item
   Introducing different array types to distinguish between arrays whose
   accesses are bounds-checked and existing C arrays whose accesses are
   not bounds-checked. A programmer places the modifier \keyword{checked}
   before the declaration of the bound(s) of the array: \texttt{int x
   checked[5][5]} declares a 2-dimensional array for which all
-  accesses will be bounds-checked.
+  accesses will be bounds-checked.  Arrays with null terminators
+  as their last element can be declared using \keyword{nt\_checked}
+  instead of \keyword{checked}.
 \item
   For structure types with \arrayptr -typed members, a
   programmer declares \emph{member bounds} for those members. A member
   bounds declares the bounds for a member in terms of members of the
   structure type. Member bounds can be suspended temporarily for
   specific variables and objects. Static checking ensures that updates
-  to members maintain the member bounds.
+  to members maintain the member bounds.   A programmer may declare
+  bounds for \ntarrayptr -typed embers also, although that is often
+  not necessary.
 \item
   Introducing bounds-safe interfaces to address the problem of
   interoperation between checked code and unchecked code. A bounds-safe
@@ -147,7 +160,7 @@ check this information.
 To simplify bounds and reasoning about bounds for
 \arrayptr\ types, pointer arithmetic overflow for \arrayptr\
 types is considered a runtime error. Pointer arithmetic involving a null
-pointer for \arrayptr\ types is also a runtime error.
+pointer for \arrayptr\ or \ntarrayptr types is also a runtime error.
 
 Efficiency is addressed by extending the static checking so that it can
 guarantee that specific bounds checks will always succeed at runtime for

--- a/spec/bounds_safety/introduction.tex
+++ b/spec/bounds_safety/introduction.tex
@@ -65,9 +65,8 @@ Checked C addresses the bounds checking problem for C by:
   and three new {\it checked} pointer types are added: one for pointers
   that are never used in pointer arithmetic and do not need bounds
   checking (\ptr),  one for \emph{array pointer types} that are involved
-  in pointer arithmetic and need bounds checking (\arrayptr), and one
-  for \emph{array pointer types where the array is null-terminated}
-  (\ntarrayptr).
+  in pointer arithmetic and need bounds checking (\arrayptr), and an
+  extension to \arrayptr for null-terminated arrays (\ntarrayptr).
 \item
   For array pointer types (\arrayptr), in keeping with the low-level
   nature of C,  bounds checking is placed under programmer control. 
@@ -80,14 +79,6 @@ Checked C addresses the bounds checking problem for C by:
   operators such as addition, subtraction, and address-of (\texttt{\&})
   operators. Static checking ensures that programs declare and maintain
   bounds information properly. The bounds are used at runtime to enforce
-  bounds safety, if necessary.
-\item
-  Null-terminated array types (\ntarrayptr) extend 
-  array pointer types.  An \ntarrayptr\ variable points to
-  an array that is followed in memory by a sequence of elements
-  that ends with a null terminator.  The runtime bounds checking
-  and the static checking are extended to handle the sequence.
-  This allows C string-processing code to be bounds checked.
 \item
   Introducing different array types to distinguish between arrays whose
   accesses are bounds-checked and existing C arrays whose accesses are
@@ -103,9 +94,7 @@ Checked C addresses the bounds checking problem for C by:
   bounds declares the bounds for a member in terms of members of the
   structure type. Member bounds can be suspended temporarily for
   specific variables and objects. Static checking ensures that updates
-  to members maintain the member bounds.   A programmer may declare
-  bounds for \ntarrayptr -typed embers also, although that is often
-  not necessary.
+  to members maintain the member bounds.
 \item
   Introducing bounds-safe interfaces to address the problem of
   interoperation between checked code and unchecked code. A bounds-safe
@@ -160,7 +149,7 @@ check this information.
 To simplify bounds and reasoning about bounds for
 \arrayptr\ types, pointer arithmetic overflow for \arrayptr\
 types is considered a runtime error. Pointer arithmetic involving a null
-pointer for \arrayptr\ or \ntarrayptr types is also a runtime error.
+pointer for \arrayptr\ types is also a runtime error.
 
 Efficiency is addressed by extending the static checking so that it can
 guarantee that specific bounds checks will always succeed at runtime for

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -72,7 +72,8 @@ Section~\ref{section:non-modifying-expressions}  describes
 non-modifying expressions in detail.
 
 In a bounds declaration of the form \boundsdecl{\var{x}}{\var{bounds-exp}},
-\var{x} can have an \arrayptr\ or a checked array type.
+\var{x} can have an \arrayptr\, \ntarrayptr\,  checked array type, or
+checked null-terminated array type.
 For the form  \boundsdecl{\var{x}}{\boundscount{\var{e1}}},  the type of
 \var{x} cannot be \arrayptrvoid\ and the type of \var{e1} must be an integral type.
 The usual C integer conversions are applied to \var{e1}.\footnote{If the
@@ -87,21 +88,22 @@ This is useful for describing the results of casts and
 bounds for \arrayptrvoid\ pointers.
 
 For any variable with a bounds declaration, the variable must be
-non-null when memory is accessed There is no requirement that an
-\arrayptr\ variable stay within its bounds. The requirement is
-that the \arrayptr\ variable can only be dereferenced if it is
-in bounds. This avoids bound checks on pointer arithmetic.
+non-null when memory is accessed.  There is no requirement that an
+\arrayptr\ or \ntarrayptr\ variable stay within its bounds. The requirement 
+is that the \arrayptr\ or \ntarrayptr variable can only be dereferenced if it
+is in bounds. This avoids bound checks on pointer arithmetic.
 
 Count expressions have limits on their ranges to prevent signed integer
 overflow and unsigned integer wraparound from affecting size
 computations. Section~\ref{section:integer-overflow-informal}
 explains these limits in detail. The limits
-depend on the element type of the \arrayptr\ and the type of the count
+depend on the element type of the \arrayptr\ or \ntarrayptr\ 
+and the type of the count
 expression. For \boundsdecl{\var{x}}{\boundscount{\var{e1}}}, where \var{x}
-has type \arrayptrT ,
+has type \arrayptrT or \ntarrayptrT,
 \var{e1} must be greater than or equal to 0. \var{e1} must be less
 than the maximum number of an
-\arrayptrT\ elements
+\arrayptrT\ or \ntarrayptrT\ elements
 that can be indexed by an integer whose type matches that of \var{e1}.
 A bounds declaration \boundsdecl{\var{x}}{\boundscount{\var{e1}}} is an
 abbreviation for \boundsdecl{\var{x}}{\bounds{\var{x}}{\var{x} \texttt{+} \var{e1}}} with additional conditions that \var{e1}
@@ -113,7 +115,7 @@ abbreviation for \boundsdecl{\var{x}}{\bounds{\var{x}}{\var{x} \texttt{+} \var{e
 The conditions may require programmers to add additional checks at memory allocations
 to show that \var{e1} is in range. However, the conditions have advantages too.
 They provide scaffolding for proving that expressions based on
-element counts of \arrayptr\ variables do not overflow or wraparound.
+element counts of \arrayptr\ or \ntarrayptr\ variables do not overflow or wraparound.
 
 The meaning and correctness of bounds are based on the C semantics for
 pointers and pointer arithmetic. At runtime, any non-null pointer in C
@@ -564,28 +566,46 @@ must be the identifier \texttt{any} or the identifier \texttt{none}.
 \section{Insertion of bounds checks at pointer dereferences}
 
 \label{section:bounds-checking-indirections}
-
-Given *\var{e1}, where \var{e1} is an expression of type
+The semantics of C expressions is subtle.  The expression
+\texttt{*\var{e1}} does not dereference memory.  It
+produces an lvalue that can be used to access memory. If the expression
+occurs on the left-hand side of an assigment, the memory pointed to
+by the lvalue is updated with the value of the right-hand side of
+the assignment.
+For example, given \texttt{*\var{e1} = \var{e2}},
+the memory pointed to by the lvalue is updated with the value of \var{e2}.
+If the expression occurs within another expression, the lvalue is usually 
+(but not always)  used to read memory.  In the terminology of the C Standard,
+an lvalue conversion is inserted that reads memory. For example, given \texttt{*\var{e1} + 5},
+an lvalue conversion is inserted for \texttt{*\var{e1}}.  A case where a
+conversion is not inserted is  when the address of an expression is taken:
+\texttt{\&*\var{e1}}. Subscript expression behave similarly to pointer
+dereference expressions.  The expression \texttt{\var{e1}{[\var{e2}]}} produces
+an lvalue that can be used to access memory.
+ 
+A bounds check is inserted at a dereference expression or subscript expression 
+of an \arrayptr\ or \ntarrayptr\ whose result will be used to directly
+access mmemory (the result must be used by the left-hand side of an
+assignment or an lvalue conversion).
+Given \texttt{*\var{e1}}, where \var{e1} is an expression of type
 \arrayptr, the compiler determines the bounds for \var{e1}
 following the rules in Section~\ref{section:inferring-expression-bounds}.
 Special rules are followed in
 \texttt{bundled} blocks to determine the bounds for \var{e1}. The
-compiler inserts checks before the memory pointed to by \var{e1} is
-read or written that \var{e1} is non-null and that the value of
-\var{e1} is in bounds.
+compiler inserts the bounds check as part of the evaluation of \var{*e1}.
+The bound check is inserted after \var{e1} is evaluated and before the result of
+\var{*e1} is produced.  The compiler also inserts a null check.
 
-If \boundsinfer{\var{e1}}{\bounds{\var{e2}}{\var{e3}}},
-the compiler inserts a runtime check that \texttt{\var{e2} <= \var{e1} \&\&
-\var{e1} < \var{e3}}. If the runtime check fails, the program
+If {\var{e1}} has {\bounds{\var{e2}}{\var{e3}}}, the compiler
+computes \var{e1} to a temporary \var{t}.   The compiler inserts a runtime check that
+\texttt{\var{e2} <= \var{t} \&\&
+\var{t} < \var{e3}}. If the runtime check fails, the program
 will be terminated by the runtime system or in, systems that support it,
-a runtime exception will be raised.   If \boundsinfer{\var{e1}}{\boundscount{\var{e2}}},
-this is expanded to \boundsinfer{\var{e1}}{\bounds{\var{e1}}{\var{e1} + \var{e2}}}
-before inserting checks.  Of course a temporary variable would be used to hold the
-value of \var{e1}.
+a runtime exception will be raised.   If {\var{e1}} has bounds {\boundscount{\var{e2}}},
+the bounds are expanded to \bounds{\var{t}}{\var{t} + \var{e2}} before inserting a check.
 
-Consider as an example, \verb|z = *x;| where 
-\verb|x : bounds(x, x + c)|. The compiler will produce code of the form
-
+Consider as an example \verb|z = *x;| where 
+\verb|x| has \verb|bounds(x, x + c)|. The compiler will produce code equivalent to:
 \begin{quote}
 \begin{verbatim}
 dynamic_check(x != null);
@@ -602,29 +622,71 @@ Now suppose pointer arithmetic is involved and \texttt{z = *(x + 5)}. The
 bounds of \texttt{x + 5} will be the same as the bounds of \texttt{x}.
 The expression \texttt{x + 5} must point into the same object as
 \texttt{x} for this to be a valid memory access. This means that
-\boundsdecl{\texttt{x + 5}}{\bounds{\texttt{x}}{\texttt{x + c}}}.
-The compiler will produce code of the form:
+{\texttt{x + 5}} has {\bounds{\texttt{x}}{\texttt{x + c}}}.
+The compiler will produce code equivalent to:
 
 \begin{quote}
 \begin{verbatim}
 dynamic_check(x != null);
 t1 = x + 5;
-dynamic_check(t1 != null && x <= t1 && t1 < x + c);
+dynamic_check(t1 != null)
+dynamic_check(x <= t1 && t1 < x + c);
 z = *t1;
 \end{verbatim}
 \end{quote}
 
-Array subscripting works as expected. For \texttt{e1[e2]}, the
-compiler computes the bounds of \texttt{e1}. The compiler inserts
-runtime checks that \texttt{e1 + e2} is within this bounds. For example,
-given \verb|x[5]| where \verb|x : bounds(x, x + c)|, the
+Array subscripting works as expected. For \texttt{\var{e1}[\var{e2}]}, the
+compiler inserts bounds checks if the result of \texttt{\var{e1}[\var{e2}]}
+is used to access memory.   The compiler computes the bounds of
+\texttt{e1}. The compiler inserts
+runtime checks that \texttt{\var{e1} + \var{e2}} is within this bounds as
+part of the evaluation of \texttt{\var{e1}[\var{e2}]} For example,
+given \verb|x[5]| where \verb|x| has \verb|bounds(x, x + c)|, the
 compiler inserts runtime checks that \verb|x <= x + 5 < x + c|. 
 The runtime checks simplify to \verb|5 < c|.
 
-\subsection{Evaluation of bounds at bounds checks}
+For a multi-dimensional array access, only one bounds check is done.
+The check ensures that the memory access is within the bounds of the entire multi-dimensional
+array.  Given \texttt{\var{e1}[\var{e2}][e3]}, the expression \texttt{\var{e1}[\var{e2}]} is
+evaluated.  However, \texttt{\var{e1}[\var{e2}]} has array type, so no lvalue
+conversion is inserted. That means that no bounds check is inserted:
+\texttt{\var{e1}[\var{e2}]} becomes pointer arithmetic.  The bounds check
+is inserted as part of the subscript operation involving \var{e3}. 
 
-The preceding example raises a subtle point, which is when bounds
-expressions are evaluated. Consider the following code:
+This means that bounds are not checked for each individual dimension access.
+Accessing outside of the bounds for an
+individual dimension is a violation of the C Standard and logically incorrect,
+but it does not compromise memory safety or type safety.
+
+Bounds checks for \ntarrayptr\ values differ from those for
+\arrayptr\ values because they need to treat access to
+memory at the upper bound differently.  The checks also depend on
+whether the result is used to read or write memory.   For memory reads,
+given \texttt{*\var{e1}} where {\var{e1}} has {\bounds{\var{e2}}{\var{e3}}}, 
+the compiler computer \var{e1} to some temporary \var{t}.
+the compiler inserts a runtime check that  \texttt{\var{e2} <= \var{t} \&\&
+\var{t} <= \var{e3}}.   For memory writes, the compiler inserts a check that 
+\texttt{(\var{e2} <= \var{t} \&\& \var{t} < \var{e3}) ||
+(\var{t} ==\var{e3} \&\& *\var{t} != 0)}.
+
+No bounds checks are inserted when the \texttt{\&} operator is applied to 
+a dereference or subscript exression.    
+The dereference or subscript expression does not produce a result that is used
+to access memory.  This expression \texttt{\&\var{e1}[\var{e2}]} works as
+expected by C programmers.  It is equivalent to pointer arithmetic computed using 
+\texttt{\var{e1} + \var{e2}}.   Similarly, \texttt{+\&\var{e}} works 
+as expected.  The \texttt{\&} and the \texttt{*} operator cancel so that
+the value of the entire expression is \var{e}.
+
+\subsection{Deferring evaluation of bounds expressions to bounds checks}
+
+The previous section covered an important point about the evaluation of
+bounds expression in passing that is worth emphasizing:
+the evaluation of a bounds expression that occurs in
+a bounds declaration is {\em deferred} until a bounds check uses the
+bounds expression.
+
+Consider the following code:
 
 \begin{verbatim}
 array_ptr<int> x;
@@ -632,13 +694,16 @@ x = malloc ((sizeof(int) * 5)
 where x : bounds(x, x + 5);
 \end{verbatim}
 
-When is \texttt{x + 5} evaluated?  In this design, 
-the evaluation of a bounds expression in a bounds declaration is
-{\em deferred} until a bounds check uses the bounds expression. 
-This avoids the need for temporary storage to 
-hold the value of \texttt{x + 5}.  The need for temporary storage would
-be particularly problematic when bounds declarations are extended
-to structures.   It also avoids complications when \texttt{x} is
+The bounds expression \texttt{bounds(x, x + 5)} is not evaluated at the
+bounds declaration.   it is evaluated at any bounds check involving a
+pointer derived from \var{x}.  The reason for deferring the
+evaluation of bounds expressions is that it avoids the need for
+storage to hold the ranges produced by the bounds
+expressions (in this case, the values of \texttt{x} and \texttt{x + 5}).
+Additional storage would be particularly
+problematic when bounds declarations are extend to structure members.
+It would cause the size and layout of data structures to change.
+Deferring evaluation also avoids complications when \texttt{x} is
 \texttt{null}. Section~\ref{section:bounds-declarations-alternate-semantics} 
 discusses eager evaluation of bounds expressions at
 bounds declarations in more detail and explains why this was not chosen.

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -3,11 +3,10 @@
 \chapter{Bounds for variables}
 \label{chapter:tracking-bounds}
 
-Variable with \arrayptr\ types that are used to access
+Variables with \arrayptr\ types that are used to access
 memory must have bounds declared for them.  The same requirement
 holds for variables with incomplete checked array types.
-
-For an \arrayptr\ variable, the bounds will be used to check
+The bounds will be used to check
 memory accesses at runtime involving the pointers stored in the variable
 or pointers produced by pointer arithmetic that uses those pointers.
 Runtime checks can be omitted if a compiler proves that they are
@@ -72,8 +71,7 @@ Section~\ref{section:non-modifying-expressions}  describes
 non-modifying expressions in detail.
 
 In a bounds declaration of the form \boundsdecl{\var{x}}{\var{bounds-exp}},
-\var{x} can have an \arrayptr\, \ntarrayptr\,  checked array type, or
-checked null-terminated array type.
+\var{x} can have an \arrayptr\ or a checked array type.
 For the form  \boundsdecl{\var{x}}{\boundscount{\var{e1}}},  the type of
 \var{x} cannot be \arrayptrvoid\ and the type of \var{e1} must be an integral type.
 The usual C integer conversions are applied to \var{e1}.\footnote{If the
@@ -89,22 +87,24 @@ bounds for \arrayptrvoid\ pointers.
 
 For any variable with a bounds declaration, the variable must be
 non-null when memory is accessed.  There is no requirement that an
-\arrayptr\ or \ntarrayptr\ variable stay within its bounds. The requirement 
-is that the \arrayptr\ or \ntarrayptr variable can only be dereferenced if it
-is in bounds. This avoids bound checks on pointer arithmetic.
+\arrayptr\ variable stay within its bounds. The requirement is
+that the \arrayptr\ or variable can only be dereferenced if it is
+in bounds. This avoids bound checks on pointer arithmetic.
 
 Count expressions have limits on their ranges to prevent signed integer
 overflow and unsigned integer wraparound from affecting size
 computations. Section~\ref{section:integer-overflow-informal}
 explains these limits in detail. The limits
-depend on the element type of the \arrayptr\ or \ntarrayptr\ 
-and the type of the count
+depend on the element type of the \arrayptr\ and the type of the count
 expression. For \boundsdecl{\var{x}}{\boundscount{\var{e1}}}, where \var{x}
-has type \arrayptrT or \ntarrayptrT,
+has type \arrayptrT\,
 \var{e1} must be greater than or equal to 0. \var{e1} must be less
-than the maximum number of an
-\arrayptrT\ or \ntarrayptrT\ elements
+than the maximum number of \arrayptrT\ elements
 that can be indexed by an integer whose type matches that of \var{e1}.
+For \ntarrayptr, there is
+an null terminator at or beyond the upper bound, so \var{e1}
+must be less than the maximum number of \arrayptrT elements minus one.
+
 A bounds declaration \boundsdecl{\var{x}}{\boundscount{\var{e1}}} is an
 abbreviation for \boundsdecl{\var{x}}{\bounds{\var{x}}{\var{x} \texttt{+} \var{e1}}} with additional conditions that \var{e1}
 \texttt{>= 0 \&\& \var{e1} <= (char *)}
@@ -115,7 +115,7 @@ abbreviation for \boundsdecl{\var{x}}{\bounds{\var{x}}{\var{x} \texttt{+} \var{e
 The conditions may require programmers to add additional checks at memory allocations
 to show that \var{e1} is in range. However, the conditions have advantages too.
 They provide scaffolding for proving that expressions based on
-element counts of \arrayptr\ or \ntarrayptr\ variables do not overflow or wraparound.
+element counts of \arrayptr\ variables do not overflow or wraparound.
 
 The meaning and correctness of bounds are based on the C semantics for
 pointers and pointer arithmetic. At runtime, any non-null pointer in C
@@ -574,19 +574,22 @@ by the lvalue is updated with the value of the right-hand side of
 the assignment.
 For example, given \texttt{*\var{e1} = \var{e2}},
 the memory pointed to by the lvalue is updated with the value of \var{e2}.
-If the expression occurs within another expression, the lvalue is usually 
+If the expression occurs within another expression, the lvalue is usually
 (but not always)  used to read memory.  In the terminology of the C Standard,
 an lvalue conversion is inserted that reads memory. For example, given \texttt{*\var{e1} + 5},
 an lvalue conversion is inserted for \texttt{*\var{e1}}.  A case where a
 conversion is not inserted is  when the address of an expression is taken:
-\texttt{\&*\var{e1}}. Subscript expression behave similarly to pointer
+\texttt{\&*\var{e1}}. Subscript expressions behave similarly to pointer
 dereference expressions.  The expression \texttt{\var{e1}{[\var{e2}]}} produces
 an lvalue that can be used to access memory.
- 
-A bounds check is inserted at a dereference expression or subscript expression 
+
+A bounds check is inserted at a dereference expression or subscript expression
 of an \arrayptr\ or \ntarrayptr\ whose result will be used to directly
-access mmemory (the result must be used by the left-hand side of an
-assignment or an lvalue conversion).
+access memory (the result must be used by the left-hand side of an
+assignment or an lvalue conversion).   We first describe bounds checks
+for \arrayptr\.   The bounds checks for \ntarrayptr\ are slightly
+different and described later in this section.
+
 Given \texttt{*\var{e1}}, where \var{e1} is an expression of type
 \arrayptr, the compiler determines the bounds for \var{e1}
 following the rules in Section~\ref{section:inferring-expression-bounds}.
@@ -604,7 +607,7 @@ will be terminated by the runtime system or in, systems that support it,
 a runtime exception will be raised.   If {\var{e1}} has bounds {\boundscount{\var{e2}}},
 the bounds are expanded to \bounds{\var{t}}{\var{t} + \var{e2}} before inserting a check.
 
-Consider as an example \verb|z = *x;| where 
+Consider as an example \verb|z = *x;| where
 \verb|x| has \verb|bounds(x, x + c)|. The compiler will produce code equivalent to:
 \begin{quote}
 \begin{verbatim}
@@ -651,30 +654,32 @@ array.  Given \texttt{\var{e1}[\var{e2}][e3]}, the expression \texttt{\var{e1}[\
 evaluated.  However, \texttt{\var{e1}[\var{e2}]} has array type, so no lvalue
 conversion is inserted. That means that no bounds check is inserted:
 \texttt{\var{e1}[\var{e2}]} becomes pointer arithmetic.  The bounds check
-is inserted as part of the subscript operation involving \var{e3}. 
+is inserted as part of the subscript operation involving \var{e3}.
 
 This means that bounds are not checked for each individual dimension access.
 Accessing outside of the bounds for an
 individual dimension is a violation of the C Standard and logically incorrect,
 but it does not compromise memory safety or type safety.
 
-Bounds checks for \ntarrayptr\ values differ from those for
-\arrayptr\ values because they need to treat access to
-memory at the upper bound differently.  The checks also depend on
-whether the result is used to read or write memory.   For memory reads,
-given \texttt{*\var{e1}} where {\var{e1}} has {\bounds{\var{e2}}{\var{e3}}}, 
+Bounds checks for \ntarrayptr\ values allow access to memory exactly
+at the upper bound.  This is the beginning of the null-terminated
+sequence (bounds checks for \arrayptr\ values only allow access to
+memory below the upper bounds).  Bounds checks for \ntarrayptr\ values also
+depends on whether the value is being used to read to read or write memory.
+for \arrayptr\ values.  For \arrayptr  For memory reads,
+given \texttt{*\var{e1}} where {\var{e1}} has {\bounds{\var{e2}}{\var{e3}}},
 the compiler computes \var{e1} to some temporary \var{t}.
 the compiler inserts a runtime check that  \texttt{\var{e2} <= \var{t} \&\&
-\var{t} <= \var{e3}}.   For memory writes, the compiler inserts a check that 
+\var{t} <= \var{e3}}.   For memory writes, the compiler inserts a check that
 \texttt{(\var{e2} <= \var{t} \&\& \var{t} < \var{e3}) ||
 (\var{t} ==\var{e3} \&\& *\var{t} != 0)}.
 
-No bounds checks are inserted when the \texttt{\&} operator is applied to 
-a dereference or subscript exression.    
+No bounds checks are inserted when the \texttt{\&} operator is applied to
+a dereference or subscript exression.
 The dereference or subscript expression does not produce a result that is used
 to access memory.  This expression \texttt{\&\var{e1}[\var{e2}]} works as
-expected by C programmers.  It is equivalent to pointer arithmetic computed using 
-\texttt{\var{e1} + \var{e2}}.   Similarly, \texttt{+\&\var{e}} works 
+expected by C programmers.  It is equivalent to pointer arithmetic computed using
+\texttt{\var{e1} + \var{e2}}.   Similarly, \texttt{+\&\var{e}} works
 as expected.  The \texttt{\&} and the \texttt{*} operator cancel so that
 the value of the entire expression is \var{e}.
 

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -661,18 +661,19 @@ Accessing outside of the bounds for an
 individual dimension is a violation of the C Standard and logically incorrect,
 but it does not compromise memory safety or type safety.
 
-Bounds checks for \ntarrayptr\ values allow access to memory exactly
+Bounds checks for \ntarrayptr\ values allow read access to memory exactly
 at the upper bound.  This is the beginning of the null-terminated
 sequence (bounds checks for \arrayptr\ values only allow access to
-memory below the upper bounds).  Bounds checks for \ntarrayptr\ values also
-depends on whether the value is being used to read to read or write memory.
-for \arrayptr\ values.  For \arrayptr  For memory reads,
+memory below the upper bounds).  For memory reads,
 given \texttt{*\var{e1}} where {\var{e1}} has {\bounds{\var{e2}}{\var{e3}}},
 the compiler computes \var{e1} to some temporary \var{t}.
-the compiler inserts a runtime check that  \texttt{\var{e2} <= \var{t} \&\&
-\var{t} <= \var{e3}}.   For memory writes, the compiler inserts a check that
-\texttt{(\var{e2} <= \var{t} \&\& \var{t} < \var{e3}) ||
-(\var{t} ==\var{e3} \&\& *\var{t} != 0)}.
+The compiler inserts a runtime check that  \texttt{\var{e2} <= \var{t} \&\&
+\var{t} <= \var{e3}}.   For memory writes, the compiler inserts the
+same check as for \arrayptr:
+\texttt{\var{e2} <= \var{t} \&\& \var{t} < \var{e3}}.
+If the bounds for \var{e1} are inferred, the checks
+must be provably true at compile time.
+
 
 No bounds checks are inserted when the \texttt{\&} operator is applied to
 a dereference or subscript exression.

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -663,7 +663,7 @@ Bounds checks for \ntarrayptr\ values differ from those for
 memory at the upper bound differently.  The checks also depend on
 whether the result is used to read or write memory.   For memory reads,
 given \texttt{*\var{e1}} where {\var{e1}} has {\bounds{\var{e2}}{\var{e3}}}, 
-the compiler computer \var{e1} to some temporary \var{t}.
+the compiler computes \var{e1} to some temporary \var{t}.
 the compiler inserts a runtime check that  \texttt{\var{e2} <= \var{t} \&\&
 \var{t} <= \var{e3}}.   For memory writes, the compiler inserts a check that 
 \texttt{(\var{e2} <= \var{t} \&\& \var{t} < \var{e3}) ||

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -658,7 +658,7 @@ is inserted as part of the subscript operation involving \var{e3}.
 
 This means that bounds are not checked for each individual dimension access.
 Accessing outside of the bounds for an
-individual dimension is a violation of the C Standard and logically incorrect,
+individual inner dimension is a violation of the C Standard and logically incorrect,
 but it does not compromise memory safety or type safety.
 
 Bounds checks for \ntarrayptr\ values allow read access to memory exactly

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -88,7 +88,7 @@ bounds for \arrayptrvoid\ pointers.
 For any variable with a bounds declaration, the variable must be
 non-null when memory is accessed.  There is no requirement that an
 \arrayptr\ variable stay within its bounds. The requirement is
-that the \arrayptr\ or variable can only be dereferenced if it is
+that the \arrayptr\ variable can only be dereferenced if it is
 in bounds. This avoids bound checks on pointer arithmetic.
 
 Count expressions have limits on their ranges to prevent signed integer


### PR DESCRIPTION
This change adds a new type `nt_array_ptr` that is a variant of `array_ptr` for pointers to null-terminated arrays.   The change:
- describes the new type in core-extensions.tex.   
- describes a new checked null-terminated array type go with `nt_array_ptr`
- describes the runtime bounds checking rules for nt_array_ptr.

Most of the rules later in the specification for `array_ptr` apply to `nt_array_ptr`.    I initially started down the route of updating all occurrences of `array_ptr` to say "or `nt_array_ptr`".   I decided that was resulting in lots of changes that didn't help understanding much and made the text longer.   There is a paragraph in the description of `nt_array_ptr` that says that the rules for `array_ptr` usually apply to `nt_array_ptr` and that we mention `nt_array_ptr` only when the rules are different.

This change also cleans up some aspects of the spec:
- Remove the text that says bounds-checking is done for &e, if e is a dereference or subscript operation.  This is incorrect and doesn't match what the implementation does.
- Makes the description of bounds checks more precise, by describing the use of temporaries instead of expressions during bounds checking (the expression being bounds checked is not re-evaluated).
- Revise the section describing the deferral of the evaluation of bounds expression.

Still to do (in another pull request):
- Update the rules for conversions between checked pointer types.
- Update the description of inference of bounds and the checking of bounds declarations to cover the widening of bounds for `nt_array_ptr`.   If we determine the element at the upper bound is not a null-terminator, we can widen the bounds of the `nt_array_ptr` by 1.

