### PR TITLE
Test parsing and type checking of null-terminated arrays and pointers.

### DIFF
--- a/include/stdchecked.h
+++ b/include/stdchecked.h
@@ -3,7 +3,9 @@
 
 #define ptr _Ptr
 #define array_ptr _Array_ptr
+#define nt_array_ptr _Nt_array_ptr
 #define checked _Checked
+#define nt_checked _Nt_checked
 #define unchecked _Unchecked
 #define where _Where
 #define dynamic_check _Dynamic_check

--- a/tests/parsing/checked_array_types.c
+++ b/tests/parsing/checked_array_types.c
@@ -42,6 +42,27 @@ extern void f7(int a checked[5]checked[5], int y) {
 }
 
 //
+// Null-terminated array versions
+//
+
+extern void f10(int a nt_checked[], int y) {
+}
+
+extern void f11(int a nt_checked[5], int y) {
+}
+
+extern void f12(const int a nt_checked[5], int y) {
+}
+
+// Arrays of null-terminated checked arrays are allowed.
+extern void f13(int a checked[]nt_checked[5], int y) {
+}
+
+extern void f14(int a checked[5]nt_checked[5], int y) {
+}
+
+
+//
 // Second parameter is a new pointer type
 //
 
@@ -69,6 +90,25 @@ extern void g7(int y, int a checked[5]checked[5]) {
 }
 
 //
+// Null-terminated checked array versions.
+//
+extern void g10(int y, int a nt_checked[]) {
+}
+
+extern void g11(int y, int a nt_checked[5]) {
+}
+
+extern void g12(int y, const int a nt_checked[5]) {
+}
+
+// Arrays of null-terminated checked arrays are allowed.
+extern void g13(int y, int a checked[]nt_checked[5]) {
+}
+
+extern void g14(int y, int a checked[5]nt_checked[5]) {
+}
+
+//
 // Local variables with pointer types
 //
 
@@ -78,6 +118,8 @@ extern void k1(int y)
     int arr2 checked[5];
     int arr3 checked[][5] = { { 1 }, {2 } };
     int arr4 checked[5][5];
+    int arr5 nt_checked[] = { 0, 1 , 2 };
+    int arr6 nt_checked[5];
 }
 
 //
@@ -113,44 +155,67 @@ extern int Multiply2(ptr<struct Vector> vec1p, ptr<struct Vector> vec2p) {
 // Declaring checked arrays of function pointers
 //
 
+struct FixedLengthString {
+  char str nt_checked[5];
+};
 
 int (*array_of_unchecked_ptr_to_func checked[10])(int x, int y);
+int (*nullterm_array_of_unchecked_ptr_to_func nt_checked[10])(int x, int y);
 extern int (*incomplete_array_of_unchecked_ptr_to_func checked[])(int x, int y);
+extern int (*nullterm_incomplete_array_of_unchecked_ptr_to_func nt_checked[])(int x, int y);
 ptr<int(int x, int  y)> array_of_ptr_to_func checked[10];
 extern ptr<int(int x, int  y)> array_of_ptr_to_func checked[];
 ptr<int(int x checked[10], int y)> aptr2 checked[10];
+ptr<int(int x nt_checked[10], int y)> aptr3 nt_checked[10];
 
 //
 // Declaring pointers to arrays and arrays of pointers
 //
 int (*unchecked_ptr_to_array)checked[5];
 ptr<int checked[5]> ptr_to_array;
+ptr<int nt_checked[5]> ptr_to_nullterm_array;
 array_ptr<int checked[5]> array_ptr_to_array;
+array_ptr<int nt_checked[5]> array_ptr_to_nullterm_array;
 
 int(*unchecked_ptr_to_incomplete_array)checked[];
 ptr<int checked[]> ptr_to_incomplete_array;
+ptr<int nt_checked[]> ptr_to_nullterm_incomplete_array;
 array_ptr<int checked[]> array_ptr_to_incomplete_array;
+array_ptr<int nt_checked[]> array_ptr_to_nullterm_incomplete_array;
 
 // Declaring checked arrays of pointers
 int *array_of_unchecked_ptrs checked[5];
+int *nullterm_array_of_unchecked_ptrs nt_checked[5];
 ptr<int> array_of_ptrs checked[5];
+ptr<int> nullterm_array_of_ptrs nt_checked[5];
 array_ptr<int> array_of_array_ptrs checked[5];
+array_ptr<int> nullterm_array_of_array_ptrs nt_checked[5];
+nt_array_ptr<int> array_of_nullterm_array_ptrs checked[5];
+nt_array_ptr<int> nullterm_array_of_nullterm_array_ptrs nt_checked[5];
 
 // Declare an unchecked pointer to checked arrays of pointers
 int *(*uncheckedptr_to_array_of_unchecked_ptrs) checked[5];
 ptr<int>(*unchecked_ptr_to_array_of_ptrs) checked[5];
 array_ptr<int>(*unchecked_ptr_to_array_of_array_ptrs) checked[5];
+array_ptr<int>(*unchecked_ptr_to_null_term_array_of_array_ptrs) nt_checked[5];
 
 // Declare ptr to checked arrays of pointers
 ptr<int *checked[5]> ptr_to_array_of_unchecked_ptrs;
 ptr<ptr<int> checked[5]> ptr_to_array_of_ptrs;
 ptr<array_ptr<int> checked[5]> ptr_to_array_of_array_ptrs;
+ptr<array_ptr<int> nt_checked[5]> ptr_to_nullterm_array_of_array_ptrs;
+ptr<nt_array_ptr<int> nt_checked[5]> ptr_to_nullterm_array_of_nullterm_array_ptrs;
 
 // Declare ptr to a checked array of function pointers
 ptr<int (*checked[5])(int x, int y)> ptr_to_array_of_unchecked_func_ptrs;
 ptr<ptr<int (int x, int y)>checked [5]> ptr_to_array_of_checked_func_ptrs;
+ptr<ptr<int (int x, int y)>nt_checked [5]> ptr_to_nullterm_array_of_checked_func_ptrs;
 // Make parameter and return types be ptrs too.
-ptr<ptr<ptr<int> (ptr<int> x, ptr<int> y)>checked[5]> ptr_to_array_of_checked_func_ptrs_with_ptr_parameters;
+ptr<ptr<ptr<int>(ptr<int> x, ptr<int> y)>checked[5]>
+ptr_to_array_of_checked_func_ptrs_with_ptr_parameters;
+ptr<ptr<ptr<int> (ptr<int> x, ptr<int> y)>nt_checked[5]>
+  ptr_to_nullterm_array_of_checked_func_ptrs_with_ptr_parameters;
+
 
 //
 // Typedefs using checked pointer types
@@ -160,6 +225,8 @@ typedef int arr_ty[5];
 typedef int incomplete_arr_ty[];
 typedef int checked_arr_ty checked[5];
 typedef int incomplete_checked_array_ty checked[];
+typedef int nullterm_checked_arr_ty nt_checked[5];
+typedef int nullterm_incomplete_checked_array_ty nt_checked[];
 
 //
 // Operators that take types
@@ -167,16 +234,32 @@ typedef int incomplete_checked_array_ty checked[];
 
 void parse_operators_with_types(void) {
     int s1 = sizeof(int checked[10]);
-    int s3 = sizeof(ptr<int checked[5]>);
-    int s4 = sizeof(array_ptr<int checked[5]>);
-    int s5 = sizeof(ptr<int>checked[5]);
-    int s6 = sizeof(array_ptr<int> checked[5]);
+    int s2 = sizeof(ptr<int checked[5]>);
+    int s3 = sizeof(array_ptr<int checked[5]>);
+    int s4 = sizeof(ptr<int>checked[5]);
+    int s5 = sizeof(array_ptr<int> checked[5]);
 
-    int s11 = _Alignof(int checked[10]);
-    int s13 = _Alignof(ptr<int checked[5]>);
-    int s14 = _Alignof(array_ptr<int checked[5]>);
-    int s15 = _Alignof(ptr<int> checked[5]);
-    int s16 = _Alignof(array_ptr<int>checked[5]);
+    // null-terminated versions.
+    int s6 = sizeof(int nt_checked[10]);
+    int s7 = sizeof(ptr<int nt_checked[5]>);
+    int s8 = sizeof(array_ptr<int nt_checked[5]>);
+    int s9 = sizeof(ptr<int> nt_checked[5]);
+    int s10 = sizeof(array_ptr<int> nt_checked[5]);
+
+    int s20 = _Alignof(int checked[10]);
+    int s21 = _Alignof(ptr<int checked[5]>);
+    int s22 = _Alignof(array_ptr<int checked[5]>);
+    int s23 = _Alignof(ptr<int> checked[5]);
+    int s24 = _Alignof(array_ptr<int>checked[5]);
+    int s25 = _Alignof(nt_array_ptr<int>checked[5]);
+
+    // null-terminated versions.
+    int s26 = _Alignof(int nt_checked[10]);
+    int s27 = _Alignof(ptr<int nt_checked[5]>);
+    int s28 = _Alignof(array_ptr<int nt_checked[5]>);
+    int s29 = _Alignof(ptr<int> nt_checked[5]);
+    int s30 = _Alignof(array_ptr<int> nt_checked[5]);
+    int s31 = _Alignof(nt_array_ptr<int> nt_checked[5]);
 
     // Test parsing of some cast operations that should pass checking
     // of bounds declarations

--- a/tests/parsing/pointer_types.c
+++ b/tests/parsing/pointer_types.c
@@ -16,7 +16,7 @@
 #include <stdchecked.h>
 
 //
-// parameter have new pointer types
+// parameters have new pointer types
 //
 
 extern void f1(ptr<int> p, int y) {
@@ -46,6 +46,20 @@ extern void f6(array_ptr<int> p : count(1), int y) {
 extern void f7(array_ptr<int> p : count(1), int y) {
    *p = y;
    f6(p, y);
+}
+
+extern void f8(nt_array_ptr<int> p : count(1), int y) {
+  *p = y;
+}
+
+extern void f9(nt_array_ptr<int> p : count(1), int y) {
+  *p = y;
+  f8(p, y);
+}
+
+extern void f10(nt_array_ptr<nt_array_ptr<int>> p : count(1),
+                nt_array_ptr<int> y) {
+  *p = y;
 }
 
 //
@@ -78,6 +92,12 @@ extern void g6(int y, array_ptr<int> p : count(1)) {
    f7(p, y);
 }
 
+extern void g7(int y, nt_array_ptr<int> p : count(1)) {
+  *p = y;
+  f9(p, y);
+}
+
+
 //
 // returns a new pointer type
 //
@@ -107,6 +127,26 @@ extern ptr<ptr<ptr<int>>> h5(int y, ptr<ptr<ptr<int>>> p) {
    return p;
 }
 
+extern array_ptr<int> h6(int y, array_ptr<int> p) {
+  return p;
+}
+
+
+extern array_ptr<ptr<int>> h7(int y, array_ptr<ptr<int>> p : count(1)) {
+  **p = y;
+  return p;
+}
+
+extern nt_array_ptr<int> h8(int y, nt_array_ptr<int> p) {
+  return p;
+}
+
+
+extern nt_array_ptr<ptr<int>> h9(int y, nt_array_ptr<ptr<int>> p : count(1)) {
+  **p = y;
+  return p;
+}
+
 //
 // Local variables with pointer types
 //
@@ -117,6 +157,7 @@ extern void k1(int y)
    ptr<int> t1 = &v;
    array_ptr<int> t2 : count(1) = &v;
    array_ptr<ptr<int>> t3  : count(1) = &t1;
+   nt_array_ptr<int> t4 = 0;
    *t1 = 0;
    *t2 = 0;
    *t3 = 0;
@@ -151,6 +192,10 @@ extern int Multiply2(ptr<struct Vector> vec1p, ptr<struct Vector> vec2p) {
     return 0;
 }
 
+struct StringWrapper {
+  nt_array_ptr<char> str : count(0);
+};
+
 //
 // Declaring pointers to functions
 //
@@ -159,13 +204,13 @@ extern int Multiply2(ptr<struct Vector> vec1p, ptr<struct Vector> vec2p) {
 int (*unchecked_ptr_to_func)(int x, int y);
 // A ptr to a function that takes two integer parameters and returns an integer
 ptr<int (int x, int y)> ptrfunc;
-// An array_ptr to a function that takes two integer paramters and returns an integer
-// Note that because function types have no size, you can't declare bounds or do pointer arithmetic,
-// so this is pretty useless.
-array_ptr<int (int x, int y)> array_ptrfunc;
-// An array_ptr to an array of function pointers.  This, on the other hand, is pretty useful.
-// You can declare bounds for it, do pointer arithmetic, and access memory.
-array_ptr<ptr<int(int x, int  y)>> array_of_ptrfunc;
+// Not allowed: an array_ptr of a function type:
+// array_ptr<int (int x, int y)> array_ptrfunc;
+// Function types have no size, so bounds checking does not make sense.
+//
+// Allowed: An array_ptr to an array of function pointers.
+array_ptr<ptr<int(int x, int  y)>> array_ptr_of_ptrfunc;
+nt_array_ptr<ptr<int(int x, int  y)>> nullterm_array_ptr_of_ptrfunc;
 
 //
 // Declaring pointers to arrays and arrays of pointers
@@ -173,25 +218,50 @@ array_ptr<ptr<int(int x, int  y)>> array_of_ptrfunc;
 int (*unchecked_ptr_to_array)[5];
 ptr<int[5]> ptr_to_array;
 array_ptr<int[5]> array_ptr_to_array;
+// not allowed: null terminated array_ptr to array
+// nt_array_ptr<int[5]> nullterm_array_ptr_to_array;
 
 int(*unchecked_ptr_to_incomplete_array)[];
 ptr<int[]> ptr_to_incomplete_array;
 array_ptr<int[]> array_ptr_to_incomplete_array;
+// not allowed: null terminated array_ptr to incomplete array
+// nt_array_ptr<int[]> nullterm_array_ptr_to_incomplete_array;
 
 // Declaring arrays of pointers
 int *array_of_unchecked_ptrs[5];
 ptr<int> array_of_ptrs[5];
 array_ptr<int> array_of_array_ptrs[5];
+nt_array_ptr<int> array_of_nullterm_pointers[5];
+
+// Declaring null-terminated arrays of pointers
+int *nullterm_array_of_unchecked_ptrs nt_checked[5];
+ptr<int> nullterm_array_of_ptrs nt_checked[5];
+array_ptr<int> nullterm_array_of_array_ptrs nt_checked[5];
+nt_array_ptr<int> nullterm_array_of_nullterm_pointers nt_checked[5];
 
 // Declare an unchecked pointer to arrays of pointers
 int *(*uncheckedptr_to_array_of_unchecked_ptrs)[5];
 ptr<int>(*unchecked_ptr_to_array_of_ptrs)[5];
 array_ptr<int>(*unchecked_ptr_to_array_of_array_ptrs)[5];
+nt_array_ptr<int>(*unchecked_ptr_to_array_of_null_term_array_ptrs)[5];
+
+int *(*uncheckedptr_to_nullterm_array_of_unchecked_ptrs) nt_checked[5];
+ptr<int>(*unchecked_ptr_to_nullterm_array_of_ptrs) nt_checked[5];
+array_ptr<int>(*unchecked_ptr_to_null_termarray_of_array_ptrs) nt_checked[5];
+nt_array_ptr<int>(*unchecked_ptr_to_null_term_array_of_null_term_array_ptrs)nt_checked[5];
 
 // Declare ptr to arrays of pointers
 ptr<int *[5]> ptr_to_array_of_unchecked_ptrs;
 ptr<ptr<int>[5]> ptr_to_array_of_ptrs;
 ptr<array_ptr<int>[5]> ptr_to_array_of_array_ptrs;
+ptr<nt_array_ptr<int>[5]> ptr_to_array_of_nullterm_array_ptrs;
+
+// Declare ptr to nullterm arrays of pointers
+ptr<int *nt_checked[5]> ptr_to_nullterm_array_of_unchecked_ptrs;
+ptr<ptr<int>nt_checked[5]> ptr_to_nullterm_array_of_ptrs;
+ptr<array_ptr<int>nt_checked[5]> ptr_to_nullterm_array_of_array_ptrs;
+ptr<nt_array_ptr<int>nt_checked[5]> ptr_to_nullterm_array_of_nullterm_array_ptrs;
+
 
 // Declare ptr to an array of function pointers
 ptr<int (*[5])(int x, int y)> ptr_to_array_of_unchecked_func_ptrs;
@@ -207,6 +277,8 @@ typedef ptr<int> t_ptr_int;
 typedef ptr<int (int x, int y)> t_ptr_func;
 typedef array_ptr<int> t_array_ptr_int;
 typedef array_ptr<ptr<int>> t_array_ptr_ptr_int;
+typedef nt_array_ptr<int> t_nullterm_array_ptr_int;
+typedef nt_array_ptr<ptr<int>> t_nullterm_array_ptr_ptr_int;
 
 //
 // Operators that take types
@@ -215,36 +287,44 @@ typedef array_ptr<ptr<int>> t_array_ptr_ptr_int;
 void parse_operators_with_types(void) {
     int s1 = sizeof(ptr<int>);
     int s2 = sizeof(array_ptr<int>);
-    int s3 = sizeof(ptr<int[5]>);
-    int s4 = sizeof(array_ptr<int[5]>);
-    int s5 = sizeof(ptr<int>[5]);
-    int s6 = sizeof(array_ptr<int>[5]);
+    int s3 = sizeof(nt_array_ptr<int>);
+    int s4 = sizeof(ptr<int[5]>);
+    int s5 = sizeof(array_ptr<int[5]>);
+    // not allowed: sizeof(nt_array_ptr<int[5]>);
+    int s6 = sizeof(ptr<int>[5]);
+    int s7 = sizeof(array_ptr<int>[5]);
+    int s8 = sizeof(nt_array_ptr<int>[5]);
     // C11 spec says sizeof function types is illegal, but clang accepts it.
-    int s7 = sizeof(int(int x, int y));
-    int s8 = sizeof(ptr<int>(int x, int y));
+    int s9 = sizeof(int(int x, int y));
+    int s10 = sizeof(ptr<int>(int x, int y));
     // These are OK
-    int s9 = sizeof(ptr<int(int x, int y)>);
-    int s10 = sizeof(int(*)(int x, int y));
+    int s11 = sizeof(ptr<int(int x, int y)>);
+    int s12 = sizeof(int(*)(int x, int y));
 
-    int s11 = _Alignof(ptr<int>);
-    int s12 = _Alignof(array_ptr<int>);
-    int s13 = _Alignof(ptr<int[5]>);
-    int s14 = _Alignof(array_ptr<int[5]>);
-    int s15 = _Alignof(ptr<int>[5]);
-    int s16 = _Alignof(array_ptr<int>[5]);
+    int s20 = _Alignof(ptr<int>);
+    int s21 = _Alignof(array_ptr<int>);
+    int s22 = _Alignof(nt_array_ptr<int>);
+    int s23 = _Alignof(ptr<int[5]>);
+    int s24 = _Alignof(array_ptr<int[5]>);
+    // not allowed: _Alignof(nt_array_ptr<int[5]>);
+    int s25 = _Alignof(ptr<int>[5]);
+    int s26 = _Alignof(array_ptr<int>[5]);
+    int s27 = _Alignof(nt_array_ptr<int>[5]);
     // C11 spec says _Alignof function types is illegal, but clang accepts it.
-    int s17 = _Alignof(int(int x, int y));
-    int s18 = _Alignof(ptr<int>(int x, int y));
+    int s28 = _Alignof(int(int x, int y));
+    int s29 = _Alignof(ptr<int>(int x, int y));
     // These are OK
-    int s19 = _Alignof(ptr<int(int x, int y)>);
-    int s20 = _Alignof(int(*)(int x, int y));
+    int s30 = _Alignof(ptr<int(int x, int y)>);
+    int s31 = _Alignof(int(*)(int x, int y));
 
     // Test parsing of some cast operations that should pass checking
-    // of bounds declaration
+    // of bounds declarations.
     int x = 0;
     int arr[5];
     ptr<int> px = (ptr<int>) &x;
     array_ptr<int> pax = (array_ptr<int>) &x;
+    int nt_arr nt_checked[5];
+    nt_array_ptr<int> nt_pax = (nt_array_ptr<int>) nt_arr;
     // ptr to array type
     ptr<int[5]> parr = 0;
     parr = &arr;

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -543,7 +543,7 @@ void invalid_local_var_bounds_decl(void)
   enum E1 t53 : count(5) = EnumVal1; // expected-error {{expected 't53' to have a pointer or array type}}
   ptr<int> t54 : count(1) = 0;       // expected-error {{bounds declaration not allowed because 't54' has a _Ptr type}}
   array_ptr<void> t55 : count(1) = 0; // expected-error {{expected 't55' to have a non-void pointer type}}
-  array_ptr<void (void)> t56 : count(1);  // expected-error {{bounds declaration not allowed because 't56' has a function pointer type}}
+  array_ptr<void (void)> t56 : count(1);  // expected-error {{declared as _Array_ptr to function of type 'void (void)'; use _Ptr to function instead}}
 
   int *t57 : count(1) = 0;          // expected-error {{bounds declaration not allowed for local variable with unchecked pointer type}}
   int t58[5] : count(5);            // expected-error {{bounds declaration not allowed for local variable with unchecked array type}}
@@ -554,7 +554,7 @@ void invalid_local_var_bounds_decl(void)
   struct S1 t62 : byte_count(8) = { 0 };      // expected-error {{expected 't62' to have a pointer, array, or integer type}}
   union U1 t63 : byte_count(8) = { 0 };       // expected-error {{expected 't63' to have a pointer, array, or integer type}}
   ptr<int> t64 : byte_count(sizeof(int)) = 0; // expected-error {{bounds declaration not allowed because 't64' has a _Ptr type}}
-  array_ptr<void (void)> t65 : byte_count(1); // expected-error {{bounds declaration not allowed because 't65' has a function pointer type}}
+  array_ptr<void (void)> t65 : byte_count(1); // expected-error {{declared as _Array_ptr to function of type 'void (void)'; use _Ptr to function instead}}
 
   int *t67 : byte_count(sizeof(int)) = 0;     // expected-error {{bounds declaration not allowed for local variable with unchecked pointer type}}
   int t68[5] : byte_count(5 * sizeof(int));   // expected-error {{bounds declaration not allowed for local variable with unchecked array type}}
@@ -565,7 +565,7 @@ void invalid_local_var_bounds_decl(void)
   struct S1 t72 : bounds(arr, arr + 1) = { 0 }; // expected-error {{expected 't72' to have a pointer, array, or integer type}}
   union U1 t73 : bounds(arr, arr + 1) = { 0 };  // expected-error {{expected 't73' to have a pointer, array, or integer type}}
   ptr<int> t74 : bounds(arr, arr + 1) = 0;      // expected-error {{bounds declaration not allowed because 't74' has a _Ptr type}}
-  array_ptr<void (void)> t75 : bounds(arr, arr + 1);  // expected-error {{bounds declaration not allowed because 't75' has a function pointer type}}
+  array_ptr<void (void)> t75 : bounds(arr, arr + 1);  // expected-error {{declared as _Array_ptr to function of type 'void (void)'; use _Ptr to function instead}}
 
   int *t78 : bounds(arr, arr + 1) = 0;          // expected-error {{bounds declaration not allowed for local variable with unchecked pointer type}}
   int t79[5] : bounds(arr, arr + 1);            // expected-error {{bounds declaration not allowed for local variable with unchecked array type}}

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -902,11 +902,13 @@ int *fn3(int len) : count(len) { return 0; }
 
 // byte_count
 extern array_ptr<int> fn4(void) : byte_count(5 * sizeof(int));
+extern nt_array_ptr<int> fn4a(void) : byte_count(5 * sizeof(int));
 extern array_ptr<void> fn5(void) : byte_count(5 * sizeof(int));
 extern int *fn6(void) : byte_count(5 * sizeof(int));
 
 // bounds
 array_ptr<int> fn10(void) : bounds(s1, s1 + 5) { return 0; }
+nt_array_ptr<int> fn10a(void) : bounds(s1, s1 + 5) { return 0; }
 array_ptr<void> fn11(void) : bounds(s1, s1 + 5) { return 0; }
 int *fn12(void) : bounds(s1, s1 + 5) { return 0; }
 
@@ -987,7 +989,7 @@ int fn106(float p1 : byte_count(5 * sizeof(int))); // expected-error {{expected 
 int fn107(array_ptr<void> p1 : byte_count(5 * sizeof(int)));
 
 void fn108(array_ptr<int> p1 : bounds(p1, p1 + 5));
-void fn108a(array_ptr<int> p1 : bounds(p1, p1 + 5));
+void fn108a(nt_array_ptr<int> p1 : bounds(p1, p1 + 5));
 void fn109(array_ptr<int> p1, int p2 : bounds(p1, p1 + 5));
 void fn110(array_ptr<int> p1, float p2 : bounds(p1, p1 + 5)); // expected-error {{expected 'p2' to have a pointer, array, or integer type}}
 void fn111(array_ptr<void> p1 : bounds((char *)p1, (char *)p1 + (5 * sizeof(int))));
@@ -1018,6 +1020,7 @@ void fn206(int (*fnptr)(float p1 : byte_count(5 * sizeof(int)))); // expected-er
 void fn207(int (*fnptr)(array_ptr<void> p1 : byte_count(5 * sizeof(int))));
 
 void fn208(void (*fnptr)(array_ptr<int> p1 : bounds(p1, p1 + 5)));
+void fn208a(void(*fnptr)(nt_array_ptr<int> p1 : bounds(p1, p1 + 5)));
 void fn209(void (*fnptr)(array_ptr<int> p1, int p2 : bounds(p1, p1 + 5)));
 void fn210(void (*fnptr)(array_ptr<int> p1, float p2 : bounds(p1, p1 + 5))); // expected-error {{expected 'p2' to have a pointer, array, or integer type}}
 void fn211(void (*fnptr)(array_ptr<void> p1 : bounds((char *) p1, (char *) p1 + (5 * sizeof(int)))));
@@ -1066,6 +1069,7 @@ void fn263(array_ptr<void> (*fnptr)(void) : count(5)); // expected-error {{count
 void function_pointers() {
   // Assignments to function pointers with return bounds on array_ptr types
   array_ptr<int>(*t1)(void) : count(5) = fn1;
+  nt_array_ptr<int>(*t1a)(void) : count(0) = fn1a;
   // Assignment to function pointers with bounds-safe interfaces on
   // unchecked pointer return types.  Unchecked pointers are compatible with
   // unchecked pointers with bounds-safe interfaces.  This extends recursively
@@ -1085,6 +1089,7 @@ void function_pointers() {
   ptr<int *(void) : byte_count(5*sizeof(int))> t12 = fn6;
 
   array_ptr<int>(*t13)(void) : bounds(s1, s1 + 5) = fn10;
+  nt_array_ptr<int>(*t13a)(void) : bounds(s1, s1 + 5) = fn10a;
   int *(*t14)(void) = fn12;
   int *(*t15)(void) : bounds(s1, s1 + 5) = fn12;
   int *(*t16)(void) : bounds(s1, s1 + 6) = fn12;    // expected-warning {{incompatible pointer types}}
@@ -1112,6 +1117,8 @@ void function_pointers() {
   fn206(fn106);
   fn207(fn107);
   fn208(fn108);
+  fn208(fn108a); // expected-error {{parameter of incompatible type}}
+  fn208a(fn108a);
   fn209(fn109);
   fn210(fn110);
   fn211(fn111);

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -29,6 +29,22 @@ extern void check_indirection_checked_incomplete(int p checked[] : count(len),
   y = *const_p;
 }
 
+extern void check_indirection_nt_checked(int p nt_checked[10], const int const_p nt_checked[10], int y) {
+  *p = y;
+  y = *p;
+  *const_p = y; // expected-error {{read-only variable is not assignable}}
+  y = *const_p;
+}
+
+extern void check_indirection_checked_nt_incomplete(int p checked[] : count(len),
+                                                    const int const_p nt_checked[] : count(len),
+                                                    int len, int y) {
+  *p = y;
+  y = *p;
+  *const_p = y; // expected-error {{read-only variable is not assignable}}
+  y = *const_p;
+}
+
 extern void check_subscript_unchecked(int p[10], int y) {
   p[0] = y;
   y = p[0]; 
@@ -36,7 +52,7 @@ extern void check_subscript_unchecked(int p[10], int y) {
   y = 0[p];
 }
 
-extern void check_subscript_checked(int p checked[10], const int p_const[10], int y) {
+extern void check_subscript_checked(int p checked[10], const int p_const checked[10], int y) {
   p[0] = y;  // OK
   y = p[0];  // OK
   0[p] = y;  // OK
@@ -48,7 +64,31 @@ extern void check_subscript_checked(int p checked[10], const int p_const[10], in
 }
 
 extern void check_subscript_checked_incomplete(int p checked[] : count(len),
-                                               const int p_const[] : count(len),
+                                               const int p_const checked[] : count(len),
+                                               int len, int y) {
+  p[0] = y;  // OK
+  y = p[0];  // OK
+  0[p] = y;  // OK
+  y = 0[p];  // OK
+  p_const[0] = y;  // expected-error {{read-only variable is not assignable}}
+  y = p_const[0];  // OK
+  0[p_const] = y;  // expected-error {{read-only variable is not assignable}}
+  y = 0[p_const];  // OK
+}
+
+extern void check_subscript_nt_checked(int p nt_checked[10], const int p_const checked[10], int y) {
+  p[0] = y;  // OK
+  y = p[0];  // OK
+  0[p] = y;  // OK
+  y = 0[p];  // OK
+  p_const[0] = y;  // expected-error {{read-only variable is not assignable}}
+  y = p_const[0];  // OK
+  0[p_const] = y;  // expected-error {{read-only variable is not assignable}}
+  y = 0[p_const];  // OK
+}
+
+extern void check_subscript_nt_checked_incomplete(int p checked[] : count(len),
+                                               const int p_const checked[] : count(len),
                                                int len, int y) {
   p[0] = y;  // OK
   y = p[0];  // OK
@@ -62,19 +102,24 @@ extern void check_subscript_checked_incomplete(int p checked[] : count(len),
 
 static int global_arr[10];
 static int global_checked_arr checked[10];
+static int global_nt_checked_arr nt_checked[10];
 
 typedef int unchecked_arr_type[10];
 typedef int checked_arr_type[10];
+typedef int nt_checked_arr_type[10];
 
 // Test assignments between pointers and arrays, excluding const/volatile attributes.
 extern void check_assign(int val, int p[10], int q[], int r checked[10], int s checked[],
-                         int s2d checked[10][10]) {
+                         int s2d checked[10][10], int v nt_checked[10], int w nt_checked[],
+                         int w2d checked[10]nt_checked[10]) {
   int t[10];
   int t2d[10][10];
   int u checked[10];
   int u2d checked[10][10]; // This is a checked array of checked arrays. checked propagates
                             // to immediately nested array types in array declarators.  It does
                             // not propagate through typedefs
+  int x nt_checked[10];
+  int x2d checked[10]nt_checked[10];
 
   // Single-dimensional array type conversions to pointer types.
   int *t1 = p;          // T *  = T[constant] OK
@@ -82,10 +127,13 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   int *t3 = t;          // T *  = T[constant] OK;
   int *t4 = r;          // expected-error {{expression of incompatible type}} 
                         // Assignment of checked pointer to unchecked pointer not allowed
+  int *t4a = v;         // expected-error {{expression of incompatible type}}
   int *t5 = s;          // expected-error {{expression of incompatible type}} 
                         // ditto
+  int *t5a = w;         // expected-error {{expression of incompatible type}}
   int *t6 = u;          // expected-error {{expression of incompatible type 'int checked[10]'}}
                         // ditto
+  int *t6a = x;         // expected-error {{expression of incompatible type 'int nt_checked[10]'}}
     
   // Various forms of array_ptr<T> = T[]. Note that the rhs does not need to have known bounds
   // because the lhs pointers have no bounds (and cannot be dereferenced).  
@@ -95,30 +143,60 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   array_ptr<int> t7 = p;  
   array_ptr<int> t8 = q;
   array_ptr<int> t9 = r;
+  array_ptr<int> t9a = v;
   array_ptr<int> t10  = s;
+  array_ptr<int> t9b = w;
   array_ptr<int> t11 = t;
+  array_ptr<int> t11a = u;
   array_ptr<int> t12 = u;
+  nt_array_ptr<int> t12a = x;
+  nt_array_ptr<int> t12b = u;      // expected-error {{expression of incompatible type 'int checked[10]'}}
   array_ptr<int> t13 = s2d[0];
+  array_ptr<int> t13a = w2d[0];
+  nt_array_ptr<int> t13b = w2d[0];
+  nt_array_ptr<int> t13c = s2d[0]; // expected-error {{expression of incompatible type 'int checked[10]'}}
   array_ptr<int> t14 = t2d[0];
   array_ptr<int> t15 = u2d[0];
-
+  array_ptr<int> t15a = x2d[0];
+  nt_array_ptr<int> t15b = x2d[0];
+  nt_array_ptr<int> t15c = u2d[0]; // expected-error {{expression of incompatible type 'int checked[10]'}}
 
   // Multi-dimensional array type conversions to pointer types.
   int *t16 = s2d[0];     // expected-error {{expression of incompatible type 'int checked[10]'}}
+  int *t16a = w2d[0];    // expected-error {{expression of incompatible type 'int nt_checked[10]'}}
   int *t17 = t2d[0];
   int *t18 = u2d[0];     // expected-error {{expression of incompatible type 'int checked[10]'}}
+  int *t18a = x2d[0];     // expected-error {{expression of incompatible type 'int nt_checked[10]'}}
   int(*t19)[10] = s2d;   // expected-error {{expression of incompatible type '_Array_ptr<int checked[10]>'}}
+                         // assignment of checked array to unchecked array not allowed
+  int(*t19a)[10] = w2d;  // expected-error {{expression of incompatible type '_Array_ptr<int nt_checked[10]>'}}
                          // assignment of checked array to unchecked array not allowed
   int (*t20)[10] = t2d;
   int (*t21)[10] = u2d;  // expected-error {{expression of incompatible type 'int checked[10][10]'}}
                          // assignment of checked array to unchecked array not allowed
+  int(*t21a)[10] = x2d;  // expected-error {{expression of incompatible type 'int checked[10]nt_checked[10]'}}
+                         // assignment of checked array to unchecked array not allowed
   array_ptr<int[10]> t22 = s2d; // expected-error {{expression of incompatible type '_Array_ptr<int checked[10]>'}}
                                 // assignment of checked to unchecked not allowed
+  array_ptr<int[10]> t22a = w2d; // expected-error {{expression of incompatible type '_Array_ptr<int nt_checked[10]>'}}
+                                 // assignment of checked to unchecked not allowed
+  array_ptr<int checked[10]> t22b = w2d; // expected-error {{expression of incompatible type '_Array_ptr<int nt_checked[10]>'}}
+                                         // assignment of checked to unchecked not allowed
+  array_ptr<int nt_checked[10]> t22c = s2d; // expected-error {{expression of incompatible type '_Array_ptr<int checked[10]>'}}
+                                            // assignment of checked to unchecked not allowed
   array_ptr<int[10]> t23 = t2d;
   array_ptr<int[10]> t24 = u2d; // expected-error {{expression of incompatible type 'int checked[10][10]'}}
                                 // assignment of checked to unchecked not allowed
+  array_ptr<int[10]> t24a = x2d; // expected-error {{expression of incompatible type 'int checked[10]nt_checked[10]'}}
+                                 // assignment of checked to unchecked not allowed
+  array_ptr<int checked[10]> t24b = x2d; // expected-error {{expression of incompatible type 'int checked[10]nt_checked[10]'}}
+                                 // assignment of checked to unchecked not allowed
+  array_ptr<int nt_checked[10]> t24c = u2d; // expected-error {{expression of incompatible type 'int checked[10][10]'}}
+                                         // assignment of checked to unchecked not allowed
   array_ptr<int checked[10]> t25 = s2d;
+  array_ptr<int nt_checked[10]> t25a = w2d;
   array_ptr<int checked[10]> t26 = t2d;
+  array_ptr<int nt_checked[10]> t26a = t2d; // expected-error {{expression of incompatible type 'int [10][10]'}}
   array_ptr<int checked[10]> t27 = u2d;
 
   // Assignments to array-typed parameters are allowed.  The outermost array modifier
@@ -127,13 +205,17 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   q = p;
   s = r;
   r = t;
+  w = x;
   p = r;  // expected-error {{assigning to 'int *' from incompatible type '_Array_ptr<int>'}}
+          // assignment of checked pointer to unchecked pointer not allowed
+  p = w;  // expected-error {{assigning to 'int *' from incompatible type '_Nt_array_ptr<int>'}}
           // assignment of checked pointer to unchecked pointer not allowed
 
   // Assignments to array-typed local and global variables are not allowed
   t = p;  // expected-error {{array type 'int [10]' is not assignable}}
   t = r;  // expected-error {{array type 'int [10]' is not assignable}}
   u = r;  // expected-error {{array type 'int checked[10]' is not assignable}}
+  x = w;  // expected-error {{array type 'int nt_checked[10]' is not assignable}}
   global_arr = p; // expected-error {{array type 'int [10]' is not assignable}}
   global_arr = r; // expected-error {{array type 'int [10]' is not assignable}}
   global_checked_arr = r; // expected-error {{array type 'int checked[10]' is not assignable}}
@@ -142,10 +224,14 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
 // Test that dimensions in multi-dimensional arrays are either all checked or unchecked arrays.
 extern void check_dimensions1(void) {
   int t1 checked[10][5]checked[5];     // multiple checked modifiers are allowed
+  int t1a checked[10][5]nt_checked[5];
   int t2 checked[10][5][5]checked[5];
 
   // checked mixing of checked/unchecked array dimensions
   int t3[10]checked[10];               // expected-error {{unchecked array of checked array not allowed}}
+  int t3a[10]nt_checked[10];           // expected-error {{unchecked array of checked array not allowed}}
+  int t3b nt_checked[10]checked[10];   // expected-error {{only integer and pointer types allowed}}
+  int t3c nt_checked[10][10];          // expected-error {{only integer and pointer types allowed}}
   typedef int dim_unchecked[10];
   dim_unchecked t4 checked[10];        // expected-error {{checked array of unchecked array not allowed \
 ('dim_unchecked' is an unchecked array)}}
@@ -173,10 +259,16 @@ extern void check_dimensions1(void) {
 extern void check_dimensions2(int r2d checked[][10] : count(len), int len) {
 }
 
+extern void check_dimensions2a(int r2d checked[]nt_checked[10] : count(len), int len) {
+}
+
 extern void check_dimensions3(int (r2d checked[])[10] : count(len), int len) {
 }
 
 extern void check_dimensions4(int r2d []checked[10] : count(len), int len) { // expected-error {{unchecked array of checked array not allowed}}
+}
+
+extern void check_dimensions4a(int r2d[]nt_checked[10] : count(len), int len) { // expected-error {{unchecked array of checked array not allowed}}
 }
 
 extern void check_dimensions5(int (r2d[])checked[10] : count(len), int len) { // expected-error {{unchecked array of checked array not allowed}}
@@ -201,10 +293,12 @@ extern void check_dimensions8(int (r2d) checked[const][10] : count(len), int len
 
 // Test assignments between pointers of different kinds with const/volatile
 // attributes on referent types
-extern void check_assign_cv(int param[10], 
-                            int checked_param checked[10], 
+extern void check_assign_cv(int param[10],
+                            int checked_param checked[10],
+                            int nt_checked_param nt_checked[10],
                             int param_const_ptr[const 10], 
                             int checked_param_const_ptr checked[const 10],
+                            int nt_checked_param_const_ptr nt_checked[const 10],
                             const int const_param[10],
                             const int const_checked_param checked[10],
                             const int const_param_const_ptr[const 10],
@@ -213,20 +307,25 @@ extern void check_assign_cv(int param[10],
                             volatile int checked_volatile_param checked[10]) {
   int a[10];
   int b checked[10];
+  // We only spot check a few cases for null-terminated array pointers.
+  int c nt_checked[10];
   const int const_a[10];
   const int const_b checked[10];
+  const int const_c nt_checked[10];
   volatile int volatile_a[10];
 
   int a_const_ptr[const 10]; // expected-error {{type qualifier used in array declarator}}
-    
+
   //
   // check assignments to parameters
   //
   // assign an unchecked array,where the element type does not have modifiers
   param = a;
   checked_param = a;
+  nt_checked_param = c;
   param_const_ptr = a;                // expected-error {{cannot assign to variable}}
   checked_param_const_ptr = a;        // expected-error {{cannot assign to variable}}
+  nt_checked_param_const_ptr = c;     // expected-error {{cannot assign to variable}}
   const_param = a;
   const_checked_param = a;
   const_param_const_ptr = a;          // expected-error {{cannot assign to variable}}
@@ -237,6 +336,8 @@ extern void check_assign_cv(int param[10],
   // assign a checked array, where the element type does not have modifiers
   param = b;                          // expected-error {{incompatible type}}
   checked_param = b;
+  nt_checked_param = c;
+  nt_checked_param = b;               // expected-error {{incompatible type}}
   param_const_ptr = b;                // expected-error {{cannot assign to variable}}
   checked_param_const_ptr = b;        // expected-error {{cannot assign to variable}}
   const_param = b;                    // expected-error {{incompatible type}}
@@ -248,6 +349,7 @@ extern void check_assign_cv(int param[10],
   // check assigning an unchecked array where the element type has modifiers
   param = const_a;                    // expected-warning {{discards qualifiers}}
   checked_param = const_a;            // expected-warning {{discards qualifiers}}
+  nt_checked_param = const_c;         // expected-warning {{discards qualifiers}}
   const_param = const_a;
   const_checked_param = const_a;
   volatile_param = const_a;           // expected-warning {{discards qualifiers}}
@@ -361,15 +463,31 @@ extern void check_assign_cv(int param[10],
 // Test conditional expressions where arms have different
 // kinds of checked and unchecked arrays.
 extern void check_condexpr(int val) {
-  int p [5];
+  int p[5];
   int r checked[5];
   float s[5];
   float u checked[5];
+  int v nt_checked[6];
 
-  int *t1 = val ? p : p;            // T[5] and T[5] OK;
-  array_ptr<int> t2 = val ? p : r;  // T[5] and T checked[5] OK
-  array_ptr<int> t3 = val ? r : p;  // T checked[5] and T[5] OK
-  array_ptr<int> t4 = val ? r : r;  // T checked[5] and T checked[5] OK.
+  // N and M are arbitrary positive integer constants below.
+  int *t1 = val ? p : p;            // T[N] and T[M] OK;
+  array_ptr<int> t2 = val ? p : r;  // T[N] and T checked[M] OK
+  array_ptr<int> t2a = val ? p : v; // T[N] and T nt_checked[M] OK.
+  nt_array_ptr<int> t2b = val ? p : v; // expected-error {{incompatible type}}
+                                       // T[N] and T nt_checked[M] produce
+                                       // only array_ptr.
+  array_ptr<int> t3 = val ? r : p;  // T checked[N] and T[M] OK
+  array_ptr<int> t3a = val ? v : p; // T nt_checked[N] and T[M] OK.
+  nt_array_ptr<int> t3b = val ? v : p; // expected-error {{incompatible type}}
+                                       // But they produce only array_ptr.
+  array_ptr<int> t4 = val ? r : r;  // T checked[N] and T checked[M] OK.
+  array_ptr<int> t4a = val ? r : v;  // T checked[N] and T nt_checked[M] OK.
+  array_ptr<int> t4b = val ? v : r;  // T nt_checked[N] and T checked[M] OK.
+  nt_array_ptr<int> t4c = val ? r : v;  // expected-error {{incompatible type}}
+                                        // But they produce only array_ptr.
+  nt_array_ptr<int> t4d = val ? v : r;  // expected-error {{incompatible type}}
+                                        // But they produce only array_ptr
+  nt_array_ptr<int> t4e = val ? v : v;  // T nt_checked[M] and T nt_checked[N] OK.
 
   // omit assignment because type of expression is not valid when there is an error.
   val ? s : r;     // expected-error {{pointer type mismatch}}
@@ -394,7 +512,9 @@ extern void check_condexpr(int val) {
 
   // Implicit conversion of 0 to a safe pointer type is OK.
   array_ptr<int> t5 = val ? r : 0;
+  array_ptr<int> t5a = val ? v : 0;
   array_ptr<int> t6 = val ? 0 : r;
+  nt_array_ptr<int> t6a = val ? 0 : v;
   array_ptr<float> t7 = val ? u : 0;
   array_ptr<float> t8 = val ? 0 : u;
 }
@@ -405,11 +525,13 @@ extern void check_condexpr_2d(int val) {
   float s[5][6];
   float u checked[5][6];
   int y checked[5][20];
+  int z checked[5]nt_checked[6];
 
   int (*t1)[6] = val ? p : p;                  // T[5][6] and T[5][6] OK;
   array_ptr<int checked[6]> t2 = val ? p : r;  // T[5][6] and T checked[5][6] OK
   array_ptr<int checked[6]> t3 = val ? r : p;  // T checked[5][6] and T[5][6] OK
   array_ptr<int checked[6]> t4 = val ? r : r;  // T checked[5][6] and T checked[5][6] OK.
+  array_ptr<int nt_checked[6]> t4a = val ? z : z;  // T checked[5][6] and T checked[5][6] OK.
 
   array_ptr<int [6]> t5 = val ? p : r;  // expected-error {{incompatible type}}
                                         // T[5][6] and T checked[5][6] produce a checked array
@@ -417,6 +539,10 @@ extern void check_condexpr_2d(int val) {
                                         // T checked[5][6] and T[5][6] produce a checked array
   array_ptr<int [6]> t7 = val ? r : r;  // expected-error {{incompatible type}}
                                         // T checked[5][6] and T checked[5][6] produce a checked array
+  array_ptr<int[6]> t7a = val ? z : z;  // expected-error {{incompatible type}}
+                                        // T nt_checked[5][6] and T nt_checked[5][6] produce an nt_checked array
+  array_ptr<int checked[6]> t7b = val ? z : z; // expected-error {{incompatible type}}
+                                       // T checked[5]nt_checked[6] and T checked[5]nt_checked[6] produce an nt_checked array
 
   // omit assignment because type of expression is not valid when there is an error.
   val ? s : r;     // expected-error {{pointer type mismatch}}
@@ -444,6 +570,13 @@ extern void check_condexpr_2d(int val) {
   val ? r : y;      // expected-error {{pointer type mismatch}}
                     // different dimension sizes are not OK
 
+  // check that mismatching checkedness of inner arrays causes an error.
+  val ? p : z;   // expected-error {{pointer type mismatch}}
+  val ? z : p;   // expected-error {{pointer type mismatch}}
+  val ? r : z;   // expected-error {{pointer type mismatch}}
+  val ? z : r;   // expected-error {{pointer type mismatch}}
+
+
   // Implicit conversion of 0 to a checked pointer type is OK.
   array_ptr<int checked[6]> t11 = val ? r : 0;
   array_ptr<int checked[6]> t12 = val ? 0 : r;
@@ -461,7 +594,10 @@ extern void check_condexpr_cv(void)
   volatile int p_volatile[5];
   int r checked[5];
   const int r_const checked[5] = { 0, 1, 2, 3, 4};
-  volatile int r_volatile[5];
+  volatile int r_volatile checked[5];
+  int s nt_checked[5];
+  const int s_const nt_checked[5] = { 0, 1, 2, 3, 0 };
+  volatile int s_volatile nt_checked[5];
 
   // test different kinds of pointers with const modifiers
   const int *t1 = val ? p : p_const;       // int * and const int * OK
@@ -485,6 +621,20 @@ extern void check_condexpr_cv(void)
   array_ptr<const int> t32 = val ? r_const : r;       // array_ptr<const int> and array_ptr<int> OK
   array_ptr<const int> t33 = val ? r_const : r_const; // array_ptr<const int> and array_ptr<const int> OK
 
+  array_ptr<const int> t25a = val ? p : s_const;       // int * and nt_array_ptr<const int> OK
+  array_ptr<const int> t26a = val ? s_const : p;       // nt_array_ptr<const int> and int * OK
+  array_ptr<const int> t27a = val ? p_const : s;       // const int * and nt_array_ptr<int> OK
+  array_ptr<const int> t28a = val ? s : p_const;       // nt_array_ptr<int> and const int * OK
+  array_ptr<const int> t29a = val ? p_const : s_const; // const int * and nt_array_ptr<const int> OK
+  array_ptr<const int> t30a = val ? s_const : p_const; // nt_array_ptr<const int> and const int * OK
+  array_ptr<const int> t31a = val ? s : r_const;       // nt_array_ptr<int> and array_ptr<const int> OK
+  array_ptr<const int> t32a = val ? r_const : s;       // array_ptr<const int> and nt_array_ptr<int> OK
+  array_ptr<const int> t33a = val ? s_const : r_const; // nt_array_ptr<const int> and array_ptr<const int> OK
+  array_ptr<const int> t33b = val ? r_const : s_const; // array_ptr<const int> and nt_array_ptr<const int> OK
+  array_ptr<const int> t33c = val ? s : s_const;       // nt_array_ptr<int> and nt_array_ptr<const int> OK
+  array_ptr<const int> t33d = val ? s_const : s;       // nt_array_ptr<const int> and nt_array_ptr<int> OK
+  array_ptr<const int> t33e = val ? s_const : s_const; // nt_array_ptr<const int> and nt_array_ptr<const int> OK
+
   array_ptr<int> t34 = val ? p : r_const;   // expected-warning {{discards qualifiers}}
                                             // int * and array_ptr<const int> produce array_ptr<const int>
   array_ptr<int> t35 = val ? r_const : p;   // expected-warning {{discards qualifiers}}
@@ -503,6 +653,35 @@ extern void check_condexpr_cv(void)
                                             // array_ptr<const int> and array_ptr<int> produce array_ptr<const int>
   array_ptr<int> t42 = val ? r_const : r_const;   // expected-warning {{discards qualifiers}}
                                             // array_ptr<const int> and array_ptr<const int> produce array_ptr<const int>
+
+  array_ptr<int> t34a = val ? p : s_const;  // expected-warning {{discards qualifiers}}
+                                            // int * and nt_array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t35a = val ? s_const : p;  // expected-warning {{discards qualifiers}}
+                                            // nt_array_ptr<const int> and int * produce array_ptr<const int>
+  array_ptr<int> t36a = val ? p_const : s;  // expected-warning {{discards qualifiers}}
+                                            // const int * and nt_array_ptr<int> produce array_ptr<const int>
+  array_ptr<int> t37a= val ? s : p_const;   // expected-warning {{discards qualifiers}}
+                                            // nt_array_ptr<int> and const int * produce array_ptr<const int>
+  array_ptr<int> t38a = val ? p_const : s_const;  // expected-warning {{discards qualifiers}}
+                                                  // const int * and nt_array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t39a = val ? s_const : p_const;  // expected-warning {{discards qualifiers}}
+                                                  // nt_array_ptr<const int> and const int * produce array_ptr<const int>
+  array_ptr<int> t40a = val ? s : r_const;  // expected-warning {{discards qualifiers}}
+                                            // nt_array_ptr<int> and array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t41a = val ? r_const : s;  // expected-warning {{discards qualifiers}}
+                                            // array_ptr<const int> and nt_array_ptr<int> produce array_ptr<const int>
+  array_ptr<int> t42a = val ? r_const : s_const;  // expected-warning {{discards qualifiers}}
+                                                  // array_ptr<const int> and nt_array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t43a = val ? s_const : r_const;  // expected-warning {{discards qualifiers}}
+                                                  // nt_array_ptr<const int> and array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t43b = val ? r_const : s_const; // expected-warning {{discards qualifiers}}
+                                                 // array_ptr<const int> and nt_array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t43c = val ? s : s_const;       // expected-warning {{discards qualifiers}}
+                                                 // nt_array_ptr<int> and nt_array_ptr<const int> produce array_ptr<const int>
+  array_ptr<int> t43d = val ? s_const : s;       // expected-warning {{discards qualifiers}}
+                                                 // nt_array_ptr<const int> and nt_array_ptr<int> produce array_ptr<const int>
+  array_ptr<int> t42e = val ? s_const : s_const; // expected-warning {{discards qualifiers}}
+                                                 // nt_array_ptr<const int> and nt_array_ptr<const int> produce array_ptr<const int>
 
   // test different kinds of pointers with volatile modifers
   volatile int *t50 = val ? p : p_volatile;          // int * and volatile int * OK
@@ -526,6 +705,20 @@ extern void check_condexpr_cv(void)
   array_ptr<volatile int> t81 = val ? r_volatile : r;          // array_ptr<volatile int> and array_ptr<int> OK
   array_ptr<volatile int> t82 = val ? r_volatile : r_volatile; // array_ptr<volatile int> and array_ptr<volatile int> OK
 
+  array_ptr<volatile int> t74a = val ? p : s_volatile;          // int * and nt_array_ptr<volatile int> OK
+  array_ptr<volatile int> t75a = val ? s_volatile : p;          // nt_array_ptr<volatile int> and int * OK
+  array_ptr<volatile int> t76a = val ? p_volatile : s;          // volatile int * and nt_array_ptr<int> OK
+  array_ptr<volatile int> t77a = val ? s : p_volatile;          // nt_array_ptr<int> and volatile int * OK
+  array_ptr<volatile int> t78a = val ? p_volatile : s_volatile; // volatile int * and nt_array_ptr<volatile int> OK
+  array_ptr<volatile int> t79a = val ? s_volatile : p_volatile; // nt_array_ptr<volatile int> and volatile int * OK
+  array_ptr<volatile int> t80a = val ? s : r_volatile;          // nt_array_ptr<int> and nt_array_ptr<volatile int> OK
+  array_ptr<volatile int> t81a = val ? r_volatile : s;          // nt_array_ptr<volatile int> and nt_array_ptr<int> OK
+  array_ptr<volatile int> t82a = val ? r_volatile : s_volatile;  // array_ptr<volatile int> and nt_array_ptr<volatile int> OK
+  array_ptr<volatile int> t82b = val ? s_volatile : r_volatile; // nt_array_ptr<volatile int> and array_ptr<volatile int> OK
+  array_ptr<volatile int> t82c = val ? s : s_volatile;          // nt_array_ptr<int> and nt_array_ptr<volatile int> OK
+  array_ptr<volatile int> t82d = val ? s_volatile : s;          // nt_array_ptr<volatile int> and nt_array_ptr<int> OK
+  array_ptr<volatile int> t82e = val ? s_volatile : s_volatile; // nt_array_ptr<volatile int> and nt_array_ptr<volatile int> OK
+
   array_ptr<int> t83 = val ? p : r_volatile;          // expected-warning {{discards qualifiers}}
                                                       // int * and array_ptr<volatile int> produce array_ptr<volatile int>
   array_ptr<int> t84 = val ? r_volatile : p;          // expected-warning {{discards qualifiers}}
@@ -544,6 +737,33 @@ extern void check_condexpr_cv(void)
                                                       // array_ptr<volatile int> and array_ptr<int> produce array_ptr<volatile int>
   array_ptr<int> t92 = val ? r_volatile : r_volatile;  // expected-warning {{discards qualifiers}}
                                                        // array_ptr<volatile int> and array_ptr<volatile int> produce array_ptr<volatile int>
+
+  array_ptr<int> t83a = val ? p : s_volatile;          // expected-warning {{discards qualifiers}}
+                                                       // int * and nt_array_ptr<volatile int> produce array_ptr<volatile int>
+  array_ptr<int> t84a = val ? s_volatile : p;          // expected-warning {{discards qualifiers}}
+                                                       // mt+array_ptr<volatile int> and int * produce array_ptr<volatile int>
+  array_ptr<int> t85a = val ? p_volatile : s;          // expected-warning {{discards qualifiers}}
+                                                       // volatile int * and nt_array_ptr<int> produce array_ptr<volatile int>
+  array_ptr<int> t86a = val ? s : p_volatile;          // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<int> and volatile int * produce array_ptr<volatile int>
+  array_ptr<int> t87a = val ? p_volatile : s_volatile; // expected-warning {{discards qualifiers}}
+                                                       // volatile int * and nt_array_ptr<volatile int> produce array_ptr<volatile int>
+  array_ptr<int> t88a = val ? s_volatile : p_volatile; // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<volatile int> and volatile int * produce array_ptr<volatile int>
+  array_ptr<int> t89a = val ? s : r_volatile;          // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<int> and array_ptr<volatile int> produce array_ptr<volatile int>
+  array_ptr<int> t90a = val ? r_volatile : s;          // expected-warning {{discards qualifiers}}
+                                                       // array_ptr<volatile int> and nt_array_ptr<int> produce array_ptr<volatile int>
+  array_ptr<int> t92a = val ? s : r_volatile;          // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<volatile int> and array_ptr<volatile int> produce array_ptr<volatile int>
+  array_ptr<int> t92b = val ? r_volatile : s_volatile; // expected-warning {{discards qualifiers}}
+                                                        // array_ptr<volatile int> and nt_array_ptr<volatile int> produce array_ptr<volatile int>
+  array_ptr<int> t92c = val ? s : s_volatile;          // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<int> and nt_array_ptr<volatile int> produce array_ptr<volatile int>
+  array_ptr<int> t92d = val ? s_volatile : s;          // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<volatile int> and nt_array_ptr<int> produce array_ptr<volatile int>
+  array_ptr<int> t92e = val ? s_volatile : s_volatile; // expected-warning {{discards qualifiers}}
+                                                       // nt_array_ptr<volatile int> and nt_array_ptr<volatile int> produce array_ptr<volatile int>
 }
 
 // Define functions used to test typechecking of call expressions.
@@ -555,6 +775,10 @@ extern void f2(int p[10], int y) {
 }
 
 extern void f3(int p checked[10], int y) {
+  *p = y;
+}
+
+extern void f3a(int p nt_checked[10], int y) {
   *p = y;
 }
 
@@ -573,16 +797,28 @@ extern void f7(array_ptr<int[10]> p, int y) {
 extern void f8(int(*p) checked[10], int y) {
 }
 
+extern void f8a(int(*p) nt_checked[10], int y) {
+}
+
 extern void f9(ptr<int checked[10]> p, int y) {
 }
 
+extern void f9a(ptr<int nt_checked[10]> p, int y) {
+}
+
 extern void f10(array_ptr<int checked[10]> p, int y) {
+}
+
+extern void f10a(array_ptr<int nt_checked[10]> p, int y) {
 }
 
 extern void f11(int p[10][10], int y) {
 }
 
 extern void f12(int p checked[10][10],int y) {
+}
+
+extern void f12a(int p checked[10]nt_checked[10], int y) {
 }
 
 extern void f13(_Bool p, int y) {
@@ -603,6 +839,9 @@ extern void f1_const(const int p[10], int y) {
 extern void f2_const(const int p checked[10], int y) {
 }
 
+extern void f2a_const(const int p checked[10], int y) {
+}
+
 // Spot check second parameter whose type invovles an array
 //
 
@@ -617,105 +856,184 @@ extern void g3(int y, int p checked[10]) {
   *p = y;
 }
 
+extern void g3a(int y, int p nt_checked[10]) {
+  *p = y;
+}
+
 extern void check_call(void) {
   int x[10];
   int y checked[10];
   int x2d[10][10];
   int y2d checked[10][10];
+  int z nt_checked[10];
+  int z2d checked[10]nt_checked[10];
 
 
   // f1(int *p, int y)
   f1(x, 0);
   f1(y, 0);              // expected-error {{parameter of incompatible type 'int *'}}
+  f1(z, 0);              // expected-error {{parameter of incompatible type 'int *'}}
   f1(x2d, 0);            // expected-warning {{incompatible pointer types passing}}
   f1(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int *'}}
+  f1(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type 'int *'}}
 
   // f2(int p[10], int y)
   f2(x, 0);
   f2(y, 0);              // expected-error {{parameter of incompatible type 'int *'}}
+  f2(z, 0);              // expected-error {{parameter of incompatible type 'int *'}}
   f2(x2d, 0);            // expected-warning {{incompatible pointer types passing}}
   f2(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int *'}}
+  f2(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type 'int *'}}
 
   // f3(int p checked[10], int y)
   f3(x, 0);
   f3(y, 0);
+  f3(z, 0);              // TODO: this will produce a bounds error.
   f3(x2d, 0);            // expected-error {{parameter of incompatible type}}
   f3(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Array_ptr<int>'}}
+  f3(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type '_Array_ptr<int>'}}
+
+  // f3a(int p nt_checked[10], int y)
+  f3a(x, 0);             // expected-error {{passing 'int [10]' to parameter of incompatible type '_Nt_array_ptr<int>'}}
+  f3a(y, 0);             // expected-error {{passing 'int checked[10]' to parameter of incompatible type '_Nt_array_ptr<int>'}}
+  f3a(z, 0);
+  f3a(x2d, 0);            // expected-error {{parameter of incompatible type}}
+  f3a(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Nt_array_ptr<int>'}}
+  f3a(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type '_Nt_array_ptr<int>'}}
+
 
   // f4(int **p, int y);
   f4(x, 0);              // expected-warning {{incompatible pointer types passing}}
   f4(y, 0);              // expected-error {{passing 'int checked[10]' to parameter of incompatible type 'int **'}}
+  f4(z, 0);              // expected-error {{passing 'int nt_checked[10]' to parameter of incompatible type 'int **'}}
   f4(x2d, 0);            // expected-warning {{incompatible pointer types passing}}
   f4(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int **'}}
+  f4(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type 'int **'}}
 
   // f5(int (*p)[10], int y);
   f5(x, 0);              // expected-warning {{incompatible pointer types passing}}
   f5(y, 0);              // expected-error {{passing 'int checked[10]' to parameter of incompatible type 'int (*)[10]'}}
+  f5(z, 0);              // expected-error {{passing 'int nt_checked[10]' to parameter of incompatible type 'int (*)[10]'}}
   f5(x2d, 0);            // OK
   f5(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type 'int (*)[10]'}}
+  f5(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type 'int (*)[10]'}}
 
    // f6(ptr<int[10]>, int y);
   f6(x, 0);              // expected-error {{parameter of incompatible type}}
   f6(y, 0);              // expected-error {{passing 'int checked[10]' to parameter of incompatible type '_Ptr<int [10]>'}}
+  f6(z, 0);              // expected-error {{passing 'int nt_checked[10]' to parameter of incompatible type '_Ptr<int [10]>'}}
   f6(x2d, 0);            // OK
   f6(y2d, 0);            // expected-error {{passing 'int checked[10][10]' to parameter of incompatible type '_Ptr<int [10]>'}}
+  f6(z2d, 0);            // expected-error {{passing 'int checked[10]nt_checked[10]' to parameter of incompatible type '_Ptr<int [10]>'}}
 
    // f7(array_ptr<int[10]>, int y);
   f7(x, 0);              // expected-error {{parameter of incompatible type}}
   f7(y, 0);              // expected-error {{parameter of incompatible type}}
+  f7(z, 0);              // expected-error {{parameter of incompatible type}}
   f7(x2d, 0);            // OK
   f7(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f7(z2d, 0);            // expected-error {{parameter of incompatible type}}
 
   // f8(int (*p) checked[10], int y);
   f8(x, 0);              // expected-error {{parameter of incompatible type}}
   f8(y, 0);              // expected-error {{parameter of incompatible type}}
+  f8(z, 0);              // expected-error {{parameter of incompatible type}}
   f8(x2d, 0);            // OK
   f8(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f8(z2d, 0);            // expected-error {{parameter of incompatible type}}
+
+  // f8a(int (*p) nt_checked[10], int y);
+  f8a(x, 0);              // expected-error {{parameter of incompatible type}}
+  f8a(y, 0);              // expected-error {{parameter of incompatible type}}
+  f8a(z, 0);              // expected-error {{parameter of incompatible type}}
+  f8a(x2d, 0);            // expected-error {{parameter of incompatible type}}
+  f8a(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f8a(z2d, 0);            // expected-error {{parameter of incompatible type}}
 
   // f9(ptr<int checked[10]> p, int y);
-  f8(x, 0);              // expected-error {{parameter of incompatible type}}
-  f8(y, 0);              // expected-error {{parameter of incompatible type}}
-  f8(x2d, 0);            // OK
-  f8(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f9(x, 0);              // expected-error {{parameter of incompatible type}}
+  f9(y, 0);              // expected-error {{parameter of incompatible type}}
+  f9(z, 0);              // expected-error {{parameter of incompatible type}}
+  f9(x2d, 0);            // OK
+  f9(y2d, 0);            // OK
+  f9(z2d, 0);            // expected-error {{parameter of incompatible type}}
+
+  // f9a(ptr<int nt_checked[10]> p, int y);
+  f9a(x, 0);              // expected-error {{parameter of incompatible type}}
+  f9a(y, 0);              // expected-error {{parameter of incompatible type}}
+  f9a(z, 0);              // expected-error {{parameter of incompatible type}}
+  f9a(x2d, 0);            // expected-error {{parameter of incompatible type}}
+  f9a(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f9a(z2d, 0);            // OK
 
   // f10(array_ptr<int checked[10]> p, int y);
   f10(x, 0);              // expected-error {{parameter of incompatible type}}
   f10(y, 0);              // expected-error {{parameter of incompatible type}}
+  f10(z, 0);              // expected-error {{parameter of incompatible type}}
   f10(x2d, 0);            // OK
   f10(y2d, 0);            // OK
+  f10(z2d, 0);            // expected-error {{parameter of incompatible type}}
+
+  // f10a(array_ptr<int nt_checked[10]> p, int y);
+  f10a(x, 0);              // expected-error {{parameter of incompatible type}}
+  f10a(y, 0);              // expected-error {{parameter of incompatible type}}
+  f10a(z, 0);              // expected-error {{parameter of incompatible type}}
+  f10a(x2d, 0);            // expected-error {{parameter of incompatible type}}
+  f10a(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f10a(z2d, 0);            // OK.
 
   // f11(int p[10][10], int y);
   f11(x, 0);              // expected-warning {{incompatible pointer types}}
   f11(y, 0);              // expected-error {{parameter of incompatible type}}
+  f11(z, 0);              // expected-error {{parameter of incompatible type}}
   f11(x2d, 0);            // OK
   f11(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f11(z2d, 0);            // expected-error {{parameter of incompatible type}}
 
   // f12(int p checked[10][10], int y);
   f12(x, 0);              // expected-error {{parameter of incompatible type}}
   f12(y, 0);              // expected-error {{parameter of incompatible type}}
+  f12(z, 0);              // expected-error {{parameter of incompatible type}}
   f12(x2d, 0);            // OK
   f12(y2d, 0);            // OK
+  f12(z2d, 0);            // expected-error {{parameter of incompatible type}}
+
+  // f12a(int p checked[10]nt_checked[10], int y);
+  f12a(x, 0);              // expected-error {{parameter of incompatible type}}
+  f12a(y, 0);              // expected-error {{parameter of incompatible type}}
+  f12a(z, 0);              // expected-error {{parameter of incompatible type}}
+  f12a(x2d, 0);            // expected-error {{parameter of incompatible type}}
+  f12a(y2d, 0);            // expected-error {{parameter of incompatible type}}
+  f12a(z2d, 0);            // OK.
 
   // f13(_Bool b, int y);
   f13(x, 0);              // OK
   f13(y, 0);              // OK
+  f13(z, 0);              // OK
   f13(x2d, 0);            // OK
   f13(y2d, 0);            // OK
+  f13(z2d, 0);            // OK
 
   // spot check calls where an array is the second argument
   g1(0, x);
   g1(0, y);  // expected-error {{parameter of incompatible type}}
+  g1(0, z);  // expected-error {{parameter of incompatible type}}
   g2(0, x);
   g2(0, y);  // expected-error {{parameter of incompatible type}}
+  g2(0, z);  // expected-error {{parameter of incompatible type}}
   g3(0, x);
   g3(0, y);
-
+  g3(0, z);  // TODO: this should produce a bounds error.
+  g3a(0, x); // expected-error {{parameter of incompatible type}}
+  g3a(0, y); // expected-error {{parameter of incompatible type}}
+  g3a(0, z);
 }
 
 extern void check_call_void(void) {
   int val = 0;
   int p[10];
   int r checked[10];
+  int v nt_checked[10];
 
   // TODO: s will need bounds information
   void *s = 0;
@@ -730,11 +1048,16 @@ extern void check_call_void(void) {
   f1_void(p, val);    // param ptr<void>, arg int[10] OK.
   f3_void(r, val);    // param array_ptr<void>, arg int checked[10] OK.
   f3_void(p, val);    // param array_ptr<void>, arg int[10] OK, provided that param has no bounds.
+  f3_void(r, val);    // param array_ptr<void>, arg int checked[10] OK, provided that param has no bounds.
+  f3_void(v, val);    // param array_ptr<void>, arg int nt+checked[10] OK, provided that param has no bounds.
 
   // Expected to not typecheck
   f1_void(r, val);    // expected-error {{incompatible type}}
                       // param void *, arg int checked[10] not OK
+  f1_void(v, val);    // expected-error {{incompatible type}}
+                      // param void *, arg int nt_checked[10] not OK
   f2_void(r, val);    // param ptr<void>, arg int checked[10] OK
+  f2_void(v, val);    // param ptr<void>, arg int nt_checked[10] OK
 
   // Try passing void pointers to functions expected array types
   // f1(int *, int)
@@ -751,6 +1074,11 @@ extern void check_call_void(void) {
   f3(s, 0);           // expected-error {{argument has no bounds}}
   f3(t, 0);           // expected-error {{incompatible type}}
   f3(u, 0);           // expected-error {{argument has no bounds}}
+
+  // f3a(int p nt_checked[10], int)
+  f3a(s, 0);           // expected-error {{incompatible type}}
+  f3a(t, 0);           // expected-error {{incompatible type}}
+  f3a(u, 0);           // expected-error {{incompatible type}}
 }
 
 void check_call_cv(void) {
@@ -759,6 +1087,8 @@ void check_call_cv(void) {
   const int p_const[10] = { 0, 1, 2, 3, 4,5, 6, 7, 8, 9};
   int r checked[10];
   const int r_const checked[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int s nt_checked[10];
+  const int s_const nt_checked[10];
 
   // Parameters that are pointers to constants being passed pointers to non-const & const values.
   f1_const(p, val);           // param const int[10], arg int[10] OK
@@ -767,6 +1097,8 @@ void check_call_cv(void) {
   f2_const(p_const, val);     // param const int checked[10], arg const int[10] OK, provided int * has bounds
   f2_const(r, val);           // param const int checked[10], arg int checked[10] OK
   f2_const(r_const, val);     // param const int checked[10], arg const int checked[10]  OK
+  f2a_const(s, val);           // param const int nt_checked[10], arg int nt_checked[10] OK
+  f2a_const(s_const, val);     // param const int nt_checked[10], arg const int nt_checked[10]  OK
 
   // Parameters that are not pointers to constants being passed arrays of const
   f1(p_const, val);     // expected-warning {{discards qualifiers}}
@@ -774,6 +1106,8 @@ void check_call_cv(void) {
   f2(p_const, val);     // expected-warning {{discards qualifiers}}
                         // param int[10], arg const int[10] not OK
   f3(r_const, val);     // expected-warning {{discards qualifiers}}
+                        // param int checked[10], arg const int checked[10] not OK
+  f3(s_const, val);     // expected-warning {{discards qualifiers}}
                         // param int checked[10], arg const int checked[10] not OK
 }
 
@@ -792,8 +1126,13 @@ extern checked_arr_type h2(void) {    // expected-error {{function cannot return
   return 0;
 }
 
+extern nt_checked_arr_type h2a(void) {    // expected-error {{function cannot return array type}}
+  return 0;
+}
+
 int global[10];
 int checked_global checked[10];
+int nt_checked_global nt_checked[10];
 
 int *h3(void) {
   return global;
@@ -807,6 +1146,10 @@ array_ptr<int> h5(void) {
   return global;
 }
 
+nt_array_ptr<int> h5a(void) {
+  return global;         // expected-error {{incompatible result type}}
+}
+
 int *h6(void) {
   return checked_global; // expected-error {{incompatible result type}}
 }
@@ -815,21 +1158,36 @@ ptr<int> h7(void) {
   return checked_global; // ptr<T> = array_ptr<T> OK
 }
 
+ptr<int> h7a(void) {
+  return nt_checked_global; // ptr<T> = nt_array_ptr<T> OK
+}
+
 array_ptr<int> h8(void) {
   return checked_global;
 }
+
+array_ptr<int> h8a(void) {
+  return nt_checked_global;
+}
+
+nt_array_ptr<int> h8b(void) {
+  return checked_global;    // expected-error {{incompatible result type}}
+}
+
+nt_array_ptr<int> h8c(void) {
+  return nt_checked_global;
+}
+
 
 int *h9(int arr[10]) {
   return arr;
 }
 
-int global_arr1[10];
-
-ptr<int> h10(void) {  
-  return global_arr1;
+array_ptr<int> h11(int arr checked[10]) {
+  return arr;
 }
 
-array_ptr<int> h11(int arr checked[10]) {
+array_ptr<int> h11a(int arr nt_checked[10]) {
   return arr;
 }
 
@@ -837,13 +1195,26 @@ int *h12(int arr checked[10]) {
   return arr;  // expected-error {{incompatible result type}}
 }
 
+int *h12a(int arr nt_checked[10]) {
+  return arr;  // expected-error {{incompatible result type}}
+}
+
 ptr<int> h13(int arr checked[10]) {
   return arr;  // ptr<T> = array_ptr<T> OK
 }
 
-array_ptr<int> h14(int arr checked[10]) {
+ptr<int> h13a(int arr nt_checked[10]) {
+  return arr;  // ptr<T> = nt_array_ptr<T> OK
+}
+
+nt_array_ptr<int> h14(int arr checked[10]) {
+  return arr;  // expected-error {{incompatible result type}}
+}
+
+nt_array_ptr<int> h14a(int arr nt_checked[10]) {
   return arr;
 }
+
 
 int *h15(int arr checked[]) {
   return arr;  // expected-error {{incompatible result type}}
@@ -853,7 +1224,15 @@ ptr<int> h17(int arr checked[]) {
   return arr;  // expected-error {{expression has no bounds}}, ptr<T> = array_ptr<T> OK
 }
 
+ptr<int> h17a(int arr nt_checked[]) {
+  return arr;  // expected-error {{expression has no bounds}}, ptr<T> = nt_array_ptr<T> OK
+}
+
 array_ptr<int> h18(int arr checked[]) {
+  return arr;
+}
+
+array_ptr<int> h18a(int arr nt_checked[]) {
   return arr;
 }
 
@@ -876,11 +1255,25 @@ int (*h22(int arr checked[10][10]))[10] {
   return arr;  // expected-error {{incompatible result type}}
 }
 
+// h22a is a function that returns a pointer to a 10-element array of integers.
+int(*h22a(int arr checked[10]nt_checked[10]))[10]{
+  return arr;  // expected-error {{incompatible result type}}
+}
+
 ptr<int[10]> h23(int arr checked[10][10]) {
   return arr;  // expected-error {{incompatible result type}}
 }
 
+ptr<int[10]> h23a(int arr checked[10]nt_checked[10]) {
+  return arr;  // expected-error {{incompatible result type}}
+}
+
+
 array_ptr<int[10]> h24(int arr checked[10][10]) {
+  return arr;  // expected-error {{incompatible result type}}
+}
+
+array_ptr<int[10]> h24a(int arr checked[10]nt_checked[10]) {
   return arr;  // expected-error {{incompatible result type}}
 }
 
@@ -889,21 +1282,39 @@ int (*h25(int arr checked[10][10])) checked[10]{
   return arr;  // expected-error {{incompatible result type}}
 }
 
+int(*h25a(int arr checked[10]nt_checked[10])) checked[10]{
+  return arr;  // expected-error {{incompatible result type}}
+}
+
+
 ptr<int checked[10]> h26(int arr checked[10][10]) {
   return arr;  // ptr<T> = array_ptr<T> OK
+}
+
+ptr<int checked[10]> h26a(int arr checked[10]nt_checked[10]) {
+  return arr;  // expected-error {{incompatible result type}}
 }
 
 array_ptr<int checked[10]> h27(int arr checked[10][10]) {
   return arr;
 }
 
+array_ptr<int nt_checked[10]> h27a(int arr checked[10]checked[10]) {
+  return arr;  // expected-error {{incompatible result type}}
+}
+
+array_ptr<int nt_checked[10]> h27b(int arr checked[10]nt_checked[10]) {
+  return arr;
+}
 
 void check_pointer_arithmetic(void) {
   int p[5];
   int r checked[5];
+  int s nt_checked[5];
 
   int *p_tmp;
   array_ptr<int> r_tmp;
+  nt_array_ptr<int> s_tmp;
 
   p_tmp = p + 5;
   p_tmp = 5 + p;
@@ -940,6 +1351,25 @@ void check_pointer_arithmetic(void) {
 
   // adding two pointers is not allowed
   r + r; // expected-error {{invalid operands}}
+
+  s_tmp = s + 5;
+  s_tmp = 5 + s;
+  s_tmp = s_tmp - 2;
+  s_tmp = 2 - s;         // expected-error {{invalid operands}}
+  s_tmp = s++;        // expected-error {{cannot increment value}}
+  s_tmp = s--;        // expected-error {{cannot decrement value}}
+  s_tmp = ++s;        // expected-error {{cannot increment value}}
+  s_tmp = --s;        // expected-error {{cannot decrement value}}
+  s_tmp = (s += 1);   // expected-error {{invalid operands}}
+  s_tmp = (s -= 1);   // expected-error {{invalid operands}}
+                      // 0 interpreted as an integer, not null
+  s_tmp = s + 0;
+  s_tmp = 0 + s;
+  s_tmp = s - 0;
+  s_tmp = 0 - s; // expected-error {{invalid operands to binary expression}}
+
+                 // adding two pointers is not allowed
+  s + s; // expected-error {{invalid operands}}
 }
 
 void check_pointer_difference(int flag) {
@@ -952,6 +1382,7 @@ void check_pointer_difference(int flag) {
 
   int a_int[5];
   int checked_a_int checked[5];
+  int nt_checked_a_int checked[5];
 
   float a_float[5];
   float checked_a_float checked[5];
@@ -964,14 +1395,26 @@ void check_pointer_difference(int flag) {
   // pointer - array
   count = p_int - a_int;
   count = p_int - checked_a_int;
+  count = p_int - nt_checked_a_int;
   count = r_int - a_int;
   count = r_int - checked_a_int;
+  count = r_int - nt_checked_a_int;
 
   // array - pointer
   count = a_int - p_int;
   count = checked_a_int - p_int;
+  count = nt_checked_a_int - p_int;
   count = a_int - r_int;
   count = checked_a_int - r_int;
+  count = nt_checked_a_int - r_int;
+
+  // array - array
+  count = a_int - checked_a_int;
+  count = checked_a_int - a_int;
+  count = nt_checked_a_int - checked_a_int;
+  count = checked_a_int - nt_checked_a_int;
+  count = nt_checked_a_int - nt_checked_a_int;
+
 
   // spot check mismatched types
   count = a_float - p_int;          // expected-error {{not pointers to compatible types}}
@@ -985,6 +1428,7 @@ void check_pointer_relational_compare(void) {
   int val_int[5];
   float val_float[5];
   int checked_val_int checked[5];
+  int nt_checked_val_int nt_checked[5];
   float checked_val_float checked[5];
 
   float *p_float = val_float;
@@ -995,24 +1439,29 @@ void check_pointer_relational_compare(void) {
 
   array_ptr<float> r_float = val_float;
   array_ptr<int> r_int = val_int;
+  nt_array_ptr<int> s_int = 0;
 
   // relational comparisons between pointers and unchecked arrays;
   result = val_int < p_int;
   result = val_int <= q_int;
   result = val_int >= r_int;
+  result = val_int >= s_int;
 
   result = p_int > val_int;
   result = q_int < val_int;
   result = r_int <= val_int;
+  result = s_int <= val_int;
 
   // relational comparisons between pointers and checked arrays;
   result = checked_val_int < p_int;
   result = checked_val_int <= q_int;
   result = checked_val_int >= r_int;
+  result = checked_val_int >= s_int;
 
   result = p_int > checked_val_int;
   result = q_int < checked_val_int;
   result = r_int <= checked_val_int;
+  result = s_int <= checked_val_int;
 
   // invalid relational comparisons
 
@@ -1024,6 +1473,7 @@ void check_pointer_relational_compare(void) {
   result = p_int > val_float;  // expected-warning {{comparison of distinct pointer types}}
   result = q_float < val_int;  // expected-warning {{comparison of distinct pointer types}}
   result = r_int <= val_float; // expected-warning {{comparison of distinct pointer types}}
+  result = s_int <= val_float; // expected-warning {{comparison of distinct pointer types}}
 
   // spot check comparisons between pointers and checked arrays;
   result = checked_val_int < p_float;  // expected-warning {{comparison of distinct pointer types}} 
@@ -1033,6 +1483,7 @@ void check_pointer_relational_compare(void) {
   result = p_int > checked_val_float;  // expected-warning {{comparison of distinct pointer types}}
   result = q_float < checked_val_int;  // expected-warning {{comparison of distinct pointer types}}
   result = r_int <= checked_val_float; // expected-warning {{comparison of distinct pointer types}}
+  result = s_int <= checked_val_float; // expected-warning {{comparison of distinct pointer types}}
 }
 
 void check_pointer_equality_compare(void) {
@@ -1041,6 +1492,7 @@ void check_pointer_equality_compare(void) {
   int val_int[5];
   float val_float[5];
   int checked_val_int checked[5];
+  int nt_checked_val_int nt_checked[5];
   float checked_val_float checked[5];
 
   float *p_float = val_float;
@@ -1051,24 +1503,37 @@ void check_pointer_equality_compare(void) {
 
   array_ptr<float> r_float = val_float;
   array_ptr<int> r_int = val_int;
+  nt_array_ptr<int> s_int = 0;
 
   // equality/inequality comparisons between pointers and unchecked arrays;
   result = val_int == p_int;
   result = val_int != q_int;
   result = val_int == r_int;
+  result = val_int == s_int;
 
   result = p_int != val_int;
   result = q_int == val_int;
   result = r_int != val_int;
+  result = s_int != val_int;
 
   // equality/inequality comparisons between pointers and checked arrays;
   result = checked_val_int == p_int;
   result = checked_val_int != q_int;
   result = checked_val_int == r_int;
 
+  result = nt_checked_val_int == p_int;
+  result = nt_checked_val_int != q_int;
+  result = nt_checked_val_int == r_int;
+  result = nt_checked_val_int == s_int;
+
   result = p_int != checked_val_int;
   result = q_int == checked_val_int;
   result = r_int != checked_val_int;
+
+  result = p_int != nt_checked_val_int;
+  result = q_int == nt_checked_val_int;
+  result = r_int != nt_checked_val_int;
+  result = s_int != nt_checked_val_int;
 
   // invalid equality/inequality comparisons
 
@@ -1076,15 +1541,21 @@ void check_pointer_equality_compare(void) {
   result = val_int == p_float;  // expected-warning {{comparison of distinct pointer types}}
   result = val_float != q_int; // expected-warning {{comparison of distinct pointer types}}
   result = val_int == r_float; // expected-warning {{comparison of distinct pointer types}}
+  result = val_float != s_int; // expected-warning {{comparison of distinct pointer types}}
 
   result = p_int != val_float;  // expected-warning {{comparison of distinct pointer types}}
   result = q_float == val_int;  // expected-warning {{comparison of distinct pointer types}}
   result = r_int != val_float; // expected-warning {{comparison of distinct pointer types}}
+  result = s_int != val_float; // expected-warning {{comparison of distinct pointer types}}
 
   // spot check equality comparisons between pointers and checked arrays;
   result = checked_val_int == p_float;  // expected-warning {{comparison of distinct pointer types}} 
   result = checked_val_float != q_int; // expected-warning {{comparison of distinct pointer types}}
   result = checked_val_int != r_float; // expected-warning {{comparison of distinct pointer types}}
+
+  result = nt_checked_val_int == p_float;  // expected-warning {{comparison of distinct pointer types}} 
+  result = nt_checked_val_int!= q_float; // expected-warning {{comparison of distinct pointer types}}
+  result = nt_checked_val_int != r_float; // expected-warning {{comparison of distinct pointer types}}
 
   result = p_int == checked_val_float;  // expected-warning {{comparison of distinct pointer types}}
   result = q_float != checked_val_int;  // expected-warning {{comparison of distinct pointer types}}
@@ -1094,37 +1565,52 @@ void check_pointer_equality_compare(void) {
 void check_logical_operators(void) {
   int p[5];
   int r checked[5];
+  int s nt_checked[5];
 
   _Bool b;
 
   b = !p;
   b = !r;
+  b = !s;
 
   b = p || b;
   b = r || b;
+  b = s || b;
   b = b || p;
   b = b || r;
+  b = b || s;
 
   b = r || p;
+  b = s || p;
   b = p || r;
+  b = p || s;
 
   b = p && b;
   b = r && b;
+  b = s && b;
   b = b && p;
   b = b && r;
+  b = b && s;
 
   b = r && p;
+  b = s && p;
   b = p && r;
+  b = p && s;
 }
 
 void check_cast_operator(void) {
   int x = 0;
   int arr checked[5];
+  int nt_arr nt_checked[5];
 
   // casts involving array types
   array_ptr<int> pax = (array_ptr<int>) &x;
   pax = (int checked[]) &x;   // expected-error {{cast to incomplete type}}
   pax = (int checked[1]) &x;  // expected-error {{arithmetic or pointer type is required}}
+
+  array_ptr<int> nt_pax = (array_ptr<int>) &x;
+  pax = (int nt_checked[]) &x;   // expected-error {{cast to incomplete type}}
+  pax = (int nt_checked[1]) &x;  // expected-error {{arithmetic or pointer type is required}}
 
   // casts involving pointers to array types
 
@@ -1134,10 +1620,23 @@ void check_cast_operator(void) {
   parr = (int(*)checked[5]) ((int(*)checked[]) &arr);
   parr = (int(*)checked[3]) &arr; // expected-error {{incompatible type}}
 
+  ptr<int nt_checked[5]> nt_parr = 0;
+  nt_parr = (int(*)nt_checked[5]) &nt_arr;
+  nt_parr = (int(*)nt_checked[5]) ((int(*)nt_checked[]) &nt_arr);
+  nt_parr = (int(*)nt_checked[3]) &nt_arr; // expected-error {{incompatible type}}
+
+  parr = (int(*)nt_checked[5]) &nt_arr; // expected-error {{incompatible type}}
+  parr = (int(*)nt_checked[5]) ((int(*)nt_checked[]) &nt_arr); // expected-error {{incompatible type}}
+  parr = (int(*)nt_checked[3]) &nt_arr; // expected-error {{incompatible type}}
+
   // ptr to array
   parr = (ptr<int checked[5]>) &arr;
   parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr);
   parr = (ptr<int checked[3]>) &arr; // expected-error {{incompatible type}}
+
+  nt_parr = (ptr<int nt_checked[5]>) &arr;
+  nt_parr = (ptr<int nt_checked[5]>) ((ptr<int checked[]>) &arr);
+  nt_parr = (ptr<int nt_checked[3]>) &arr; // expected-error {{incompatible type}}
 
   // array_ptr to array
   array_ptr<int checked[5]> aparr = 0;
@@ -1151,6 +1650,7 @@ void check_cast_operator(void) {
 void check_illegal_operators(void) {
   int p[5];
   int r checked[5];
+  int s nt_checked[5];
 
   p * 5;  // expected-error {{invalid operands to binary expression}}
   5 * p;  // expected-error {{invalid operands to binary expression}}
@@ -1160,11 +1660,18 @@ void check_illegal_operators(void) {
   5 * r;  // expected-error {{invalid operands to binary expression}}
   r *= 5; // expected-error {{invalid operands to binary expression}}
 
+  s * 5;  // expected-error {{invalid operands to binary expression}}
+  5 * s;  // expected-error {{invalid operands to binary expression}}
+  s *= 5; // expected-error {{invalid operands to binary expression}}
+
   p * p;  // expected-error {{invalid operands to binary expression}}
   p *= p; // expected-error {{invalid operands to binary expression}}
 
   r * r;  // expected-error {{invalid operands to binary expression}}
   r *= r; // expected-error {{invalid operands to binary expression}}
+
+  s * s;  // expected-error {{invalid operands to binary expression}}
+  s *= s; // expected-error {{invalid operands to binary expression}}
 
   //
   // Test /
@@ -1178,11 +1685,19 @@ void check_illegal_operators(void) {
   5 / r;  // expected-error {{invalid operands to binary expression}}
   r /= 5; // expected-error {{invalid operands to binary expression}}
 
+  s / 5;  // expected-error {{invalid operands to binary expression}}
+  5 / s;  // expected-error {{invalid operands to binary expression}}
+  s /= 5; // expected-error {{invalid operands to binary expression}}
+
   p / p;  // expected-error {{invalid operands to binary expression}}
   p /= p; // expected-error {{invalid operands to binary expression}}
 
   r / r;  // expected-error {{invalid operands to binary expression}}
   r /= r; // expected-error {{invalid operands to binary expression}}
+
+  s / s;  // expected-error {{invalid operands to binary expression}}
+  s /= s; // expected-error {{invalid operands to binary expression}}
+
 
   //
   // Test %
@@ -1196,11 +1711,19 @@ void check_illegal_operators(void) {
   5 % r;  // expected-error {{invalid operands to binary expression}}
   r %= 5; // expected-error {{invalid operands to binary expression}}
 
+  s % 5;  // expected-error {{invalid operands to binary expression}}
+  5 % s;  // expected-error {{invalid operands to binary expression}}
+  s %= 5; // expected-error {{invalid operands to binary expression}}
+
+
   p % p;  // expected-error {{invalid operands to binary expression}}
   p %= p; // expected-error {{invalid operands to binary expression}}
 
   r % r;  // expected-error {{invalid operands to binary expression}}
   r %= r; // expected-error {{invalid operands to binary expression}}
+
+  s % s;  // expected-error {{invalid operands to binary expression}}
+  s %= s; // expected-error {{invalid operands to binary expression}}
 
   //
   // Test <<
@@ -1214,11 +1737,18 @@ void check_illegal_operators(void) {
   5 << r;  // expected-error {{invalid operands to binary expression}}
   r <<= 5; // expected-error {{invalid operands to binary expression}}
 
+  s << 5;  // expected-error {{invalid operands to binary expression}}
+  5 << s;  // expected-error {{invalid operands to binary expression}}
+  s <<= 5; // expected-error {{invalid operands to binary expression}}
+
   p << p;  // expected-error {{invalid operands to binary expression}}
   p <<= p; // expected-error {{invalid operands to binary expression}}
 
   r << r;  // expected-error {{invalid operands to binary expression}}
   r <<= r; // expected-error {{invalid operands to binary expression}}
+
+  s << s;  // expected-error {{invalid operands to binary expression}}
+  s <<= s; // expected-error {{invalid operands to binary expression}}
 
   //
   // Test >>
@@ -1231,11 +1761,18 @@ void check_illegal_operators(void) {
   5 >> r;  // expected-error {{invalid operands to binary expression}}
   r >>= 5; // expected-error {{invalid operands to binary expression}}
 
+  s >> 5;  // expected-error {{invalid operands to binary expression}}
+  5 >> s;  // expected-error {{invalid operands to binary expression}}
+  s >>= 5; // expected-error {{invalid operands to binary expression}}
+
   p >> p;  // expected-error {{invalid operands to binary expression}}
   p >>= p; // expected-error {{invalid operands to binary expression}}
 
   r >> r;  // expected-error {{invalid operands to binary expression}}
   r >>= r; // expected-error {{invalid operands to binary expression}}
+
+  s >> s;  // expected-error {{invalid operands to binary expression}}
+  s >>= s; // expected-error {{invalid operands to binary expression}}
 
   //
   // Test |
@@ -1249,11 +1786,18 @@ void check_illegal_operators(void) {
   5 | r;  // expected-error {{invalid operands to binary expression}}
   r |= 5; // expected-error {{invalid operands to binary expression}}
 
+  s | 5;  // expected-error {{invalid operands to binary expression}}
+  5 | s;  // expected-error {{invalid operands to binary expression}}
+  s |= 5; // expected-error {{invalid operands to binary expression}}
+
   p | p;  // expected-error {{invalid operands to binary expression}}
   p |= p; // expected-error {{invalid operands to binary expression}}
 
   r | r;  // expected-error {{invalid operands to binary expression}}
   r |= r; // expected-error {{invalid operands to binary expression}}
+
+  s | s;  // expected-error {{invalid operands to binary expression}}
+  s |= s; // expected-error {{invalid operands to binary expression}}
 
   //
   // Test &
@@ -1267,11 +1811,18 @@ void check_illegal_operators(void) {
   5 & r;  // expected-error {{invalid operands to binary expression}}
   r &= 5; // expected-error {{invalid operands to binary expression}}
 
+  s & 5;  // expected-error {{invalid operands to binary expression}}
+  5 & s;  // expected-error {{invalid operands to binary expression}}
+  s &= 5; // expected-error {{invalid operands to binary expression}}
+
   p & p;  // expected-error {{invalid operands to binary expression}}
   p &= p; // expected-error {{invalid operands to binary expression}}
 
   r & r;  // expected-error {{invalid operands to binary expression}}
   r &= r; // expected-error {{invalid operands to binary expression}}
+
+  s & s;  // expected-error {{invalid operands to binary expression}}
+  s &= s; // expected-error {{invalid operands to binary expression}}
 
   //
   // Test ^
@@ -1285,33 +1836,44 @@ void check_illegal_operators(void) {
   5 ^ r;  // expected-error {{invalid operands to binary expression}}
   r ^= 5; // expected-error {{invalid operands to binary expression}}
 
+  s ^ 5;  // expected-error {{invalid operands to binary expression}}
+  5 ^ s;  // expected-error {{invalid operands to binary expression}}
+  s ^= 5; // expected-error {{invalid operands to binary expression}}
+
   p ^ p;  // expected-error {{invalid operands to binary expression}}
   p ^= p; // expected-error {{invalid operands to binary expression}}
 
   r ^ r;  // expected-error {{invalid operands to binary expression}}
   r ^= r; // expected-error {{invalid operands to binary expression}}
 
+  s ^ s;  // expected-error {{invalid operands to binary expression}}
+  s ^= s; // expected-error {{invalid operands to binary expression}}
+
   //
   // Test ~
   //
   ~p;  // expected-error {{invalid argument type}}
   ~r;  // expected-error {{invalid argument type}}
+  ~s;  // expected-error {{invalid argument type}}
 
   //
   // Test unary -
   //
   -p;  // expected-error {{invalid argument type}}
   -r;  // expected-error {{invalid argument type}}
+  -s;  // expected-error {{invalid argument type}}
 
   //
   // Test unary +
   //
   +p;  // expected-error {{invalid argument type}}
   +r;  // expected-error {{invalid argument type}}
+  +s;  // expected-error {{invalid argument type}}
 }
 
 extern void check_vla(int i) {
   int x[i];
   int y checked[i];     // expected-error {{checked variable-length array not allowed}}
   int z checked[10][i]; // expected-error {{checked variable-length array not allowed}}
+  int z nt_checked[i];  // expected-error {{checked variable-length array not allowed}}
 }

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1382,7 +1382,7 @@ void check_pointer_difference(int flag) {
 
   int a_int[5];
   int checked_a_int checked[5];
-  int nt_checked_a_int checked[5];
+  int nt_checked_a_int nt_checked[5];
 
   float a_float[5];
   float checked_a_float checked[5];
@@ -1875,5 +1875,5 @@ extern void check_vla(int i) {
   int x[i];
   int y checked[i];     // expected-error {{checked variable-length array not allowed}}
   int z checked[10][i]; // expected-error {{checked variable-length array not allowed}}
-  int z nt_checked[i];  // expected-error {{checked variable-length array not allowed}}
+  int a nt_checked[i];  // expected-error {{checked variable-length array not allowed}}
 }

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -284,7 +284,7 @@ extern void check_assign(int val, int *p, ptr<int> q, array_ptr<int> r,
 // the source and/or destination pointers are pointers to void.
 extern void check_assign_void(int val, int *p, ptr<int> q,
                               array_ptr<int> r : count(1),
-                              void *s, ptr<void> t, 
+                              void *s, ptr<void> t,
                               array_ptr<void> u : byte_count(sizeof(int)),
                               nt_array_ptr<int> v : count(1)) {
 
@@ -518,12 +518,13 @@ extern void check_condexpr(int val, int *p, ptr<int> q, array_ptr<int> r,
 // pointer types and one or both of the types of the arms is a
 // pointer to void.
 extern void check_condexpr_void(int val, int *p, ptr<int> q, array_ptr<int> r,
-                                void *s, ptr<void> t, array_ptr<void> u,
-                                nt_array_ptr<int> v) {
+                                void *s : byte_count(sizeof(int)), ptr<void> t,
+                                array_ptr<void> u, nt_array_ptr<int> v) {
 
     // valid combinations of void pointers for the arms of the expressions.
     void *t1 = val ? s : s;           // void * and void * OK
     ptr<void> t2 = val ? s : t;       // void * and ptr<void>  OK
+    ptr<void> t2a = val ? t : s;      // ptr<void> and void * OK
     ptr<void> t3 = val ? t : t;       // ptr<void> and ptr<void> OK
     ptr<void> t4 = val ? t : (void *) &val;  // ptr<void> and void * OK
     array_ptr<void> t5 = val ? u : s; // array_ptr<void> and void * OK

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -29,6 +29,15 @@ extern void check_indirection_array_ptr(array_ptr<int> p : count(1),
 	y = *const_p;
 }
 
+extern void check_indirection_nt_array_ptr(nt_array_ptr<int> p : count(1),
+                                           nt_array_ptr<const int> const_p : count(1),
+                                           int y) {
+  *p = y;
+  y = *p;
+  *const_p = y; // expected-error {{read-only variable is not assignable}}
+  y = *const_p;
+}
+
 extern void check_subscript_unsafe_ptr(int *p, int y) {
     p[0] = y;
     y = p[0]; 
@@ -58,6 +67,19 @@ extern void check_subscript_array_ptr(array_ptr<int> p : count(1),
    y = p_const[0];  // OK
    0[p_const] = y;  // expected-error {{read-only variable is not assignable}}
    y = 0[p_const];  // OK
+}
+
+extern void check_subscript_nt_array_ptr(nt_array_ptr<int> p : count(2),
+                                         nt_array_ptr<const int> p_const : count(2),
+                                         int y) {
+  p[0] = y;  // OK
+  y = p[0];  // OK
+  0[p] = y;  // OK
+  y = 0[p];  // OK
+  p_const[0] = y;  // expected-error {{read-only variable is not assignable}}
+  y = p_const[0];  // OK
+  0[p_const] = y;  // expected-error {{read-only variable is not assignable}}
+  y = 0[p_const];  // OK
 }
 
 // Test assignments between different kinds of pointers, excluding


### PR DESCRIPTION
This change adds tests for parsing and typechecking the new Checked C null-terminated array and pointer types.  This matches a corresponding Checked C clang compiler pull request (https://github.com/Microsoft/checkedc-clang/pull/394).  The changes are integrated into existing test cases for checked arrays and array_ptrs.  

The tests for parsing are straightforward.  The new keywords `nt_checked` and `nt_array_ptr` can be used in place of the `checked` and `array_ptr` keywords.  For type checking, we add tests for building the new types. We check that null-terminated arrays and pointers can only be built from integer or pointer types (the assumption is that 0 is the null-terminator value, so only types for which 0 is a valid value can be used).

We also add tests that cover implicit conversions at assignments, function calls, and conditional expressions.  Nt_array_ptrs can be converted to array_ptrs and ptrs, but not the reverse.  The problem is that array_ptrs or ptrs may not point to null-terminated data, or, if they do, there may be an alias that permits the null-terminator to be overwritten.  We also add tests that cover uses of operators with the new types.

The tests include positive cases (where no error is expected) and many more negative cases, where the compiler is expected to issue an error. To avoid unnecessary source code changes that would obscure the new tests, I avoided renumbering temporary variables. I added letter suffixes to existing variables instead.

The compiler change disallows array_ptrs to function types (https://github.com/Microsoft/checkedc/issues/34), so we add tests of that too.  Functions have indeterminate size, so bounds checking does not make sense for them.  We allow array_ptrs to ptrs to function types.
