### PR TITLE
Add another example of using strings and add string support to stdio_checked.h

### DIFF
--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -1,12 +1,9 @@
 //---------------------------------------------------------------------//
-// Bounds-safe interfaces for functions in math.h that                 //
+// Bounds-safe interfaces for functions in stdio.h that                //
 // take pointer arguments.                                             //
 //                                                                     //
 // These are listed in the same order that they occur in the C11       //
 // specification.                                                      //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 //                                                                     //
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
@@ -26,20 +23,17 @@ extern FILE *stdout : itype(_Ptr<FILE>);
 extern FILE *stderr : itype(_Ptr<FILE>);
 #endif
 
-// TODO: handle strings
-// int remove(const char *name);
-// int rename(const char *from, const char *to);
+int remove(const char *name : itype(_Nt_array_ptr<const char>));
+int rename(const char *from : itype(_Nt_array_ptr<const char>),
+           const char *to : itype(_Nt_array_ptr<const char>));
 FILE *tmpfile(void) : itype(_Ptr<FILE>);
-// TODO: handle strings
-// char *tmpnam(char *source);
+char *tmpnam(char *source : itype(_Nt_array_ptr<char>)) : itype(_Nt_array_ptr<char>);
 int fclose(FILE *stream : itype(_Ptr<FILE>));
 int fflush(FILE *stream : itype(_Ptr<FILE>));
-_Unchecked
-FILE *fopen(const char * restrict filename,
-            const char * restrict mode) : itype(_Ptr<FILE>);
-_Unchecked
-FILE *freopen(const char * restrict filename,
-              const char * restrict mode,
+FILE *fopen(const char * restrict filename : itype(restrict _Nt_array_ptr<const char>),
+            const char * restrict mode : itype(restrict _Nt_array_ptr<const char>)) : itype(_Ptr<FILE>);
+FILE *freopen(const char * restrict filename : itype(restrict _Nt_array_ptr<const char>),
+              const char * restrict mode : itype(restrict _Nt_array_ptr<const char>),
               FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
   itype(_Ptr<FILE>);
 
@@ -58,13 +52,14 @@ int setvbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 //
 _Unchecked
 int fprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
-            const char * restrict format, ...);
+            const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 _Unchecked
 int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
-           const char * restrict format, ...);
-// TODO: handle strings
-// int printf(const char * restrict format, ...);
-// int scanf(const char * restrict format, ...);
+           const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+_Unchecked
+int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+_Unchecked
+int scanf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 
 // OMITTED INTENTIONALLY:
 // sprintf cannot be made checked.  It is missing the bounds
@@ -72,30 +67,31 @@ int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 // int sprintf(char * restrict s,
 //            const char * restrict format, ...);
 //
-// TODO: handle strings
-// int sscanf(const char * restrict s,
-//            const char * restrict format, ...);
+_Unchecked
+int sscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
+           const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 // TODO: Apple System Headers Support
 #if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 _Unchecked
 int snprintf(char * restrict s : count(n), size_t n,
-             const char * restrict format, ...);
+             const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 #endif
 
 _Unchecked
 int vfprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
-             const char * restrict format,
+             const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
              va_list arg);
 _Unchecked
 int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
-            const char * restrict format,
+            const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
             va_list arg);
 
-// TODO: handle strings
-// int vprintf(const char * restrict format,
-//             va_list arg);
-// int vscanf(const char * restrict format,
-//            va_list arg);
+_Unchecked
+int vprintf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
+             va_list arg);
+_Unchecked
+int vscanf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
+            va_list arg);
 // TODO: Apple System Headers Support
 #if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
 _Unchecked
@@ -109,19 +105,17 @@ int vsnprintf(char * restrict s : count(n), size_t n,
 // int vsprintf(char * restrict s,
 //             const char * restrict format,
 //             va_list arg);
-// TODO: handle strings
-// int vsscanf(const char * restrict s,
-//            const char * restrict format,
-//            va_list arg);
+_Unchecked
+int vsscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
+            const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
+            va_list arg);
 
 int fgetc(FILE *stream : itype(_Ptr<FILE>));
 int fputc(int c, FILE *stream : itype(_Ptr<FILE>));
-_Unchecked
 char *fgets(char * restrict s : count(n), int n,
             FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
   bounds(s, s + n);
-_Unchecked
-int fputs(const char * restrict s,
+int fputs(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
           FILE * restrict stream : itype(restrict _Ptr<FILE>));
 int getc(FILE *stream : itype(_Ptr<FILE>));
 int putc(int c, FILE *stream : itype(_Ptr<FILE>));
@@ -149,8 +143,7 @@ void rewind(FILE *stream : itype(_Ptr<FILE>));
 void clearerr(FILE *stream : itype(_Ptr<FILE>));
 int feof(FILE *stream : itype(_Ptr<FILE>));
 int ferror(FILE *stream : itype(_Ptr<FILE>));
-// TODO: strings
-// void perror(const char *s);
+void perror(const char *s : itype(_Nt_array_ptr<const char>));
 
 #include "_builtin_stdio_checked.h"
 

--- a/samples/find-pattern.c
+++ b/samples/find-pattern.c
@@ -1,0 +1,112 @@
+// This file contains an example that illustrates the use of strings in
+// Checked C.  The example is adapted from "The C Programming Language,
+// Second Edition", by Brian Kernighan and Dennis Ritchie, p. 69.
+// It reads a series of lines and check whether a string occurs in a line.
+// If it does, it prints the line.
+//
+// To compile the file using clang, on Unix/Mac use
+//  clang -o find-pattern -fcheckedc-extension find-pattern.c
+// On Windows use:
+//  clang -o find-pattern.exe -fcheckedc-extension find-pattern.c
+//
+// To run it, create a file with some lines of text in it that contain a
+// pattern you wish to match.  Then run:
+//    find-pattern {your pattern} < {your file name}
+// where you use your pattern and file name in replace of {your pattern}
+// and {your file name}.
+//
+// This file illustrates two important points about using strings in Checked C.
+// - Sometime you need to allocate a fixed size buffer that will be treated
+//   as both a null-terminated string and a regular array.  The buffer should
+//   be given a null-terminated array type, not a regular array type.
+// - You will need to either allocate an extra character, or avoid writes to the
+//   last character in the buffer.
+// - Take care when using array subscripting on strings.  It is easy to accidentally
+//   march beyond the end of the declared bounds.
+
+#include <stdchecked.h>
+#include <stdio_checked.h>
+
+// In the original code, this is 1000.  Make this 50 so we can easily test
+// exceeding the maximum number of characters allowed in a line.
+#define MAXLINE 50
+
+#pragma BOUNDS_CHECKED ON
+
+int getline(char line checked[] : count(max), int max);
+int strindex(char source nt_checked[], char searchfor nt_checked[]);
+void print_string(char str nt_checked[]);
+
+int main(int argc, nt_array_ptr<char> argv checked[] : count(argc)) {
+  if (argc < 2) {
+    // Th original code used printf.  Calls to variable argument functions
+    // aren't allowed in checked scopes, so use separate statements.
+    print_string("Usage: ");
+    print_string(argv[0]);
+    print_string(" pattern\n");
+    return -1;
+  }
+  nt_array_ptr<char> pattern = argv[1];
+  // Line is treated is both a null-terminated array and a regular array. 
+  // We don't allow array_ptrs to be converted to nt_array_ptrs, but we allow
+  // the reverse. For this reason, we make this a null-terminated array.  Add
+  // an extra byte so that we have a place for the null terminator and retain
+  // the original size (the count of  accessible elements is one less than the
+  // dimension of the array).
+  char line nt_checked[MAXLINE + 1] = {};
+  int found = 0;
+  while (getline(line, MAXLINE) > 0)
+    if (strindex(line, pattern) >= 0) {
+      // Avoid using printf again;
+      print_string(line);
+      found++;
+    }
+  return 0;
+}
+
+// Get line into s, return length.
+int getline(char s checked[] : count(lim), int lim) {
+  int c, i;
+  // The original code modifies lim, which we are using as the
+  // bounds.  Introduce a new variable for counting the available
+  // space.
+  int available = lim;
+
+  i = 0;
+  while (--available > 0 && (c = getchar()) != EOF && c != '\n')
+    s[i++] = c;
+  if (c == '\n')
+    s[i++] = c;
+  // We could have made s a nt_checked array.  We'd have to check
+  // here to make sure we aren't trying to write to the null terminator.
+  s[i] = '\0';
+  return i;
+}
+
+// Return index of t in s, -1 if none.
+int strindex(char source nt_checked[] : count(0),
+             char searchfor nt_checked[] : count(0)) {
+  int i = 0, k = 0;
+
+  nt_array_ptr<char> s : count(i) = source;
+  nt_array_ptr<char> t : count(k) = searchfor;
+
+  for (i = 0; s[i] != '\0'; i++) {
+    // The original code was:
+    //  for (j = i, k = 0; t[k] != '\0' && s[j] == t[k]; j++, k++)
+    // The problem with this approach is that on the second iteration, j > i,
+    // which will cause a runtime bounds failure for s[j].
+    // We just introduce a temporary instead and remove s[j].
+    nt_array_ptr<char> tmp_s = s + i;
+    for (k = 0; t[k] != '\0' && *tmp_s == t[k]; tmp_s++, k++)
+      ;
+     if (k > 0 && t[k] == '\0')
+       return i;
+  }
+  return -1;
+}
+
+void print_string(char str nt_checked[]) {
+  // Fputs has a bounds-safe interface and can be used in checked scopes.
+  fputs(str, stdout);
+}


### PR DESCRIPTION
The example is adapted from a simple "pattern finding" program from "The C Programming Language, Second Edition", by Kernighan and Ritchie.  The example uses only checked code.    The example does output using fputs; I updated fputs and the rest of stdio_checked.h with annotations for strings.

This example requires the compiler changes in https://github.com/Microsoft/checkedc-clang/pull/406 to compile.  I had to fix two bugs, which I'll add to the compiler pull request soon.

