### PR TITLE
Make Fortify-source definitions more fine-grained

### DIFF
--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -50,7 +50,10 @@ int setvbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 // * Any pointer arguments may not meet the requirements of the
 //  format string.
 //
-#if _FORTIFY_SOURCE == 0
+
+
+#if _FORTIFY_SOURCE == 0 || !defined(fprintf)
+#undef fprintf
 _Unchecked
 int fprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
             const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
@@ -60,7 +63,7 @@ _Unchecked
 int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
            const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 
-#if _FORTIFY_SOURCE == 0
+#if _FORTIFY_SOURCE == 0 || !defined(printf)
 _Unchecked
 int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 #endif
@@ -68,7 +71,8 @@ int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const cha
 _Unchecked
 int scanf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 
-#if _FORTIFY_SOURCE == 0
+#if _FORTIFY_SOURCE == 0 || !defined(sprintf)
+#undef sprintf
 // The output buffer parameter s is an unchecked pointer because no bounds are provided.
 _Unchecked
 int sprintf(char * restrict s,
@@ -79,11 +83,15 @@ _Unchecked
 int sscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
            const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 
-#if _FORTIFY_SOURCE == 0
+#if _FORTIFY_SOURCE == 0 || !defined(snprintf)
+#undef snprintf
 _Unchecked
 int snprintf(char * restrict s : count(n), size_t n,
              const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(vfprintf)
+#undef vfprintf
 _Unchecked
 int vfprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
              const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
@@ -95,7 +103,8 @@ int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
             const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
             va_list arg);
 
-#if _FORTIFY_SOURCE == 0
+#if _FORTIFY_SOURCE == 0 || !defined(vprintf)
+#undef vprintf
 _Unchecked
 int vprintf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
              va_list arg);
@@ -105,12 +114,16 @@ _Unchecked
 int vscanf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
             va_list arg);
 
-#if _FORTIFY_SOURCE == 0
+#if _FORTIFY_SOURCE == 0 || !defined(vsnprintf)
+#undef vsnprintf
 _Unchecked
 int vsnprintf(char * restrict s : count(n), size_t n,
               const char * restrict format,
               va_list arg);
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(vsprintf)
+#undef vsprintf
 // The output buffer parameter has an unchecked pointer type becuse it is missing bounds.
 _Unchecked
 int vsprintf(char * restrict s,

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -51,6 +51,14 @@ int setvbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
 //  format string.
 //
 
+// We wrap each definition in a complex conditional, there two boolean values:
+// - we are fortifying, or we're not (_FORTIFY_SOURCE==0 is not fortifying)
+// - there is or there isn't a macro hash-defining this symbol (defined(symbol))
+// Cases:
+// - Fortifying,     Macro Exists: this is expected, we don't need the definition
+// - Not Fortifying, Macro Exists: we need the definition, we need to undef macro
+// - Fortifying,     No Macro:     we need the definition
+// - Not Fortifying, No Macro:     we need the definition
 
 #if _FORTIFY_SOURCE == 0 || !defined(fprintf)
 #undef fprintf
@@ -64,6 +72,7 @@ int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
            const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 
 #if _FORTIFY_SOURCE == 0 || !defined(printf)
+#undef printf
 _Unchecked
 int printf(const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 #endif

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -35,36 +35,54 @@
 #undef strspn
 #endif
 
-#if _FORTIFY_SOURCE == 0
+#if _FORTIFY_SOURCE == 0 || !defined(memcpy)
+#undef memcpy
 void *memcpy(void * restrict dest : byte_count(n),
              const void * restrict src : byte_count(n),
              size_t n) : bounds(dest, (_Array_ptr<char>) dest + n);
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(memmove)
+#undef memmove
 void *memmove(void * restrict dest : byte_count(n),
               const void * restrict src : byte_count(n),
               size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(memset)
+#undef memset
 void *memset(void * dest : byte_count(n),
              int c,
              size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(strcpy)
+#undef strcpy
 // Dest is left unchecked intentionally. There is no bound on dest, so this
 // is always an unchecked function
 _Unchecked
 char *strcpy(char * restrict dest,
               const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+#endif
 
-
+#if _FORTIFY_SOURCE == 0 || !defined(strncpy)
+#undef strncpy
 char *strncpy(char * restrict dest : count(n),
               const char * restrict src : count(n),
               size_t n) : bounds(dest, (_Array_ptr<char>)dest + n);
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(strcat)
+#undef strcat
 // Dest is left unchecked intentionally. There is no bound on dest, so this
 // is always an unchecked function.
 _Unchecked
 char *strcat(char * restrict dest,
              const char * restrict src : itype(restrict _Nt_array_ptr<const char>));
+#endif
 
+#if _FORTIFY_SOURCE == 0 || !defined(strncat)
+#undef strncat
 // TODO: we have no way to express the bounds requirement on dest,
 // which needs to be count(strlen(dest) + n).
 _Unchecked

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -35,6 +35,15 @@
 #undef strspn
 #endif
 
+// We wrap each definition in a complex conditional, there two boolean values:
+// - we are fortifying, or we're not (_FORTIFY_SOURCE==0 is not fortifying)
+// - there is or there isn't a macro hash-defining this symbol (defined(symbol))
+// Cases:
+// - Fortifying,     Macro Exists: this is expected, we don't need the definition
+// - Not Fortifying, Macro Exists: we need the definition, we need to undef macro
+// - Fortifying,     No Macro:     we need the definition
+// - Not Fortifying, No Macro:     we need the definition
+
 #if _FORTIFY_SOURCE == 0 || !defined(memcpy)
 #undef memcpy
 void *memcpy(void * restrict dest : byte_count(n),


### PR DESCRIPTION
This is an annoying change, but sometimes, despite having `_FORTIFY_SOURCE` set to non-zero, the stdlib won't always give a definition for that a symbol that should be fortified (looking at you, Mac OS X 10.13 and unprotected `fprintf`)

This check introduces per-function guards. They define the normal kind of the function if:
- fortify_source == 0; or
- there is no macro for the function.
If fortify_source is zero (ie, we're not using the fortified versions), and the macro is defined, then we need to undefine it, as it's constant folding definition or similar, and we can fall back on the original definition.

Damnit I wish that system headers were more cooperative.

This will need checking on linux please @awruef 

Testing:
- Passes on Mac OS X 10.13.