### PR TITLE
Test strings with checked types and initialized checked data.

### DIFF
--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -125,8 +125,7 @@ int fputs(const char * restrict s,
           FILE * restrict stream : itype(restrict _Ptr<FILE>));
 int getc(FILE *stream : itype(_Ptr<FILE>));
 int putc(int c, FILE *stream : itype(_Ptr<FILE>));
-// TODO: strings
-// int puts(const char *str);
+int puts(const char *str : itype(_Nt_array_ptr<const char>));
 int ungetc(int c, FILE *stream : itype(_Ptr<FILE>));
 
 size_t fread(void * restrict pointer : byte_count(size * nmemb),

--- a/tests/dynamic_checking/bounds/array-bounds-decls.c
+++ b/tests/dynamic_checking/bounds/array-bounds-decls.c
@@ -20,7 +20,7 @@
 
 #include <assert.h>
 #include <signal.h>
-#include <stdio.h>
+#include <stdio_checked.h>
 #include <string.h>
 #include <stdlib_checked.h>
 #include <stdchecked.h>

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -88,7 +88,7 @@ void f4(void) checked {
   nt_array_ptr<char> t37 = g37[1];
 
 
-  f3("abc");   // expected-error {{passing 'char checked[4]' to parameter of incompatible type 'char *'}}
+  f3("abc");   // expected-error {{passing 'char nt_checked[4]' to parameter of incompatible type 'char *'}}
   unchecked{
     f3("abc");
   }

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -46,11 +46,11 @@ char g23 checked[3]nt_checked[4] = { "abc", "def", "fgh" };
 //
 
 nt_array_ptr<int> g30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 };
-nt_array_ptr<int> g31 : count(0)  = (int _Checked[]) { 0, [2] = 2, 3, 5, 0};
+nt_array_ptr<int> g31 : count(0)  = (int checked[]) { 0, [2] = 2, 3, 5, 0};
 nt_array_ptr<char> g32 : count(5) = "abcde";
 array_ptr<char> g33 : count(5) = "abcde";
 array_ptr<char> g34 : count(5) = (char[5]) { 'a', 'b', 'c', 'd', 'e' };
-array_ptr<char> g35 : count(5) = (char _Checked[5]) { 'a', 'b', 'c', 'd', 'e' };
+array_ptr<char> g35 : count(5) = (char checked[5]) { 'a', 'b', 'c', 'd', 'e' };
 
 //
 // Checked arrays of checked pointers
@@ -117,12 +117,12 @@ void f5(void) checked {
 
   nt_array_ptr<int> t30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 };
 
-  nt_array_ptr<int> t31 = (int _Checked[]) { 0, [2] = 2, 3, 5, 0 };
+  nt_array_ptr<int> t31 = (int checked[]) { 0, [2] = 2, 3, 5, 0 };
   nt_array_ptr<char> t32 : count(5) = "abcde";
 
   array_ptr<char> t33 : count(5) = "abcde";
   array_ptr<char> t34 = (char[5]) { 'a', 'b', 'c', 'd', 'e' };
-  array_ptr<char> t35 : count(5) = (char _Checked[5]) { 'a', 'b', 'c', 'd', 'e' };
+  array_ptr<char> t35 : count(5) = (char checked[5]) { 'a', 'b', 'c', 'd', 'e' };
 
   //
   // Make sure parentheses are ignored.

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -1,15 +1,14 @@
-// Feature tests of static checking of bounds declarations for variables with
-//  initializers. 
+// Feature tests of static checking for variables with initializers
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
 
 #include <stdchecked.h>
 
-// Check that declarations of automatic variables with Checked C bounds 
-// declarations or _Ptr types always have initializers.
-extern void f() {
+// Automatic variables with Checked C declarations or _Ptr types must
+// always have initializers.
+extern void f1() {
   array_ptr<int> v1;
   array_ptr<int> v2 = 0;
   array_ptr<int> v3 : bounds(none);
@@ -23,4 +22,112 @@ extern void f() {
 
   ptr<int> v20 = 0;
   ptr<int> v21;         // expected-error {{automatic variable 'v21' with _Ptr type must have initializer}}
+}
+
+//
+// Checked arrays with initializers
+//
+
+char g1 checked[] = "abc";
+int g2 checked[] = { 0, 1, 2 };
+int g3 checked[][2] = { { 0, 1}, {2, 3} };
+
+char g4 checked[4] = "abc";
+int g5 checked[3] = { 0, 1, 2 };
+int g6 checked[2][2] = { { 0, 1 },{ 2, 3 } };
+
+char g20 nt_checked[] = "abc";
+int g21 nt_checked[] = { 0, 1, 2, 0 };
+char g22 checked[3]nt_checked[3] = { { 0, 1, 0}, { 1, 1, 0}, { 3, 1, 0 } };
+char g23 checked[3]nt_checked[4] = { "abc", "def", "fgh" };
+
+//
+// Checked pointers with initialized array literals
+//
+
+nt_array_ptr<int> g30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 };
+nt_array_ptr<int> g31 : count(0)  = (int _Checked[]) { 0, [2] = 2, 3, 5, 0};
+nt_array_ptr<char> g32 : count(5) = "abcde";
+array_ptr<char> g33 : count(5) = "abcde";
+array_ptr<char> g34 : count(5) = (char[5]) { 'a', 'b', 'c', 'd', 'e' };
+array_ptr<char> g35 : count(5) = (char _Checked[5]) { 'a', 'b', 'c', 'd', 'e' };
+
+//
+// Checked arrays of checked pointers
+//
+nt_array_ptr<char> g36 checked[3][2] = { [1] = "ab", "cd", "ef", "jk" };
+nt_array_ptr<char> g37 nt_checked[] = { "the", "brown", "fox", "jumped",
+                                        "over", "the", "fence", 0 };
+
+void callback1(int a);
+void callback2(int a);
+nt_array_ptr<ptr<void (int)>> callback_table = (ptr<void (int)>[]) { callback1, callback2, 0 };
+
+void f3(char *escape) {
+}
+
+// Checked that the arrays and pointers have checked type.
+void f4(void) checked {
+  char t1 = g1[0];
+  int t2  = g2[0];
+  int t3 = g3[0][1];
+  char t4 = g4[0];
+  char t5 = g5[0];
+  int t6 = g6[1][1];
+  int t20 = g20[0];
+  int t21 = g21[3];
+  int t22 = g22[2][2];
+  nt_array_ptr<char> t23 = g23[0];
+  int t30 = g30[1];
+  int t31 = *g31;
+  char t32 = g32[5];
+  char t33 = g33[4];
+  char t34 = g34[4];
+  char t35 = g35[1];
+  nt_array_ptr<char> t36 = g36[1][0];
+  nt_array_ptr<char> t37 = g37[1];
+
+
+  f3("abc");   // expected-error {{passing 'char checked[4]' to parameter of incompatible type 'char *'}}
+  unchecked{
+    f3("abc");
+  }
+
+  nt_array_ptr<int> t100 : count(3) = (int[]) { 0, 1, 2, 3 };
+}
+
+void f5(void) checked {
+  char t1 checked[] = "abc";
+  int t2 checked[] = { 0, 1, 2 };
+  int t3 checked[][2] = { { 0, 1 },{ 2, 3 } };
+
+  char t4 checked[4] = "abc";
+  int t5 checked[3] = { 0, 1, 2 };
+  int t6 checked[2][2] = { { 0, 1 },{ 2, 3 } };
+
+  char t20 nt_checked[] = "abc";
+  int t21 nt_checked[] = { 0, 1, 2, 0 };
+  char t22 checked[3]nt_checked[3] = { { 0, 1, 0 },{ 1, 1, 0 },{ 3, 1, 0 } };
+  char t23 checked[3]nt_checked[4] = { "abc", "def", "fgh" };
+
+  //
+  // Checked pointers with initialized array literals
+  //
+
+  nt_array_ptr<int> t30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 };
+  nt_array_ptr<int> t31 = (int _Checked[]) { 0, [2] = 2, 3, 5, 0 };
+  nt_array_ptr<char> t32 : count(5) = "abcde";
+  array_ptr<char> t33 : count(5) = "abcde";
+  array_ptr<char> t34 = (char[5]) { 'a', 'b', 'c', 'd', 'e' };
+  array_ptr<char> t35 : count(5) = (char _Checked[5]) { 'a', 'b', 'c', 'd', 'e' };
+
+  //
+  // Checked arrays of checked pointers
+  //
+  nt_array_ptr<char> t36 checked[3][2] = { [1] = "ab", "cd", "ef", "jk" };
+  nt_array_ptr<char> t37 nt_checked[] = { "the", "brown", "fox", "jumped",
+    "over", "the", "fence", 0 };
+
+  nt_array_ptr<ptr<void(int)>> callback_table = (ptr<void(int)>[]) { callback1, callback2, 0 };
+
 }

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -109,25 +109,36 @@ void f5(void) checked {
   int t21 nt_checked[] = { 0, 1, 2, 0 };
   char t22 checked[3]nt_checked[3] = { { 0, 1, 0 },{ 1, 1, 0 },{ 3, 1, 0 } };
   char t23 checked[3]nt_checked[4] = { "abc", "def", "fgh" };
+  char t24 checked[3]nt_checked[4] = { ("abc"), "def", ("fgh") };
 
   //
-  // Checked pointers with initialized array literals
+  // Checked pointers with initialized array literals.
   //
 
   nt_array_ptr<int> t30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 };
+
   nt_array_ptr<int> t31 = (int _Checked[]) { 0, [2] = 2, 3, 5, 0 };
   nt_array_ptr<char> t32 : count(5) = "abcde";
+
   array_ptr<char> t33 : count(5) = "abcde";
   array_ptr<char> t34 = (char[5]) { 'a', 'b', 'c', 'd', 'e' };
   array_ptr<char> t35 : count(5) = (char _Checked[5]) { 'a', 'b', 'c', 'd', 'e' };
 
   //
-  // Checked arrays of checked pointers
+  // Make sure parentheses are ignored.
   //
-  nt_array_ptr<char> t36 checked[3][2] = { [1] = "ab", "cd", "ef", "jk" };
-  nt_array_ptr<char> t37 nt_checked[] = { "the", "brown", "fox", "jumped",
+  nt_array_ptr<int> t36 : count(4) = ((int[]) { 0, [2] = 2, 3, 5, 0 });
+  nt_array_ptr<char> t37 : count(5) = ("abcde");
+
+  //
+  // Checked arrays of checked pointers.
+  //
+  nt_array_ptr<char> t38 checked[3][2] = { [1] = "ab", "cd", "ef", "jk" };
+  nt_array_ptr<char> t39 nt_checked[] = { "the", "brown", "fox", "jumped",
     "over", "the", "fence", 0 };
 
+  char c = ((char *[2]) { "abc", "def" })[0][0];  // expected-error {{type in a checked\
+ scope must use only checked types or parameter/return types with bounds-safe interfaces}}
   nt_array_ptr<ptr<void(int)>> callback_table = (ptr<void(int)>[]) { callback1, callback2, 0 };
 
 }

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -7,6 +7,110 @@
 
 #include <stdchecked.h>
 
+//
+// Test types that are allowed for locals in checked scopes.
+//
+
+void checked_local_types(void) checked {
+  //
+  // Check pointer and array types that use only scalar types.
+  //
+
+  int *t1 = 0; // expected-error {{local variable in a checked scope must have a checked type}}
+  ptr<int> t2 = 0;
+  array_ptr<int> t3 = 0;
+  int t4[5];     // expected-error {{local variable in a checked scope must have a checked type}}
+  int t5 checked[5];
+
+  //
+  // Check pointer and array types that use other constructed types (1 level deep)
+  //
+
+  //
+  // Check pointers to other types
+  // 
+
+  // Unchecked pointers to other pointer types.
+  int **t10 = 0;           // expected-error {{local variable in a checked scope must have a checked type}}
+  ptr<int> *t11 = 0;       // expected-error {{local variable in a checked scope must have a checked type}}
+  array_ptr<int> *t12 = 0; // expected-error {{local variable in a checked scope must have a checked type}}
+
+  // Unchecked pointers to array types
+  int(*t13)[10] = 0;          // expected-error {{local variable in a checked scope must have a checked type}}
+  int(*t14)checked[10] = 0;  // expected-error {{local variable in a checked scope must have a checked type}}
+
+  // Unchecked pointers to function types
+  int(*t15)(int a, int b) = 0;  // expected-error {{local variable in a checked scope must have a checked type}}
+
+  // Checked ptrs to other pointer types
+  ptr<int *> t20 = 0;  // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<ptr<int>> t21 = 0;
+  ptr<array_ptr<int>> t22 = 0;
+
+  // Checked ptrs to array types
+  ptr<int[10]> t23 = 0;   // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<int checked[10]> t24 = 0;
+
+  // Checked ptrs to function types.
+  ptr<int(int a, int b)> t25 = 0;
+
+  // Checked array_ptrs to other pointer types
+  array_ptr<int *> t30 = 0;  // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  array_ptr<ptr<int>> t31 = 0;
+  array_ptr<array_ptr<int>> t32 = 0;
+
+  // Checked array_ptrs to array types
+  array_ptr<int[10]> t33 = 0;   // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  array_ptr<int checked[10]> t34 = 0;
+
+  // Checked array_ptrs to function types are not allowed, so don't check them.
+
+  //
+  // Check arrays of pointers, including multidimensional arrays.
+  //
+
+  int *t40[10];      // expected-error {{local variable in a checked scope must have a checked type}}
+  ptr<int> t41[10];  // expected-error {{local variable in a checked scope must have a checked type}}
+  array_ptr<int> t42[10]; // expected-error {{local variable in a checked scope must have a checked type}}
+
+  int *t43 checked[10];  // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<int> t44 checked[10];
+  array_ptr<int> t45 checked[10];
+
+  int *t46 checked[10][15];  // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<int> *t47 checked[10][15];  // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  array_ptr<int> t48 checked[3][2];
+
+  //
+  // Checked pointers to function types that use constructed types.
+  //
+
+  // Functions with different kinds of pointer return types.
+  ptr<int *(int, int)> t60 =  0;  // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<ptr<int>(int, int)> t61 = 0;
+  ptr<array_ptr<int>(int, int)> t62 = 0;
+
+  // Function with different kinds of pointer arguments.
+  ptr<void(int *)> t63 = 0; // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<void(ptr<int>)> t64 = 0;
+  ptr<void(array_ptr<int>)> t65 = 0;
+
+  ptr<int (int arg[10])> t66 = 0; // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<int(int arg[])> t67 = 0; // expected-error {{local variable in a checked \
+scope must have a pointer, array or function type that uses only checked types or parameter/return types with bounds-safe interfaces}}
+  ptr<int (int arg checked[10])> t68 = 0;
+  ptr<int (int arg checked[])> t69 = 0;
+}
 // Test for checked function specifier.
 // - check if function declaration (return/param) is checked.
 // - check if function body (compound statement) is checked.
@@ -16,6 +120,10 @@
 // - check that if a declaration is declared in an unchecked scope with an unchecked type
 //   and it is used in a checked, scope, there is an error message at uses of the declared
 //   entity.
+
+//
+// Test types that are allowed for parameters in checked scopes.
+//
 
 checked int func4(int p[]) {  // expected-error {{parameter in a checked scope must have a checked type or a bounds-safe interface}}
   return 0;
@@ -52,16 +160,8 @@ array_ptr<int> func12(array_ptr<int> x, int len) : bounds(x,x+len) checked {
 }
 
 array_ptr<int> func13(int *x, int *y) checked {
-  int *upa = 0; // expected-error {{local variable in a checked scope must have a checked type}}
-  int *upb;     // expected-error {{local variable in a checked scope must have a checked type}}
-  int a[5];     // expected-error {{local variable in a checked scope must have a checked type}}
   *y = 0;       // expected-error {{parameter used in a checked scope must have a checked type or a bounds-safe interface}}
   int z = *y;   // expected-error {{parameter used in a checked scope must have a checked type or a bounds-safe interface}}
-
-  ptr<int> pb = 0;
-  array_ptr<char> pc;
-  int pd checked[5];
-
   return 0;
 }
 
@@ -724,6 +824,8 @@ checked int func60(ptr<struct s0> st0, ptr<struct s1> st1) {
   return sum;
 }
 
+
+
 // Change type produced by address-of operator(&) in checked block.
 // ex) checked { .... int a; ptr<int> pb = &a; }
 void test_addrof_checked_scope(void) checked {
@@ -1378,43 +1480,43 @@ checked void check_cast_operator(void) {
 
   // unchecked pointer to array
   ptr<int checked[5]> parr = 0;
-  parr = (int(*)checked[5]) &arr; // expected-error {{invalid casting to unchecked type}}
-  parr = (int(*)checked[5]) ((int(*)checked[]) &arr); // expected-error {{invalid casting to unchecked type}}
-  parr = (int(*)checked[3]) &arr;   // expected-error {{invalid casting to unchecked type}}
-  parr = (int(*)[5]) &arr;          // expected-error {{invalid casting to unchecked type}}
-  parr = (int**) &arr;              // expected-error {{invalid casting to unchecked type}}
+  parr = (int(*)checked[5]) &arr; // expected-error {{type in a checked scope must be a checked pointer or array type}}
+  parr = (int(*)checked[5]) ((int(*)checked[]) &arr); // expected-error {{type in a checked scope must be a checked pointer or array type}}
+  parr = (int(*)checked[3]) &arr;   // expected-error {{type in a checked scope must be a checked pointer or array type}}
+  parr = (int(*)[5]) &arr;          // expected-error {{type in a checked scope must be a checked pointer or array type}}
+  parr = (int**) &arr;              // expected-error {{type in a checked scope must be a checked pointer or array type}}
 
   // ptr to array, ptr to unchecked array
   parr = (ptr<int checked[5]>) &arr;
   parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr);
-  parr = (ptr<int [5]>) &arr;   // expected-error {{invalid casting to unchecked type}}
-  parr = (ptr<int *>) &arr;     // expected-error {{invalid casting to unchecked type}}
+  parr = (ptr<int [5]>) &arr;   // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
+  parr = (ptr<int *>) &arr;     // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
 
   // array_ptr to array, array_ptr to unchecked array
   array_ptr<int checked[5]> aparr = 0;
   aparr = (array_ptr<int checked[5]>) &arr;
   aparr = (array_ptr<int checked[5]>) ((array_ptr<int checked[]>) &arr);
-  aparr = (array_ptr<int [5]>) &arr;  // expected-error {{invalid casting to unchecked type}}
+  aparr = (array_ptr<int [5]>) &arr;  // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
 
   // ptr to variadic/unchecked func pointer
   ptr<int(int,int)> vpa = 0;
-  vpa = (ptr<int(int,...)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
-  vpa = (ptr<int(int,ptr<int(int, ...)>)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
-  vpa = (ptr<int*(int,int)>) &arr;  // expected-error {{invalid casting to unchecked type}}
-  vpa = (ptr<int(int,ptr<int(int, ...)>, ...)>) &arr;  // expected-error {{invalid casting to type having variable arguments}}
+  vpa = (ptr<int(int,...)>) &arr;  // expected-error {{type in a checked scope cannot have variable arguments}}
+  vpa = (ptr<int(int,ptr<int(int, ...)>)>) &arr;  // expected-error {{type in a checked scope cannot have variable arguments}}
+  vpa = (ptr<int*(int,int)>) &arr;  // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
+  vpa = (ptr<int(int,ptr<int(int, ...)>, ...)>) &arr;  // expected-error {{type in a checked scope cannot have variable arguments}}
 
   int *upa;                         // expected-error {{local variable in a checked scope must have a checked type}}
   upa = arr;
-  upa = (int *)(array_ptr<int>)arr; // expected-error {{invalid casting to unchecked type}}
+  upa = (int *)(array_ptr<int>)arr; // expected-error {{type in a checked scope must be a checked pointer or array type}}
   upa = &x;
   upa = (int [])&x;                 // expected-error {{cast to incomplete type}}
-  upa = (int(*)[5])&x;              // expected-error {{invalid casting to unchecked type}}
+  upa = (int(*)[5])&x;              // expected-error {{type in a checked scope must be a checked pointer or array type}}
 
   upa = pax;
-  upa = (int *)(array_ptr<int>)pax; // expected-error {{invalid casting to unchecked type}}
+  upa = (int *)(array_ptr<int>)pax; // expected-error {{type in a checked scope must be a checked pointer or array type}}
 
   upa = aparr;
-  upa = (int *)aparr;               // expected-error {{invalid casting to unchecked type}}
+  upa = (int *)aparr;               // expected-error {{type in a checked scope must be a checked pointer or array type}}
 
   gptr0 = upa;
   gptr0 = (ptr<int>)upa;
@@ -1434,19 +1536,19 @@ checked void check_cast_operator(void) {
   array_ptr<int> r : count(5) = 0;
   checked {
   p = _Dynamic_bounds_cast<int *>(q);           // expected-error {{local variable used in a checked scope must have a checked type}} \
-                                                // expected-error {{invalid casting to unchecked type}} \
+                                                // expected-error {{type in a checked scope must be a checked pointer or array type}} \
 
   p = _Dynamic_bounds_cast<int *>(r);           // expected-error {{local variable used in a checked scope must have a checked type}} \
-                                                // expected-error {{invalid casting to unchecked type}} \
+                                                // expected-error {{type in a checked scope must be a checked pointer or array type}} \
 
   q = _Assume_bounds_cast<ptr<int>>(r);             // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
   r = _Assume_bounds_cast<array_ptr<int>>(r,4);     // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
   r = _Assume_bounds_cast<array_ptr<int>>(r,r,r+1); // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
 
-  vpa = _Dynamic_bounds_cast<ptr<int(int,...)>>(r);   // expected-error {{invalid casting to type having variable arguments}}
-  vpa = _Dynamic_bounds_cast<ptr<int(int,ptr<int(int, ...)>)>>(r);  // expected-error {{invalid casting to type having variable arguments}}
-  vpa = _Dynamic_bounds_cast<ptr<int*(int,int)>>(r);  // expected-error {{invalid casting to unchecked type}}
-  vpa = _Dynamic_bounds_cast<ptr<int(int,ptr<int(int, ...)>, ...)>>(r);  // expected-error {{invalid casting to type having variable arguments}}
+  vpa = _Dynamic_bounds_cast<ptr<int(int,...)>>(r);   // expected-error {{type in a checked scope cannot have variable arguments}}
+  vpa = _Dynamic_bounds_cast<ptr<int(int,ptr<int(int, ...)>)>>(r);  // expected-error {{type in a checked scope cannot have variable arguments}}
+  vpa = _Dynamic_bounds_cast<ptr<int*(int,int)>>(r);  // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
+  vpa = _Dynamic_bounds_cast<ptr<int(int,ptr<int(int, ...)>, ...)>>(r);  // expected-error {{type in a checked scope cannot have variable arguments}}
 
   vpa = _Assume_bounds_cast<ptr<int(int,...)>>(r);   // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
   vpa = _Assume_bounds_cast<ptr<int(int,ptr<int(int, ...)>)>>(r);  // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}


### PR DESCRIPTION
This change corresponds to a matching compiler [change](https://github.com/Microsoft/checkedc-clang/pull/396) that adds support for string literals with checked types and completes support for initialized checked data.   The language rules for string and array literals are discussed in issue #207 (they haven't been added to the Checked C specification yet).

The compiler change also improves error messages for types that occur syntactically in expressions and are used in checked scopes.  Those types must be checked and everything they use must be checked too.   This change updates checked_scope_basic.c to use new error messages.

Testing:
- Passes automated testing with the updated compiler.

