### PR TITLE
Test default bounds for null-terminated array pointers

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -15,6 +15,7 @@ ptr<int> g2 = &gtmp;
 array_ptr<int> g3 = &gtmp;
 array_ptr<int> g4 : count(1) = &gtmp;
 
+
 extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
                         array_ptr<int> arg4 : count(1)) {
   struct S1 s;
@@ -25,6 +26,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   arg4 = 0;
   arg4 = (int *)0xabcd;  // expected-error {{expression has no bounds}}
   arg4 = orig_arg4;
+
+  // TODO: compound literals, assignments of variables with array types
+  // to pointer variables, and reads/writes of struct members.
 
   // address-of
   int tmp1 = 0;
@@ -88,8 +92,8 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
 
   g1 = arg2;            // expected-error {{incompatible type}}
   g2 = arg2;
-  g3 = arg3;
-  g4 = arg4;
+  g3 = arg2;
+  g4 = arg2;
 
   g1 = arg3;            // expected-error {{incompatible type}}
   g2 = arg3;            // expected-error {{expression has no bounds}}
@@ -192,6 +196,194 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   --(*t4);
 }
 
+nt_array_ptr<int> g11 : bounds(unknown) = 0;
+nt_array_ptr<int> g12 = (int nt_checked[]) { 1, 0 }; // default bounds of count(0);
+nt_array_ptr<int> g13 : count(1) = (int nt_checked[]) { 1, 0 };
+
+struct S2 {
+  nt_array_ptr<int> f1 : bounds(unknown);
+  nt_array_ptr<int> f2;
+  nt_array_ptr<int> f3 : count(1);
+};
+
+extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
+                                 nt_array_ptr<int> arg2,
+                                 nt_array_ptr<int> arg3 : count(1)) {
+  int arr nt_checked[5] = { 0, 1, 2, 3, 0 };
+
+  // constants
+  arg1 = 0;
+  arg2 = 0;
+  arg3 = 0;
+  arg1 = (nt_array_ptr<int>)0xabcd;
+  arg2 = (nt_array_ptr<int>)0xabcd;  // expected-error {{expression has no bounds}}
+  arg3 = (nt_array_ptr<int>)0xabcd;  // expected-error {{expression has no bounds}}
+
+  // address-of
+  arg1 = &*arg1;
+  arg1 = &*arg2;
+  arg1 = &*arg3;
+  arg1 = &*arr;           // TODO: investigate why this isn't a typechecking error.
+  arg1 = &arr[1];         // expected-error {{incompatible type}}
+  arg2 = &*arg1;          // expected-error {{expression has no bounds}}
+  arg2 = &*arg2;
+  arg2 = &*arg3;
+  arg3 = &*arg1;          // expected-error {{expression has no bounds}}
+  arg3 = &*arg2;          // TODO: issue an error for incorrect bounds;
+  arg3 = &*arg3;
+
+  // variables
+
+  // globals assigned from a global
+  g11 = g11;
+  g12 = g11;           // expected-error {{expression has no bounds}}
+  g13 = g11;           // expected-error {{expression has no bounds}}
+
+  g11 = g12;
+  g12 = g12;
+  g13 = g12;           // TODO: issue an error for incorrect bounds
+
+  g11 = g13;
+  g12 = g13;
+  g13 = g13;
+
+  // parameters assigned from a global
+  arg1 = g11;
+  arg2 = g11;           // expected-error {{expression has no bounds}}
+  arg3 = g11;           // expected-error {{expression has no bounds}}
+
+  arg1 = g12;
+  arg2 = g12;
+  arg3 = g12;           // TODO: issue an error for incorrect bounds
+
+  arg1 = g13;
+  arg2 = g13;
+  arg3 = g13;
+
+
+  // globals assigned from parameters
+  g11 = arg1;
+  g12 = arg1;           // expected-error {{expression has no bounds}}
+  g13 = arg1;           // expected-error {{expression has no bounds}}
+
+  g11 = arg2;
+  g12 = arg2;
+  g13 = arg3;           // TODO: issue an error for incorrect bounds
+
+  g11 = arg3;
+  g12 = arg3;
+  g13 = arg3;
+
+    // locals assigned from parameters
+  nt_array_ptr<int> t1 : bounds(unknown);
+  nt_array_ptr<int> t2 = 0;
+  nt_array_ptr<int> t3 : count(1) = 0;
+
+  t1 = arg1;
+  t2 = arg1;            // expected-error {{expression has no bounds}}
+  t3 = arg1;            // expected-error {{expression has no bounds}}
+
+  t1 = arg2;
+  t2 = arg2;
+  t3 = arg2;            // TODO: issue an error for incorrect bounds.
+
+  t1 = arg3;
+  t2 = arg3;
+  t3 = arg3;
+
+  // spot-check locals assigned from globals
+  t1 = g13;
+  t2 = g12;
+  t3 = g11;            // expected-error {{expression has no bounds}}
+
+  // spot-check globals assigned from locals
+  g11 = t2;
+  g12 = t3;
+  g13 = t1;            // expected-error {{expression has no bounds}}
+
+  // expressions
+
+  // nested assignments
+  nt_array_ptr<int> t4 : count(1) = 0;
+  t4 = (arg3 = t3);
+  t4 = (t3 = arg3);
+  t4 = (t2 = arg3);
+  t4 = (t2 = t1);     // expected-error 2 {{expression has no bounds}}
+
+  // assignment through pointer
+  *t1 = 1;            // expected-error {{expression has no bounds}}
+  *t2 = 2;            // TODO: warn this will always fail.
+  *t3 = 3;
+
+  // read through a pointer
+  int t6 = *t1;       // expected-error {{expression has no bounds}}
+  t6 = *t2;
+  t6 = *t3;
+
+  // assignment via subcript
+  t1[0] = 1;          // expected-error {{expression has no bounds}}
+  t2[0] = 3;          // TODO: warn this will always fail
+  t3[0] = 4;
+
+  // read via subscript
+
+  int t7 = t1[0];     // expected-error {{expression has no bounds}}
+  t7 = t2[0];
+  t7 = t3[0];
+
+  // pre-increment/post-increment
+  ++(*t1);            // expected-error {{expression has no bounds}}
+  ++(*t2);            // TODO: warn this will always fail.
+  ++(*t3);
+
+  --(*t1);            // expected-error {{expression has no bounds}}
+  --(*t2);            // TODO: warn this will always fail.
+  --(*t3);
+
+  (*t1)++;            // expected-error {{expression has no bounds}}
+  (*t2)++;            // TODO: warn this will always fail.
+  (*t3)++;
+
+  --(*t1);            // expected-error {{expression has no bounds}}
+  --(*t2);            // TODO: warn this will always fail.
+  --(*t3);
+
+  // operations involving struct members
+  struct S2 s;
+  s.f1 = t1;
+  s.f1 = t2;
+  s.f1 = t3;
+
+  s.f2 = t1;          // expected-error {{expression has no bounds}}
+  s.f2 = t2;
+  s.f2 = t3;
+
+  s.f3 = t1;          // expected-error {{expression has no bounds}}
+  s.f3 = t2;          // TODO: issue an error for incorrect bounds.
+  s.f3 = t3;
+
+  t1 = s.f1;
+  t1 = s.f2;
+  t1 = s.f3;
+
+  t2 = s.f1;          // expected-error {{expression has no bounds}}
+  t2 = s.f2;
+  t2 = s.f3;
+
+  t3 = s.f1;          // expected-error {{expression has no bounds}}
+  t3 = s.f2;          // TODO: issue an error for incorrect bounds.
+  t3 = s.f3;
+
+  nt_array_ptr<int> ntp = (int nt_checked[]) { 0, 1, 2, 3, 0 };
+  ptr<nt_array_ptr<int>> pntp = &ntp;
+  *pntp = arg1;       // expected-error {{expression has no bounds}}
+  *pntp = arg2;
+  *pntp = arg3;
+  arg1 = *pntp;
+  arg2 = *pntp;
+  arg3 = *pntp;        // TODO: issue an error for incorrect bounds.
+}
+
 extern void test_f1(int *p);
 extern void test_f2(ptr<int> p);
 extern void test_f3(array_ptr<int> p);
@@ -229,11 +421,48 @@ extern void check_call_args(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   test_f2(arg5);
   test_f3(arg5);
   test_f4(arg5);
-  test_f5(arg5, 1);
+  test_f5(arg5, 1); // TODO: issue a bounds error.  arglen might not be >= 1.
+  test_f5(arg5, arglen);
 
   int count = arglen - 1;
   test_f5(arg5, ++count);  // expected-error {{increment expression not allowed}}
   test_f5(arg5, count++);  // expected-error {{increment expression not allowed}}
+}
+
+extern void test_nullterm_f1(nt_array_ptr<char> p : bounds(unknown));
+extern void test_nullterm_f2(nt_array_ptr<char> p);
+extern void test_nullterm_f3(nt_array_ptr<char> p : count(1));
+extern void test_nullterm_f4(nt_array_ptr<char> p : count(len), int len);
+
+extern void check_nullterm_call_args(
+  nt_array_ptr<char> arg1 : bounds(unknown),
+  nt_array_ptr<char> arg2,
+  nt_array_ptr<char> arg3 : count(1),
+  nt_array_ptr<char> arg4 : count(arglen), int arglen) {
+  test_nullterm_f1(arg1);
+  test_nullterm_f2(arg1);     // expected-error {{argument has no bounds}}
+  test_nullterm_f3(arg1);     // expected-error {{argument has no bounds}}
+  test_nullterm_f4(arg1, 1);  // expected-error {{argument has no bounds}}
+
+  test_nullterm_f1(arg2);
+  test_nullterm_f2(arg2);
+  test_nullterm_f3(arg2);     // TODO: issue an error for incorrect bounds
+  test_nullterm_f4(arg2, 1);  // TODO: issue an error for incorrect bounds
+
+  test_nullterm_f1(arg3);
+  test_nullterm_f2(arg3);
+  test_nullterm_f3(arg3);
+  test_nullterm_f4(arg3, 1);
+
+  test_nullterm_f1(arg4);
+  test_nullterm_f2(arg4);     // TODO: issue an error for incorrect bounds
+  test_nullterm_f3(arg4);     // TODO: issue an error for incorrect bounds
+  test_nullterm_f4(arg4, 1);  // TODO: issue an error for incorrect bounds
+  test_nullterm_f4(arg4,  arglen);
+
+  int count = arglen - 1;
+  test_nullterm_f4(arg4, ++count);  // expected-error {{increment expression not allowed}}
+  test_nullterm_f4(arg4, count++);  // expected-error {{increment expression not allowed}}
 }
 
 //
@@ -291,3 +520,81 @@ extern void check_call_bsi(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   test_bsi_f5(arg5, count++);  // expected-error {{increment expression not allowed}}
 }
 
+//
+// Test checking of bounds-safe interfaces involving null-terminated pointers.
+//
+
+// TODO: Checked C no way of declaring a bounds-safe interface type and a count for
+// a null-terminated pointer at this time.  When there is a way, we need to add tests.
+
+extern void test_nullterm_bsi_f1(int *p);
+extern void test_nullterm_bsi_f2(int *p : itype(nt_array_ptr<int>));
+extern void test_nullterm_bsi_f3(int **p : itype(ptr<nt_array_ptr<int>>));
+extern void test_nullterm_bsi_f4(int((*compar)(const int *, const int *)) :
+  itype(ptr<int(nt_array_ptr<const int>, nt_array_ptr<const int>)>));
+extern int test_nullterm_cmp(nt_array_ptr<const int> a, nt_array_ptr<const int> b);
+
+extern void check_nullterm_call_bsi(int *arg1 : itype(nt_array_ptr<int>),
+                                    nt_array_ptr<int> arg2 : bounds(unknown),
+                                    nt_array_ptr<int> arg3,
+                                    nt_array_ptr<int> arg4 : count(1),
+                                    nt_array_ptr<int> arg5 : count(arglen),
+                                    int arglen,
+                                    int **arg6,
+                                    int **arg7 : itype(ptr<nt_array_ptr<int>>),
+                                    ptr<nt_array_ptr<int>> arg8) {
+  test_nullterm_bsi_f1(arg1);    // no checking expected when passing unchecked pointers.
+  test_nullterm_bsi_f2(arg1);
+
+  test_nullterm_bsi_f1(arg2);    // expected-error {{incompatible type}}
+  test_nullterm_bsi_f2(arg2);    // expected-error {{argument has no bounds}}
+
+  test_nullterm_bsi_f1(arg3);    // expected-error {{incompatible type}}
+  test_nullterm_bsi_f2(arg3);
+
+  test_nullterm_bsi_f1(arg4);    // expected-error {{incompatible type}}
+  test_nullterm_bsi_f2(arg4);
+
+  test_nullterm_bsi_f1(arg5);    // expected-error {{incompatible type}}
+  test_nullterm_bsi_f2(arg5);    // TODO: issue an error for incorrect bounds.
+
+  test_nullterm_bsi_f3(arg6);    // no checking expected when passing unchecked pointers
+  test_nullterm_bsi_f3(arg7);    // no checking expected when passing unchecked pointers
+  test_nullterm_bsi_f3(arg8);
+
+  _Checked{
+    test_nullterm_bsi_f3(arg6);  // expected-error {{parameter used in a checked scope must have a checked type or a bounds-safe interface}}
+    test_nullterm_bsi_f4(test_nullterm_cmp);
+    arg1 = arg2;                 // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
+    *arg7 = arg2;                // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
+    *arg8 = arg2;                // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
+
+    arg2 = arg1;
+    arg2 = *arg7;
+    arg2 = *arg8;
+
+    arg1 = arg3;
+    *arg7 = arg3;
+    *arg8 = arg3;
+
+    arg3 = arg1;
+    arg3 = *arg7;
+    arg3 = *arg8;
+
+    arg4 = *arg7;               // TODO: issue an error for incorrect bounds.
+  }
+}
+
+nt_array_ptr<char> nullterm_return1(void);
+nt_array_ptr<char> nullterm_return2(void) : bounds(unknown);
+
+void check_nullterm_return_use(void) {
+  nt_array_ptr<char> p = nullterm_return1();
+  p = nullterm_return2(); // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
+}
+
+// TODO: Github issue #401.  We need to check that return expressions have bounds when expected.
+nt_array_ptr<char> check_nullterm_return1(void) {
+  nt_array_ptr<char> p : bounds(unknown) = 0;
+  return p;
+}

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1314,7 +1314,7 @@ void check_pointer_arithmetic(void) {
 
   int *p_tmp;
   array_ptr<int> r_tmp;
-  nt_array_ptr<int> s_tmp;
+  nt_array_ptr<int> s_tmp = 0;
 
   p_tmp = p + 5;
   p_tmp = 5 + p;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -385,7 +385,7 @@ extern void check_assign_cv(void) {
     array_ptr<volatile int> r_volatile = 0;
     nt_array_ptr<int> s = 0;
     nt_array_ptr<const int> s_const = 0;
-    nt_array_ptr<volatile int> s_volatile;
+    nt_array_ptr<volatile int> s_volatile = 0;
 
     p_const = p;    // unsafe pointer to const assigned unsafe pointer to non-const OK.
     q_const = q;    // ptr to const assigned ptr to non-const OK.
@@ -1156,7 +1156,7 @@ void check_pointer_arithmetic(void)
    // nt_array_ptr<void> is not allowed, so we don't have to test it.
    int *p_tmp;
    array_ptr<int> r_tmp;
-   nt_array_ptr<int> s_tmp;;
+   nt_array_ptr<int> s_tmp = 0;
 
    p_tmp = p + 5;
    p_tmp = 5 + p;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -102,7 +102,7 @@ void check_nullterm_restrictions(void) {
 // void pointers and pointers with constant/volatile attributes.
 extern void check_assign(int val, int *p, ptr<int> q, array_ptr<int> r,
                          float *s, ptr<float> t, array_ptr<float> u,
-                         nt_array_ptr<int> v, nt_array_ptr<short> x) {
+                         nt_array_ptr<int> v : count(1), nt_array_ptr<short> x) {
     int *t1 = p;              // T *  = T * OK
     ptr<int> t2 = &val;       // ptr<T> = T * OK when T * has known bounds
     ptr<int> t3 = q;          // ptr<T> = ptr<T> OK
@@ -120,8 +120,7 @@ extern void check_assign(int val, int *p, ptr<int> q, array_ptr<int> r,
                               // T * = nt_array_ptr<T> not OK
     ptr<int> t8 = r;          // expected-error {{expression has no bounds}}
                               // ptr<T> = array_ptr<T> OK
-    ptr<int> t8a = v;         // expected-error {{expression has no bounds}}
-                              // ptr<T> = nt_array_ptr<T> OK.
+    ptr<int> t8a = v;         // ptr<T> = nt_array_ptr<T> OK.
     array_ptr<int> t9 = q;    // array_ptr<T> = ptr<T> OK
     array_ptr<int> t10a = v;  // array_ptr<T> = nt_array_ptr<T> OK.
     nt_array_ptr<int> t10b = q; // expected-error {{incompatible type}}

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -111,6 +111,14 @@ void f42(array_ptr<int> p : count(len), int len);  // expected-error {{function 
 void f43(array_ptr<int> p : count(len), int len);
 void f43(array_ptr<int> p, int len);               // expected-error {{function redeclaration dropped bounds for parameter}}
 
+void f44(array_ptr<int> p);
+void f44(array_ptr<int> p : bounds(unknown));
+
+// Pointers with a null-terminated pointer type have a default bounds of count(0)
+void f45(nt_array_ptr<int> p);
+void f45(nt_array_ptr<int> p : count(0));
+void f45(nt_array_ptr<int> p : count(1));   // expected-error {{conflicting parameter bounds}}
+
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have bounds-safe interfaces for returns  //
 // must have matching interfaces.                                            //


### PR DESCRIPTION
Null-terminated array pointers have a default bounds of count(0).   This adds tests of bounds checking and type checking for null-terminated array pointers with programmer-specified bounds and default bounds.   This change matches a corresponding clang compiler change (https://github.com/Microsoft/checkedc-clang/pull/406).

There need to be additional tests added of struct members with default bounds of count(0).   I'd like to commit the compiler change soon to unblock people, so I'm opening this PR now, even though further work is needed.
