### PR TITLE
Test returning a checked pointer from a function with an interop type.

### DIFF
--- a/tests/typechecking/checked_scope.c
+++ b/tests/typechecking/checked_scope.c
@@ -1914,3 +1914,73 @@ typedef ptr<int *(void) : itype(ptr<int>)> callback_fn2;
 checked void test_function_pointer_return(callback_fn2 fn) {
   ptr<int> p = (*fn)();
 }
+
+//-----------------------------------------------------------------------
+// Test return statements in checked blocks where there is a bounds-safe
+// interface on the return type.
+//-----------------------------------------------------------------------
+
+// Return a _Ptr from a checked scope for a function with a
+// a bounds-safe interface return type of _Ptr.
+int *f100(void) : itype(_Ptr<int>) {
+  _Checked{
+    _Ptr<int> p = 0;
+    return p;
+  }
+  return 0;
+}
+
+// Return an _Array_ptr from a checked scope for a function with a
+// a bounds-safe interface return type of _Array_ptr.
+int *f101(int len) : count(len) {
+  _Checked{
+    _Array_ptr<int> p = 0;
+    return p;
+  }
+  return 0;
+}
+
+
+// Return an _Array_ptr from a checked scope for a function with a
+// a bounds-safe interface return type of _Array_ptr, where the
+// returned value has a bounds-afe interface type.
+int *f102(int * p : itype(_Ptr<int>)) : itype(_Ptr<int >) {
+  _Checked{
+    return p;
+  }
+}
+
+//
+// Return a checked value from a checked scope, with the return
+// type missing a bounds-safe interface.
+//
+
+int *f103(void) {
+  _Checked{
+    _Ptr<int> p = 0;
+    return p;  // expected-error {{returning '_Ptr<int>' from a function with incompatible result type 'int *'}}
+  }
+  return 0;
+}
+
+int *f104(int len) {
+  _Checked{
+    _Array_ptr<int> p = 0;
+    return p; // expected-error {{returning '_Array_ptr<int>' from a function with incompatible result type 'int *'}}
+  }
+  return 0;
+}
+
+int *f105(int *p : itype(_Ptr<int>)) {
+  _Checked{
+    return p;  // TODO: Github issue #339.  This should be an error.
+  }
+}
+
+// Omit returning a value when one is expected.
+int *f106(void) : itype(_Ptr<int>) {
+  _Checked{
+    return; // expected-error {{non-void function 'f106' should return a value}}
+  }
+  return 0;
+}

--- a/tests/typechecking/checked_scope.c
+++ b/tests/typechecking/checked_scope.c
@@ -1940,10 +1940,9 @@ int *f101(int len) : count(len) {
   return 0;
 }
 
-
-// Return an _Array_ptr from a checked scope for a function with a
-// a bounds-safe interface return type of _Array_ptr, where the
-// returned value has a bounds-afe interface type.
+// Return an _Ptr from a checked scope for a function with a
+// a bounds-safe interface return type of _Ptr, where the
+// returned value has a bounds-safe interface type.
 int *f102(int * p : itype(_Ptr<int>)) : itype(_Ptr<int >) {
   _Checked{
     return p;

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -305,27 +305,25 @@ void g14(array_ptr<const int> ap : count(len), int len) {
 
 //
 //
-// There are no bounds-safe interface implicit conversions when a value with a
+// There is a bounds-safe interface implicit conversion when a value with a
 // checked pointer type is returned from a function that has an unchecked
-// return pointer type with an interop bounds declaration.  An explicit cast
-// must be used in this case.
-//
+// return pointer type with an interop bounds declaration.
 //
 
 int *g15(ptr<int> p) : itype(ptr<int>) {
-  return p;  // expected-error {{incompatible result type}}
+  return p;
 }
 
 int *g16(array_ptr<int> p : count(10)) : count(10) {
-  return p;  // expected-error {{incompatible result type}}
+  return p;
 }
 
 int *g17(array_ptr<int> p : count(10)) : byte_count(10 * sizeof(int)) {
-  return p;  // expected-error {{incompatible result type}}
+  return p;
 }
 
 void *g18(array_ptr<int> p : count(10)) : byte_count(10 * sizeof(int)) {
-  return p;  // expected-error {{incompatible result type}}
+  return p;
 }
 
 //


### PR DESCRIPTION
Add tests for returning checked pointers from functions with bounds-safe interfaces for their return values.  Modify an existing test to allow this behavior.   

These tests are for the compiler change in https://github.com/Microsoft/checkedc-clang/pull/368.
