### PR TITLE
Use null-terminated array pointers in checked wrappers for C standard libraries

### DIFF
--- a/include/_builtin_common.h
+++ b/include/_builtin_common.h
@@ -8,9 +8,6 @@
 //                                                                     //
 // These are based on the types as declared within clang               //
 // and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
 #ifndef __has_builtin

--- a/include/_builtin_stdio_checked.h
+++ b/include/_builtin_stdio_checked.h
@@ -8,9 +8,6 @@
 //                                                                     //
 // These are based on the types as declared within clang               //
 // and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
 #include "_builtin_common.h"
@@ -26,7 +23,8 @@ int __snprintf_chk(char * __restrict s : count(n),
                           size_t n,
                           int flag,
                           size_t obj_size,
-                          const char * __restrict format,
+                          const char * __restrict format :
+                            itype(restrict _Nt_array_ptr<const char>),
                           ...);
 
 _Unchecked
@@ -34,7 +32,9 @@ int __builtin___snprintf_chk(char * restrict s : count(n),
                              size_t n,
                              int flag,
                              size_t obj_size,
-                             const char * restrict format,
+                             const char * restrict format :
+                               itype(restrict _Nt_array_ptr<const char>)
+                             ,
                              ...);
 #endif
 
@@ -45,7 +45,8 @@ int __vsnprintf_chk(char * __restrict s : count(n),
                            size_t n,
                            int flag,
                            size_t obj_size,
-                           const char * __restrict format,
+                           const char * __restrict format :
+                             itype(restrict _Nt_array_ptr<const char>),
                            va_list);
 
 _Unchecked
@@ -53,7 +54,8 @@ int __builtin___vsnprintf_chk(char * restrict s : count(n),
                               size_t n,
                               int flag,
                               size_t obj_size,
-                              const char * restrict format,
+                              const char * restrict format :
+                                itype(restrict _Nt_array_ptr<const char>),
                               va_list arg);
 #endif
 

--- a/include/_builtin_string_checked.h
+++ b/include/_builtin_string_checked.h
@@ -8,9 +8,6 @@
 //                                                                     //
 // These are based on the types as declared within clang               //
 // and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
 #include "_builtin_common.h"
@@ -42,10 +39,13 @@ void *__builtin___memset_chk(void * s : byte_count(n),
 #endif
 
 #if __has_builtin(__builtin___strncat_chk) || defined(__GNUC__)
-char *__builtin___strncat_chk(char * restrict dest : count(n),
+// TODO: we have no way to express the bounds requirement on dest,
+// which needs to be count(strlen(dest) + n).
+_Unchecked
+char *__builtin___strncat_chk(char * restrict dest,
                               const char * restrict src : count(n),
                               size_t n,
-                              size_t obj_size) : bounds(dest, (_Array_ptr<char>)dest + n);
+                              size_t obj_size);
 #endif
 
 #if __has_builtin(__builtin___strncpy_chk) || defined(__GNUC__)

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -4,9 +4,6 @@
 //                                                                     //
 // These are listed in the same order that they occur in the C11       //
 // specification.                                                      //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
 #include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
@@ -15,22 +12,30 @@
 #pragma BOUNDS_CHECKED ON
 
 _Unchecked
-intmax_t strtoimax(const char * restrict nptr,
-                   char ** restrict endptr : itype(restrict _Ptr<char *>),
+intmax_t strtoimax(const char * restrict nptr :
+                     itype(restrict _Nt_array_ptr<const char>),
+                   char ** restrict endptr :
+                      itype(restrict _Ptr<_Nt_array_ptr<char>>),
                    int base);
 _Unchecked
-uintmax_t strtoumax(const char * restrict nptr,
-                    char ** restrict endptr : itype(restrict _Ptr<char *>),
+uintmax_t strtoumax(const char * restrict nptr :
+                      itype(restrict _Nt_array_ptr<const char>),
+                    char ** restrict endptr :
+                      itype(restrict _Ptr<_Nt_array_ptr<char >>),
                     int base);
 
 _Unchecked
-intmax_t wcstoimax(const wchar_t * restrict nptr,
-                   wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+intmax_t wcstoimax(const wchar_t * restrict nptr :
+                     itype(restrict _Nt_array_ptr<const wchar_t>),
+                   wchar_t ** restrict endptr :
+                     itype(restrict _Ptr<_Nt_array_ptr<wchar_t>>),
                    int base);
 
 _Unchecked
-uintmax_t wcstoumax(const wchar_t * restrict nptr,
-                    wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+uintmax_t wcstoumax(const wchar_t * restrict nptr :
+                      itype(restrict _Nt_array_ptr<const wchar_t>),
+                    wchar_t ** restrict endptr :
+                      itype(restrict _Ptr<_Nt_array_ptr<wchar_t>>),
                     int base);
 
 #pragma BOUNDS_CHECKED OFF

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -4,9 +4,6 @@
 //                                                                     //
 // These are listed in the same order that they occur in the C11       //
 // specification.                                                      //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
 #include <math.h>
@@ -26,9 +23,8 @@ double remquo(double x, double y, int *quo : itype(_Ptr<int>));
 float remquof(float x, float y, int *quo : itype(_Ptr<int>));
 long double remquol(long double x, long double y, int *quo : itype(_Ptr<int>));
 
-#pragma BOUNDS_CHECKED OFF
+double nan(const char *t : itype(_Nt_array_ptr<const char>));
+float nanf(const char *t : itype(_Nt_array_ptr<const char>));
+long double nanf(const char *t : itype(_Nt_array_ptr<const char>));
 
-// TODO: strings
-// double nan(const char *t);
-// float nanf(const char *t);
-// long double nanf(const char *t);
+#pragma BOUNDS_CHECKED OFF

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -25,6 +25,6 @@ long double remquol(long double x, long double y, int *quo : itype(_Ptr<int>));
 
 double nan(const char *t : itype(_Nt_array_ptr<const char>));
 float nanf(const char *t : itype(_Nt_array_ptr<const char>));
-long double nanf(const char *t : itype(_Nt_array_ptr<const char>));
+long double nanl(const char *t : itype(_Nt_array_ptr<const char>));
 
 #pragma BOUNDS_CHECKED OFF

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -61,12 +61,11 @@ int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const cha
 _Unchecked
 int scanf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 
-// OMITTED INTENTIONALLY:
-// sprintf cannot be made checked.  It is missing the bounds
-// for the output buffer.
-// int sprintf(char * restrict s,
-//            const char * restrict format, ...);
-//
+// The output buffer parameter s is an unchecked pointer because no bounds are provided.
+_Unchecked
+int sprintf(char * restrict s,
+            const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+
 _Unchecked
 int sscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
            const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
@@ -99,12 +98,12 @@ int vsnprintf(char * restrict s : count(n), size_t n,
               const char * restrict format,
               va_list arg);
 #endif
-// OMITTED INTENTIONALLY:
-// vsprintf cannot be made checked. it is missing the bounds
-// for the output buffer.
-// int vsprintf(char * restrict s,
-//             const char * restrict format,
-//             va_list arg);
+
+// The output buffer parameter has an unchecked pointer type becuse it is missing bounds.
+_Unchecked
+int vsprintf(char * restrict s,
+             const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
+/            va_list arg);
 _Unchecked
 int vsscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
             const char * restrict format : itype(restrict _Nt_array_ptr<const char>),

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -103,7 +103,7 @@ int vsnprintf(char * restrict s : count(n), size_t n,
 _Unchecked
 int vsprintf(char * restrict s,
              const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
-/            va_list arg);
+             va_list arg);
 _Unchecked
 int vsscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
             const char * restrict format : itype(restrict _Nt_array_ptr<const char>),

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -17,7 +17,7 @@ long long int atoll(const char *s : itype(_Nt_array_ptr<const char>));
 double strtod(const char * restrict nptr :
                 itype(restrict _Nt_array_ptr<const char>),
               char ** restrict endptr :
-                itype(restrict _Ptr<_Nt_array_ptr<char>>);
+                itype(restrict _Ptr<_Nt_array_ptr<char>>));
 
 float strtof(const char * restrict nptr :
                itype(restrict _Nt_array_ptr<const char>),
@@ -65,7 +65,7 @@ char *getenv(const char *n : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array
 int atexit(void ((*func)(void)) : itype(_Ptr<void (void)>));
 int atquick_exit(void ((*func)(void)) : itype(_Ptr<void (void)>));
 
-int system(const char *s : itype(_Nt_array_ptr<char>));
+int system(const char *s : itype(_Nt_array_ptr<const char>));
 
 // TODO: compar needs to have an itype that has bounds
 // on parameters based on size.  Currently we are requiring that

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -4,48 +4,53 @@
 //                                                                     //
 // These are listed in the same order that they occur in the C11       //
 // specification.                                                      //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 #include <stdlib.h>
 
 #pragma BOUNDS_CHECKED ON
 
-// TODO: strings
-// double atof(const char *s);
-// int atoi(const char *s);
-// long int atol(const char *s);
-// long long int atoll(const char *s);
+double atof(const char *s : itype(_Nt_array_ptr<const char>));
+int atoi(const char *s : itype(_Nt_array_ptr<const char>));
+long int atol(const char *s : itype(_Nt_array_ptr<const char>));
+long long int atoll(const char *s : itype(_Nt_array_ptr<const char>));
 
-_Unchecked
-double strtod(const char * restrict nptr,
-              char ** restrict endptr : itype(restrict _Ptr<char *>));
-_Unchecked
-float strtof(const char * restrict nptr,
-             char ** restrict endptr : itype(restrict _Ptr<char *>));
-_Unchecked
-long double strtold(const char * restrict nptr,
-                    char ** restrict endptr : itype(restrict _Ptr<char *>));
+double strtod(const char * restrict nptr :
+                itype(restrict _Nt_array_ptr<const char>),
+              char ** restrict endptr :
+                itype(restrict _Ptr<_Nt_array_ptr<char>>);
 
-_Unchecked
-long int strtol(const char * restrict nptr,
-                char ** restrict endptr : itype(restrict _Ptr<char *>),
+float strtof(const char * restrict nptr :
+               itype(restrict _Nt_array_ptr<const char>),
+             char ** restrict endptr :
+                itype(restrict _Ptr<_Nt_array_ptr<char>>));
+
+long double strtold(const char * restrict nptr :
+                      itype(restrict _Nt_array_ptr<const char>),
+                    char ** restrict endptr :
+                       itype(restrict _Ptr<_Nt_array_ptr<char>>));
+
+long int strtol(const char * restrict nptr :
+                  itype(restrict _Nt_array_ptr<const char>),
+                char ** restrict endptr :
+                  itype(restrict _Ptr<_Nt_array_ptr<char>>),
                 int base);
-_Unchecked
-long long int strtoll(const char * restrict nptr,
-                      char ** restrict endptr : itype(restrict _Ptr<char *>),
+
+long long int strtoll(const char * restrict nptr :
+                        itype(restrict _Nt_array_ptr<const char>),
+                      char ** restrict endptr :
+                        itype(restrict _Ptr<_Nt_array_ptr<char>>),
                       int base);
-_Unchecked
-unsigned long int strtoul(const char * restrict nptr,
+
+unsigned long int strtoul(const char * restrict nptr :
+                            itype(restrict _Nt_array_ptr<const char>),
                           char ** restrict endptr :
-                            itype(restrict _Ptr<char *>),
+                            itype(restrict _Ptr<_Nt_array_ptr<char>>),
                           int base);
 
-_Unchecked
-unsigned long long int strtoull(const char * restrict nptr,
+unsigned long long int strtoull(const char * restrict nptr :
+                                  itype(restrict _Nt_array_ptr<const char>),
                                 char ** restrict endptr:
-                                   itype(restrict _Ptr<char *>),
+                                   itype(restrict _Ptr<_Nt_array_ptr<char>>),
                                 int base);
 
 // TODO: express alignment constraints once where clauses have been added.
@@ -55,14 +60,12 @@ void free(void *pointer : byte_count(1));
 void *malloc(size_t size) : byte_count(size);
 void *realloc(void *pointer : byte_count(1), size_t size) : byte_count(size);
 
-// TODO: strings
-// char *getenv(const char *n);
+char *getenv(const char *n : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array_ptr<char>);
 
 int atexit(void ((*func)(void)) : itype(_Ptr<void (void)>));
 int atquick_exit(void ((*func)(void)) : itype(_Ptr<void (void)>));
 
-// TODO: strings
-// int system(const char *s);
+int system(const char *s : itype(_Nt_array_ptr<char>));
 
 // TODO: compar needs to have an itype that has bounds
 // on parameters based on size.  Currently we are requiring that
@@ -94,14 +97,14 @@ int mbtowc(wchar_t * restrict output : itype(restrict _Ptr<wchar_t>),
 // 
 // int wctomb(char *s : count(MB_CUR_MAX), wchar_t wc);
 
-_Unchecked
 size_t mbstowcs(wchar_t * restrict pwcs : count(n),
-                const char * restrict s,
+                const char * restrict s :
+                  itype(restrict _Nt_array_ptr<const char>),
                 size_t n);
 
-_Unchecked
 size_t wcstombs(char * restrict output : count(n),
-                const wchar_t * restrict pwcs,
+                const wchar_t * restrict pwcs :
+                  itype(restrict _Nt_array_ptr<const wchar_t>),
                 size_t n);
 
 #pragma BOUNDS_CHECKED OFF

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -10,22 +10,29 @@
 //                                                                     //
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
+
 #include <string.h>
 
 #pragma BOUNDS_CHECKED ON
 
 // GCC has macros that it uses as part of its string implementation to optimize cases
 // where one or both strings are compile-time constants.  I'm not sure
-// why they put this logic into a macro instead of the compiler because the
+// why they put this logic into macros instead of the compiler because the
 // compiler can recognize these cases in more contexts than a macro, but they
 // did.
 //
-// For now, turn off the optimization to avoid two problems:
-//  1. Macro names for string functions are defined at this point, and the macro gets
-//     expanded in the redeclarations.
-//  2. The macros would break in a checked context anyway because they contain
-//      casts involving unchecked pointers.
-#define __NO_STRING_INLINES
+// For now, undefine the various macros.  GCC has a #define for turning off
+// this feature, but that must be set before string.h is included and we don't
+// control when that happens (string.h may already have been included before
+// this file is ever included).
+#if defined(__GNUC__)
+#undef strchr
+#undef strcmp
+#undef strcspn
+#undef strncmp
+#undef strncmp
+#undef strspn
+#endif
 
 // TODO: Apple System Headers Support
 #if !( defined(__APPLE__) && _FORTIFY_SOURCE > 0)

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -24,14 +24,11 @@ void *memmove(void * restrict dest : byte_count(n),
               const void * restrict src : byte_count(n),
               size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
 #endif
-// TODO: strings
-// char *strcpy(char * restrict dest,
-//              const char * restrict src);
 
-// OMITTED INTENTIONALLY: this cannot be made checked.
-// There is no bound on s1.
-// char *strcpy(char * restrict s1,
-//              const char * restrict s2);
+// Dest is left unchecked intentionally. There is no bound on dest, so this
+// is always an unchecked function
+char *strcpy(char * restrict s1,
+              const char * restrict s2 : itype(restrict _Nt_array_ptr<const char>));
 
 // TODO: Apple System Headers Support
 #if !( defined(__APPLE__) && _FORTIFY_SOURCE > 0)
@@ -40,24 +37,29 @@ char *strncpy(char * restrict dest : count(n),
               size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
 #endif
 
-// OMITTED INTENTIONALLY: this cannot be made checked.
-// There is no bound on dest.
-// char *strcat(char * restrict dest,
-//              const char * restrict src);
+// Dest is left unchecked intentionally. There is no bound on dest, so this
+// is always an unchecked function.
+_Unchecked
+char *strcat(char * restrict dest,
+             const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
 
 // TODO: Apple System Headers Support
 #if !( defined(__APPLE__) && _FORTIFY_SOURCE > 0)
-char *strncat(char * restrict dest : count(n),
+// TODO: we have no way to express the bounds requirement on dest,
+// which needs to be count(strlen(dest) + n).
+_Unchecked
+char *strncat(char * restrict dest,
               const char * restrict src : count(n),
-              size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
+              size_t n);
 #endif
 
 int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
            size_t n);
 
-// TODO: strings
-// int strcmp(const char *src1, const char *src2);
-// int strcoll(const char *src1, const char *src2);
+int strcmp(const char *src1 : itype(_Nt_array_ptr<char>),
+           const char *src2 : itype(_Nt_array_ptr<char>));
+int strcoll(const char *src1 : itype(_Nt_array_ptr<char>),
+            const char *src2 : itype(_Nt_array_ptr<char>));
 
 // Linux header files declare strncmp and also define a macro for it.
 // Undef the macro so that we can redeclare strncmp.
@@ -69,23 +71,33 @@ int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
 #undef strncmp
 int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
 
-_Unchecked
 size_t strxfrm(char * restrict dest : count(n),
-               const char * restrict src,
+               const char * restrict src :
+                 itype(restrict _Nt_array_ptr<const char>),
                size_t n);
 
 void *memchr(const void *s : byte_count(n), int c, size_t n) :
   bounds(s, (_Array_ptr<char>) s + n);
 
-// TODO: strings
-// char *strchr(const char *s, int c);
-// size_t strcspn(const char *s1, const char *s2);
-// char *strpbrk(const char *s1, const char *s2);
-// char *strrchr(const char *s, int c);
-// size_t strspn(const char *s1, const char *s2);
-// char *strstr(const char *s1, const char *s2);
-// char *strtok(char * restrict s1,
-//              const char * restrict s2);
+char *strchr(const char *s : itype(_Nt_array_ptr<const char>), int c) :
+  itype(_Nt_array_ptr<char>);
+
+size_t strcspn(const char *s1 : itype(_Nt_array_ptr<const char>),
+               const char *s2 : itype(_Nt_array_ptr<const char>));
+
+char *strpbrk(const char *s1 : itype(_Nt_array_ptr<const char>),
+              const char *s2 : itype(_Nt_array_ptr<const char>)) :
+  itype(_Nt_array_ptr<char>);
+char *strrchr(const char *s : itype(_Nt_array_ptr<const char>), int c) :
+  itype(_Nt_array_ptr<char>)
+size_t strspn(const char *s1 : itype(_Nt_array_ptr<const char>),
+              const char *s2 : itype(_Nt_array_ptr<const char>));
+char *strstr(const char *s1 : itype(_Nt_array_ptr<const char>),
+             const char *s2 : itype(_Nt_array_ptr<const char>)) :
+  itype(_Nt_array_ptr<char>);
+char *strtok(char * restrict s1 : itype(restrict _Nt_array_ptr<char>),
+             const char * restrict s2 : itype(restrict _Nt_array_ptr<char>)) :
+  itype(_Nt_array_ptr<char>)
 
 // TODO: Apple System Headers Support
 #if !( defined(__APPLE__) && _FORTIFY_SOURCE > 0)
@@ -93,9 +105,8 @@ void *memset(void *s : byte_count(n), int c, size_t n) :
   bounds(s, (_Array_ptr<char>) s + n);
 #endif
 
-// TODO: strings
-// char *strerror(int errnum);
-// size_t strlen(const char *s);
+char *strerror(int errnum) : itype(_Nt_array_ptr<char>);
+size_t strlen(const char *s : itype(_Nt_array_ptr<const char>));
 
 #include "_builtin_string_checked.h"
 

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -31,6 +31,7 @@
 #undef strcspn
 #undef strncmp
 #undef strncmp
+#undef strpbrk
 #undef strspn
 #endif
 

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -14,6 +14,19 @@
 
 #pragma BOUNDS_CHECKED ON
 
+// GCC has macros that it uses as part of its string implementation to optimize cases
+// where one or both strings are compile-time constants.  I'm not sure
+// why they put this logic into a macro instead of the compiler because the
+// compiler can recognize these cases in more contexts than a macro, but they
+// did.
+//
+// For now, turn off the optimization to avoid two problems:
+//  1. Macro names for string functions are defined at this point, and the macro gets
+//     expanded in the redeclarations.
+//  2. The macros would break in a checked context anyway because they contain
+//      casts involving unchecked pointers.
+#define __NO_STRING_INLINES
+
 // TODO: Apple System Headers Support
 #if !( defined(__APPLE__) && _FORTIFY_SOURCE > 0)
 void *memcpy(void * restrict dest : byte_count(n),
@@ -62,14 +75,7 @@ int strcmp(const char *src1 : itype(_Nt_array_ptr<const char>),
 int strcoll(const char *src1 : itype(_Nt_array_ptr<const char>),
             const char *src2 : itype(_Nt_array_ptr<const  char>));
 
-// Linux header files declare strncmp and also define a macro for it.
-// Undef the macro so that we can redeclare strncmp.
-//
-// Section 7.1.4 of the C11 standard allows the use of #undef to prevent
-// macros from interfering  with explicit declarations of library functions.
-// It is legal to #undef a macro that isn't defined, so we don't need to
-// conditionalize this.
-#undef strncmp
+
 int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
 
 size_t strxfrm(char * restrict dest : count(n),

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -27,6 +27,7 @@ void *memmove(void * restrict dest : byte_count(n),
 
 // Dest is left unchecked intentionally. There is no bound on dest, so this
 // is always an unchecked function
+_Unchecked
 char *strcpy(char * restrict s1,
               const char * restrict s2 : itype(restrict _Nt_array_ptr<const char>));
 
@@ -56,10 +57,10 @@ char *strncat(char * restrict dest,
 int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
            size_t n);
 
-int strcmp(const char *src1 : itype(_Nt_array_ptr<char>),
-           const char *src2 : itype(_Nt_array_ptr<char>));
-int strcoll(const char *src1 : itype(_Nt_array_ptr<char>),
-            const char *src2 : itype(_Nt_array_ptr<char>));
+int strcmp(const char *src1 : itype(_Nt_array_ptr<const char>),
+           const char *src2 : itype(_Nt_array_ptr<const char>));
+int strcoll(const char *src1 : itype(_Nt_array_ptr<const char>),
+            const char *src2 : itype(_Nt_array_ptr<const  char>));
 
 // Linux header files declare strncmp and also define a macro for it.
 // Undef the macro so that we can redeclare strncmp.
@@ -89,15 +90,15 @@ char *strpbrk(const char *s1 : itype(_Nt_array_ptr<const char>),
               const char *s2 : itype(_Nt_array_ptr<const char>)) :
   itype(_Nt_array_ptr<char>);
 char *strrchr(const char *s : itype(_Nt_array_ptr<const char>), int c) :
-  itype(_Nt_array_ptr<char>)
+  itype(_Nt_array_ptr<char>);
 size_t strspn(const char *s1 : itype(_Nt_array_ptr<const char>),
               const char *s2 : itype(_Nt_array_ptr<const char>));
 char *strstr(const char *s1 : itype(_Nt_array_ptr<const char>),
              const char *s2 : itype(_Nt_array_ptr<const char>)) :
   itype(_Nt_array_ptr<char>);
 char *strtok(char * restrict s1 : itype(restrict _Nt_array_ptr<char>),
-             const char * restrict s2 : itype(restrict _Nt_array_ptr<char>)) :
-  itype(_Nt_array_ptr<char>)
+             const char * restrict s2 : itype(restrict _Nt_array_ptr<const char>)) :
+  itype(_Nt_array_ptr<char>);
 
 // TODO: Apple System Headers Support
 #if !( defined(__APPLE__) && _FORTIFY_SOURCE > 0)

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -29,7 +29,7 @@ struct tm *localtime(const time_t *timer : itype(_Ptr<const time_t>)) :
 
 size_t strftime(char * restrict output : count(maxsize),
                 size_t maxsize,
-                const char * restrict format : itype(_Nt_array_ptr<const char>),
+                const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
                 const struct tm * restrict timeptr :
                    itype(restrict _Ptr<const struct tm>));
 

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -4,9 +4,6 @@
 //                                                                     //
 // These are listed in the same order that they occur in the C11       //
 // specification.                                                      //
-//                                                                     //
-// TODO: revise string types after support for pointers to             //
-// null-terminated arrays is added to C.                               //
 /////////////////////////////////////////////////////////////////////////
 
 #include <time.h>
@@ -18,11 +15,11 @@ time_t mktime(struct tm *timeptr : itype(_Ptr<struct tm>));
 int timespec_get(struct timespec *ts : itype(_Ptr<struct timespec>),
                  int base);
 
-_Unchecked
-char *asctime(const struct tm *timeptr : itype(_Ptr<const struct tm>));
+char *asctime(const struct tm *timeptr : itype(_Ptr<const struct tm>)) :
+  itype(_Nt_array_ptr<char>);
 
-_Unchecked
-char *ctime(const time_t *timer : itype(_Ptr<const time_t>));
+char *ctime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Nt_array_ptr<char>);
 
 struct tm *gmtime(const time_t *timer : itype(_Ptr<const time_t>)) :
   itype(_Ptr<struct tm>);
@@ -30,10 +27,9 @@ struct tm *gmtime(const time_t *timer : itype(_Ptr<const time_t>)) :
 struct tm *localtime(const time_t *timer : itype(_Ptr<const time_t>)) :
   itype(_Ptr<struct tm>);
 
-_Unchecked
 size_t strftime(char * restrict output : count(maxsize),
                 size_t maxsize,
-                const char * restrict format,
+                const char * restrict format : itype(_Nt_array_ptr<const char>),
                 const struct tm * restrict timeptr :
                    itype(restrict _Ptr<const struct tm>));
 


### PR DESCRIPTION
This change updates our checked wrappers for C standard libraries to use null-terminated array pointers for strings.
- I expanded the list of string functions and had to disable more optimized macros for GCC.
- In cases where I could make some parameters a function checked, but not other parameters checked,
I went ahead and did that.  This include functions such as `strcat` and `strncat`.   The fact that the destination buffer has an unchecked pointer type should be a warning to programmers trying to use them.
- For `strncat`, we have no way of expressing the bounds requirement in checked code, because the bounds requirement involves a function call.

Testing:
- Passed automated testing, including LNT testing.

