### PR TITLE
Compiler now warns about some out-of-bounds memory accesses.

### DIFF
--- a/tests/dynamic_checking/bounds/deref.c
+++ b/tests/dynamic_checking/bounds/deref.c
@@ -1,4 +1,4 @@
-// Test bounds checking of uses of pointer dereference expressions.
+// Test runtime bounds checking of uses of pointer dereference expressions.
 //
 // Uses are tested in read, assignment,increment, and compound assignment 
 // expressions.  The type of use is controlled by the macro names TEST_READ,
@@ -7,7 +7,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -DTEST_READ -Werror -Wno-unused-value
+// RUN: %clang -fcheckedc-extension %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-memory-accesses
 // RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -16,7 +16,7 @@
 // RUN: %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang -fcheckedc-extension %s -o %t2 -DTEST_WRITE -Werror
+// RUN: %clang -fcheckedc-extension %s -o %t2 -DTEST_WRITE -Werror -Wno-check-memory-accesses
 // RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -25,7 +25,7 @@
 // RUN: %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %s -o %t3 -DTEST_INCREMENT -Werror
+// RUN: %clang -fcheckedc-extension %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-memory-accesses
 // RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -34,7 +34,7 @@
 // RUN: %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
+// RUN: %clang -fcheckedc-extension %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses
 // RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_opt.c
+++ b/tests/dynamic_checking/bounds/deref_opt.c
@@ -1,4 +1,4 @@
-// Test bounds checking of uses of pointer dereference expressions with
+// Test runtime bounds checking of uses of pointer dereference expressions with
 // optimization enabled.
 //
 // Uses are tested in read, assignment,increment, and compound assignment 
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -O3
 // RUN: %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -22,7 +22,7 @@
 // RUN: %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t2 -DTEST_WRITE -Werror -O3
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -O3
 // RUN: %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -31,7 +31,7 @@
 // RUN: %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t3 -DTEST_INCREMENT -Werror -O3
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -O3
 // RUN: %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -40,7 +40,7 @@
 // RUN: %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
+// RUN: %clang -fcheckedc-extension %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -O3
 // RUN: %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/nullterm_pointers.c
+++ b/tests/dynamic_checking/bounds/nullterm_pointers.c
@@ -1,7 +1,7 @@
-// Test bounds checking in checked scopes of uses of pointers
+// Test runtime bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -Werror -Wno-unused-value
+// RUN: %clang -fcheckedc-extension %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses
 // RUN:  %t1 1 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-1
 // RUN:  %t1 2 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 3 | FileCheck %s --check-prefixes=CHECK

--- a/tests/dynamic_checking/dynamic-bounds-cast-check.c
+++ b/tests/dynamic_checking/dynamic-bounds-cast-check.c
@@ -1,6 +1,6 @@
 // The following lines are for the clang automated test suite
 //
-// RUN: %clang -fcheckedc-extension %s -o %t -Werror
+// RUN: %clang -fcheckedc-extension %s -o %t -Werror -Wno-check-memory-accesses
 // RUN: %t pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-1
 // RUN: %t pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-2
 // RUN: %t fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,CHECK-FAIL-1

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -312,7 +312,7 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // assignment through pointer
   *t1 = 1;            // expected-error {{expression has no bounds}}
-  *t2 = 2;            // TODO: warn this will always fail.
+  *t2 = 2;            // expected-warning {{out-of-bounds memory access}}
   *t3 = 3;
 
   // read through a pointer
@@ -322,7 +322,7 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // assignment via subcript
   t1[0] = 1;          // expected-error {{expression has no bounds}}
-  t2[0] = 3;          // TODO: warn this will always fail
+  t2[0] = 3;          // expected-warning {{out-of-bounds memory access}}
   t3[0] = 4;
 
   // read via subscript
@@ -333,19 +333,19 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // pre-increment/post-increment
   ++(*t1);            // expected-error {{expression has no bounds}}
-  ++(*t2);            // TODO: warn this will always fail.
+  ++(*t2);            // expected-warning {{out-of-bounds memory access}}
   ++(*t3);
 
   --(*t1);            // expected-error {{expression has no bounds}}
-  --(*t2);            // TODO: warn this will always fail.
+  --(*t2);            // expected-warning {{out-of-bounds memory access}}
   --(*t3);
 
   (*t1)++;            // expected-error {{expression has no bounds}}
-  (*t2)++;            // TODO: warn this will always fail.
+  (*t2)++;            // expected-warning {{out-of-bounds memory access}}
   (*t3)++;
 
   --(*t1);            // expected-error {{expression has no bounds}}
-  --(*t2);            // TODO: warn this will always fail.
+  --(*t2);            // expected-warning {{out-of-bounds memory access}}
   --(*t3);
 
   // operations involving struct members


### PR DESCRIPTION
Update dynamic tests of runtime bounds checking to suppress these warnings.  We don't expect to see warnings for these tests and turn warnings into errors.

For bounds declaration checking, turn TODO's for expected warnings into pattern matches for the expected warnings.
