### PR TITLE
Replace bounds(none) with bounds(unknown) in the specification.

### DIFF
--- a/spec/bounds_safety/checkedc.tex
+++ b/spec/bounds_safety/checkedc.tex
@@ -113,7 +113,7 @@
 \newcommand{\boundsrel}[3]{\texttt{bounds(#1, #2) \relalign{#3}}}
 \newcommand{\boundsrelval}[3]{\texttt{bounds(#1\, #2)} \relalignval{#3}}
 \newcommand{\boundsany}{\texttt{bounds(any)}}
-\newcommand{\boundsnone}{\texttt{bounds(none)}}
+\newcommand{\boundsunknown}{\texttt{bounds(unknown)}}
 \newcommand{\boundscount}[1]{\texttt{count(#1)}}
 \newcommand{\boundsbytecount}[1]{\texttt{byte\_count(#1)}}
 

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -153,7 +153,7 @@ and \var{x} has a known number of elements \var{n}, then
 \item Otherwise, the bounds are the result of the analysis in 
   Section~\ref{section:extent-definition} for this occurrence of \var{x}.
 \end{itemize}
-\item  Otherwise \var{x} has \boundsnone.
+\item  Otherwise \var{x} has \boundsunknown.
 \end{itemize}
 
 \subsection{Address-of expressions}
@@ -198,7 +198,7 @@ Suppose there is a function call expression of the form
   \item
     Any arguments that correspond to formal parameters occurring in
     \var{exp1} must be valid non-modifying expressions. If they are
-    not, \boundsinfer{\var{f}\texttt{(\var{e1} \ldots{} \var{en})}}{\boundsnone}.
+    not, \boundsinfer{\var{f}\texttt{(\var{e1} \ldots{} \var{en})}}{\boundsunknown}.
   \item
     Otherwise, substitute \texttt{\var{e1} \ldots{} \var{en}} for the formal
     parameters of \var{f} occurring in \var{exp1}. Also substitute the
@@ -208,7 +208,7 @@ Suppose there is a function call expression of the form
   \end{itemize}
 \item
   If \var{f} does not have a bounds declaration for its return value,
-  then \boundsinfer{\var{f}\texttt{(\var{e1} \ldots{} \var{en})}}{\boundsnone}.
+  then \boundsinfer{\var{f}\texttt{(\var{e1} \ldots{} \var{en})}}{\boundsunknown}.
 \end{enumerate}
 
 The special variable \texttt{return\_value} may appear \var{exp1}. It
@@ -527,7 +527,7 @@ bounds for \var{e},
   \texttt{((\var{S}) \exprcurrentvalue)} is substituted for
   all occurrences of \exprcurrentvalue.
 \item
-  Otherwise, the bounds of \var{e} are  altered to \boundsnone.
+  Otherwise, the bounds of \var{e} are  altered to \boundsunknown.
 \end{itemize}
   
 \subsection{Conditional expressions}
@@ -614,7 +614,7 @@ The updated context will be determined in three steps. First, if
   If \boundsinfer{\var{e}}{\var{exp}}, then the context is updated with
   \boundsdecl{\var{x}}{\var{exp}}.
 \item
-  Otherwise, the context is updated with \boundsdecl{\var{x}}{\boundsnone}
+  Otherwise, the context is updated with \boundsdecl{\var{x}}{\boundsunknown}
    to indicate that \var{x} has no valid bounds.
 \end{enumerate}
 
@@ -864,7 +864,7 @@ expression holds if:
 
 \begin{itemize}
 \item
-  The expected bounds expression is \boundsnone, or
+  The expected bounds expression is \boundsunknown, or
 \item
   The updated bounds expression is \boundsany, or
 \item
@@ -1342,7 +1342,7 @@ each variable \var{v} in the list,
     \item
       If \var{v} is an automatic variable then \var{v} will have an
       indeterminate value. The context is updated to map v to
-      \boundsnone.
+      \boundsunknown.
     \end{itemize}
   \item
     If \var{v} has an initializer, the initializer must have the form
@@ -1420,7 +1420,7 @@ f(int size) \{\\
 \mbox{~~~~}if (size > DEFAULT\_SIZE) \{\\
 \mbox{~~~~~~~~}bundle \{\\
 \mbox{~~~~~~~~~~~~}plen = size;\\
-\mbox{~~~~~~~~~~~~}\sethlcolor{lightblue}\hl{*parr = 314;} // error:~parr has bounds of none.\\
+\mbox{~~~~~~~~~~~~}\sethlcolor{lightblue}\hl{*parr = 314;} // error:~parr has unknown bounds.\\
 \mbox{~~~~~~~~~~~~}parr = malloc(sizeof(int) * size);\\
 \mbox{~~~~~~~~}\}\\
 \mbox{~~~~}\}\\

--- a/spec/bounds_safety/design-alternatives.tex
+++ b/spec/bounds_safety/design-alternatives.tex
@@ -396,7 +396,7 @@ bounds declarations. A bounds declaration has the form:
 \var{bounds}\=\var{-exp:} \\
 \> \texttt{count(}\var{non-modifying-exp}\texttt{)} \\
 \> \bounds{\var{non-modifying-exp}}{\var{non-modifying-exp}} \\
-\> \boundsnone \\
+\> \boundsunknown \\
 \> \boundsany
 \end{tabbing}
 

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -134,7 +134,7 @@ it separately so that there is a simple rule for casts to void pointers.}
 \item \ptrT: the bounds of \var{e} are computed using the rules
 in Section~\ref{section:checking-nested-assignment-expressions}.
 \begin{itemize}
-\item If the bounds are \boundsnone, checking fails with a compile-time
+\item If the bounds are \boundsunknown, checking fails with a compile-time
 error.
 \item Otherwise, if the bounds are \boundsany, checking 
 succeeds.
@@ -194,7 +194,7 @@ have it. It takes 1 to 3 arguments, depending on the kind of conversion being do
 
 Here is the checking that is done. The bounds of \var{e1} are computed
 using the rules in Section~\ref{section:checking-nested-assignment-expressions}.
-If the bounds of \var{e1} are \boundsnone, it is a compile-time error. 
+If the bounds of \var{e1} are \boundsunknown, it is a compile-time error. 
 If the bounds of \var{e1} are \boundsany, no runtime checks are needed.
 Otherwise the bounds must be \bounds{\var{lb}}{\var{ub}} (or convertible to that form).
 The following runtime checks are done:
@@ -384,7 +384,7 @@ from integers to checked pointers are typically not useful in Checked C because
 the checking of bounds declarations fails or the resulting pointer cannot
 be used to access memory.   The rules for checking bounds declarations only
 allow the target type to be \arrayptr\ type and the bounds of the expression to be
-\boundsnone.
+\boundsunknown.
 
 \subsection{Examples}
 
@@ -917,8 +917,8 @@ rules for inferring bounds to integral expressions:
 
   \begin{itemize}
   \item
-    If \boundsdecl{\var{e1}}{\var{b}}, where \var{b} is not \boundsnone, and 
-    \boundsdecl{\var{e2}}{\boundsnone}, and it can be proved that \texttt{\var{e1} != 0}, then
+    If \boundsdecl{\var{e1}}{\var{b}}, where \var{b} is not \boundsunknown, and 
+    \boundsdecl{\var{e2}}{\boundsunknown}, and it can be proved that \texttt{\var{e1} != 0}, then
     \boundsinfer{\var{e1} \var{op} \var{e2}}{\var{b}}.
   \item
     If the special variable \exprcurrentvalue\ occurs in \var{b}:
@@ -928,12 +928,11 @@ rules for inferring bounds to integral expressions:
       \texttt{\exprcurrentvalue\ \var{inverse-op} \var{e2}}
       is substituted for \exprcurrentvalue.
     \item
-      Otherwise the bounds of the expression are altered to be \boundsnone.
-      bounds(none).
+      Otherwise the bounds of the expression are altered to be \boundsunknown.
     \end{itemize}
   \item
-    Similar rules apply for the reverse situation where \boundsdecl{\var{e1}}{\boundsnone}
-    and \boundsdecl{\var{e2}}{\var{b}}, where \var{b} is not \boundsnone.
+    Similar rules apply for the reverse situation where \boundsdecl{\var{e1}}{\boundsunknown}
+    and \boundsdecl{\var{e2}}{\var{b}}, where \var{b} is not \boundsunknown.
   \end{itemize}
 \item
   Given \texttt{\var{e1} \var{op} \var{e2}} where \var{op} is a shift operator, \var{e1} is the integral value
@@ -941,11 +940,11 @@ rules for inferring bounds to integral expressions:
 
   \begin{itemize}
   \item
-    If \boundsdecl{\var{e1}}{\var{b}}, where \var{b} is not \boundsnone, and \var{e2} has
-    \boundsnone, and it can be proved that \texttt{\var{e1} != 0}, then \boundsinfer{\var{e1} \var{op} \var{e2}}{\var{b}}.
+    If \boundsdecl{\var{e1}}{\var{b}}, where \var{b} is not \boundsunknown, and \var{e2} has
+    \boundsunknown, and it can be proved that \texttt{\var{e1} != 0}, then \boundsinfer{\var{e1} \var{op} \var{e2}}{\var{b}}.
   \item
     If the special variable \exprcurrentvalue\ occurs in \var{b}.
-    bounds of the expression are altered to be \boundsnone. Shift
+    bounds of the expression are altered to be \boundsunknown. Shift
     expressions are not invertible because they lose information.
   \end{itemize}
 \end{itemize}

--- a/spec/bounds_safety/structure-bounds.tex
+++ b/spec/bounds_safety/structure-bounds.tex
@@ -439,7 +439,7 @@ When a member path \var{mp} of a variable \var{x} is used and
 \item
   If the use is within the extent of a bounds declaration
   \var{x}\texttt{.}\var{mp} \texttt{:} \var{bounds-exp} and
-  \var{bounds-exp} is not \boundsnone, \var{bounds-exp} is
+  \var{bounds-exp} is not \boundsunknown, \var{bounds-exp} is
   the bounds.
 \item
   Otherwise, if the state of the member bounds for
@@ -447,7 +447,7 @@ When a member path \var{mp} of a variable \var{x} is used and
   \var{x}\texttt{.}\var{mp} is used.
 \item
   Otherwise, the bounds of \var{x}\texttt{.}\var{mp} is
-  \boundsnone.
+  \boundsunknown.
 \end{itemize}
 
 \subsection{Suspends declarations and bounds for variables.}
@@ -636,11 +636,11 @@ beginning at the variable is determined.  The set is mapped to a set of pairs as
 \item For the first element, the structure variable is removed from the beginning of the
 path to create a member path.
 \item For the second element, the extent dataflow analysis is consulted for the \arrayptr\ member path.
-   If the bounds expression is not \boundsnone, it is used.   If it is \boundsnone, the result
+   If the bounds expression is not \boundsunknown, it is used.   If it is \boundsunknown, the result
    of the dataflow analysis for the member bounds state is examined. If the member bounds
    state is valid, the member bounds is used.  It is transformed to use variable member
    bounds by prefixing the member paths that occur in it with the structure variable.
-   Otherwise, \boundsnone\ is used.
+   Otherwise, \boundsunknown\ is used.
 \end{itemize}
 
 \subsection{Inferring bounds for expressions without assignments}
@@ -665,7 +665,7 @@ a member name and \boundsinfer{\var{e}}{\var{s}},
 \item Otherwise,
 \begin{itemize}
 \item If $\var{s} = \texttt{\{(\var{m}, \var{b})\}}$, then \boundsinfer{\texttt{\var{e}.\var{m}}}{b}
-\item Otherwise, \boundsinfer{\texttt{\var{e}.\var{m}}}{\boundsnone}
+\item Otherwise, \boundsinfer{\texttt{\var{e}.\var{m}}}{\boundsunknown}
 \end{itemize}
 \end{itemize}
 \item Function calls: {\em To be filled in}

--- a/spec/bounds_safety/variable-bounds.tex
+++ b/spec/bounds_safety/variable-bounds.tex
@@ -27,7 +27,7 @@ the form:
 \var{bounds}\var{-exp:} \\
 \> \texttt{count(}\var{non-modifying-exp}\texttt{)} \\
 \> \bounds{\var{non-modifying-exp}}{\var{non-modifying-exp}} \\
-\> \boundsnone \\
+\> \boundsunknown \\
 \> \boundsany
 \end{tabbing}
 
@@ -38,7 +38,7 @@ Sections~\ref{section:pointer-cast-results} and \ref{section:pointers-to-void}.
 A bounds expression describes the memory that can be accessed using the
 value of \var{x}, provided that x is not null. Bounds expressions
 include counts, pairs that specify an upper bound and lower bound,
-\boundsnone, and \boundsany:
+\boundsunknown, and \boundsany:
 
 \begin{itemize}
 \item
@@ -53,9 +53,10 @@ include counts, pairs that specify an upper bound and lower bound,
   Only memory that is at or above the location specified by \var{e1}
   and below \var{e2} can be accessed through \var{x}.
 \item
-  \boundsdecl{\var{x}}{\boundsnone} declares that \var{x} has no bounds.
-  It is an error at compile-time to attempt to access memory using a
-  variable of type \arrayptr\ with no bounds.
+  \boundsdecl{\var{x}}{\boundsunknown} declares that \var{x} has bounds that
+   are unknown at compile-time.
+  It is a compile-time error to attempt to access memory using a
+  variable of type \arrayptr\ with unknown bounds.
 \item
   \boundsdecl{\var{x}}{\boundsany} is a special form that readers can
   ignore for now. It is used for null pointers (0 cast to a pointer
@@ -539,7 +540,7 @@ statements:\\
 \end{tabbing}
 
 The names used in bounds expressions (\texttt{any},
-\texttt{bounds}, \texttt{count}, and \texttt{none}) are identifiers.
+\texttt{bounds}, \texttt{count}, and \texttt{unknown}) are identifiers.
 They are not keywords.  They can still be used for variable names,
 avoiding backward-compatibility problems.    The grammar for
 bounds expressions is:
@@ -556,7 +557,7 @@ expressions:
 \item If the first grammar clause was parsed,
 \begin{itemize}
 \item If \var{identifier} is \texttt{bounds}, the \var{non-modifying-exp}
-must be the identifier \texttt{any} or the identifier \texttt{none}.
+must be the identifier \texttt{any} or the identifier \texttt{unknown}.
 \item Otherwise \var{identifier} must be \texttt{count}.
 \end{itemize}
 \item If the second grammar clause was parsed, \var{identifier} must be
@@ -1510,7 +1511,7 @@ then
    \end{compactenum}
    then the bounds declaration applies to the component   
 \item 
-   Otherwise, the bounds declaration \boundsdecl{\var{v}}{\boundsnone}
+   Otherwise, the bounds declaration \boundsdecl{\var{v}}{\boundsunknown}
    applies to the component.
 \end{compactenum}
   
@@ -1660,14 +1661,14 @@ value to each variable at each program point in the function.
 Figure~\ref{fig:extent-dataflow-lattice} shows the lattice of values.  
 It includes singleton values consisting of the bounds
 expressions in the flow-sensitive bounds declaration for variables in
-the function, \boundsnone\ (indicating absence of bounds
+the function, \boundsunknown\ (indicating absence of bounds
 information), and \texttt{Top} (indicating contradiction or error):
 
 \begin{figure}
 \begin{center}
 \begin{tikzpicture}[sibling distance=1in]
 \node[rectangle, minimum size=8pt]{\texttt{Top}}
-  child foreach \name in {\boundsnone, \var{bounds-exp\textsubscript{1}},
+  child foreach \name in {\boundsunknown, \var{bounds-exp\textsubscript{1}},
                           \var{bounds-exp\textsubscript{2}}, \ldots}
      {node{\name} edge from parent[<-, thick]};
 \end{tikzpicture}
@@ -1683,14 +1684,14 @@ are met.
 A new lattice value is generated for the \arrayptr\ variable. If the
 assignment declares bounds for the \arrayptr\ variable, the new
 lattice value is the bounds expression in the bounds declaration.
-Otherwise, it is the value \boundsnone.
+Otherwise, it is the value \boundsunknown.
 
 A declaration of a variable is handled similarly to an assignment,
 except that there will not be any lattice value to kill. Lexical hiding
 of variables involved in bounds declarations is not permitted. If the
 declaration declares bounds for the \arrayptr\ variable, the
 new lattice value is the bounds expression in the bounds declaration.
-Otherwise, it is the value \boundsnone.
+Otherwise, it is the value \boundsunknown.
 
 A variable going out of scope kills any existing lattice values in which
 that variable occurs.


### PR DESCRIPTION
The bounds expression bounds(none) has a potentially ambiguous English meaning.   The bounds could be unbounded or be unknown.  This replaces the bounds expression bounds(none) with bounds(unknown) in the specification.  This is mostly a search-and-replace of the boundsnone macro.  I also updated the text that defines the meaning of the bounds expression.