### PR TITLE
Warnings about unprovable bounds declarations in checked scopes.

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -573,13 +573,14 @@ extern void check_nullterm_call_bsi(int *arg1 : itype(nt_array_ptr<int>),
     arg2 = *arg7;
     arg2 = *arg8;
 
-    arg1 = arg3;
-    *arg7 = arg3;
-    *arg8 = arg3;
+    // TODO: bounds declaration checking needs to understand equality after assignment
+    arg1 = arg3;                 // expected-warning {{cannot prove declared bounds for arg1 are valid after assignment}}
+    *arg7 = arg3;                // expected-warning {{cannot prove declared bounds for *arg7 are valid after assignment}}
+    *arg8 = arg3;                // expected-warning {{cannot prove declared bounds for *arg8 are valid after assignment}}
 
-    arg3 = arg1;
-    arg3 = *arg7;
-    arg3 = *arg8;
+    arg3 = arg1;                 // expected-warning {{cannot prove declared bounds for arg3 are valid after assignment}}
+    arg3 = *arg7;                // expected-warning {{cannot prove declared bounds for arg3 are valid after assignment}}
+    arg3 = *arg8;                // expected-warning {{cannot prove declared bounds for arg3 are valid after assignment}}
 
     arg4 = *arg7;               // expected-error {{declared bounds for arg4 are invalid after assignment}}
   }

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -77,15 +77,17 @@ void f4(void) checked {
   int t20 = g20[0];
   int t21 = g21[3];
   int t22 = g22[2][2];
-  nt_array_ptr<char> t23 = g23[0];
+  // TODO: bounds declaration checking needs to understand equality after assignment
+  nt_array_ptr<char> t23 = g23[0]; // expected-warning {{cannot prove declared bounds for 't23' are valid after initialization}}
   int t30 = g30[1];
   int t31 = *g31;
   char t32 = g32[5];
   char t33 = g33[4];
   char t34 = g34[4];
   char t35 = g35[1];
-  nt_array_ptr<char> t36 = g36[1][0];
-  nt_array_ptr<char> t37 = g37[1];
+  // TODO: bounds declaration checking needs to understand equality after assignment
+  nt_array_ptr<char> t36 = g36[1][0];  // expected-warning {{cannot prove declared bounds for 't36' are valid after initialization}}
+  nt_array_ptr<char> t37 = g37[1];     // expected-warning {{cannot prove declared bounds for 't37' are valid after initialization}}
 
 
   f3("abc");   // expected-error {{passing 'char _Nt_checked[4]' to parameter of incompatible type 'char *'}}

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -54,7 +54,10 @@ extern void f3() {
   q = _Dynamic_bounds_cast<ptr<int>>(r) + 3; // expected-error{{arithmetic on _Ptr type}}
 
   *(_Assume_bounds_cast<ptr<int>>(r) + 2) = 4; // expected-error{{arithmetic on _Ptr type}}
-  *(_Dynamic_bounds_cast<array_ptr<int>>(r, 1) + 2) = 4; // expected-error {{expression has no bounds}}
+  // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
+  // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
+  *(_Dynamic_bounds_cast<array_ptr<int>>(r, 1) + 2) = 4; // expected-error {{expression has no bounds}} \
+                                                         // expected-warning {{out-of-bounds memory access}}
   s = _Dynamic_bounds_cast<array_ptr<int>>(p, 5); // expected-error {{expression has no bounds}}
   s = _Assume_bounds_cast<array_ptr<int>>(r, 5); 
 }

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1633,12 +1633,12 @@ void check_cast_operator(void) {
 
   // ptr to array
   parr = (ptr<int checked[5]>) &arr;
-  parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr); // expected-error {{cast source bounds are too narrow for '_Ptr<int _Checked[5]>'}}
+  parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr);
 
   parr = (ptr<int checked[3]>) &arr; // expected-error {{incompatible type}}
 
   nt_parr = (ptr<int nt_checked[5]>) &arr;
-  nt_parr = (ptr<int nt_checked[5]>) ((ptr<int checked[]>) &arr); //expected-error {{cast source bounds are too narrow for '_Ptr<int _Nt_checked[5]>'}}
+  nt_parr = (ptr<int nt_checked[5]>) ((ptr<int checked[]>) &arr);
   nt_parr = (ptr<int nt_checked[3]>) &arr; // expected-error {{incompatible type}}
 
   // array_ptr to array

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -831,16 +831,18 @@ checked int func60(ptr<struct s0> st0, ptr<struct s1> st1) {
 void test_addrof_checked_scope(void) checked {
   int a checked[10];
   array_ptr<int> b;
-  int i;
+  int i = 0;
 
   // In checked scope, address-of operator produces _Array_ptr<T>
   // VisitBinaryOperator - check if LHS has bounds and RHS has bounds
-  ptr<int> x = &a[i]; // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)
+  ptr<int> x = &a[i]; // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int>'}} \
+                         ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)
   ptr<int> y = &b[0]; // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>) \
                       // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
   ptr<int> z = &i;    // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)
 
-  x = &a[i];  // ImplicitCastExpr _Ptr (UnaryOperator _Array_ptr<int>)
+  x = &a[i];  // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int>'}} \
+              // ImplicitCastExpr _Ptr (UnaryOperator _Array_ptr<int>)
   y = &b[1];  // ImplicitCastExpr _Ptr (UnaryOperator _Array_ptr<int>) \
               // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
   z = &i;     // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -1490,7 +1490,8 @@ checked void check_cast_operator(void) {
 
   // ptr to array, ptr to unchecked array
   parr = (ptr<int checked[5]>) &arr;
-  parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr); // expected-error {{cast source bounds are too narrow for '_Ptr<int _Checked[5]>'}}
+  parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr); // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int _Checked[5]>'}} \
+                                                            // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int _Checked[]>'}}
   parr = (ptr<int [5]>) &arr;   // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
   parr = (ptr<int *>) &arr;     // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
 

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -29,7 +29,8 @@ checked int f1(int *s : itype(ptr<int>)) {
   *(s+ 4) = 0;        // expected-error {{arithmetic on _Ptr type}}
   s[4] = 0;           // expected-error {{subscript of '_Ptr<int>'}}
 
-  array_ptr<int> t4 : count(1) = s;
+  // TODO: bounds declaration checking needs to understand equality after assignment
+  array_ptr<int> t4 : count(1) = s;  // expected-warning {{cannot prove declared bounds for 't4' are valid after initialization}}
   s = t4;
 
   array_ptr<float> t5 : count(1) = s; // expected-error {{incompatible type}}
@@ -112,7 +113,8 @@ checked void test_globals(void) {
   *(g1 + 4) = 0;       // expected-error {{arithmetic on _Ptr type}}
   g1[4] = 0;           // expected-error {{subscript of '_Ptr<int>'}}
 
-  array_ptr<int> t4 : count(1) = g1;
+  // TODO: bounds declaration checking needs to understand equality after assignment
+  array_ptr<int> t4 : count(1) = g1;  // expected-warning {{cannot prove declared bounds for 't4' are valid after initialization}}
   g1 = t4;
 
   array_ptr<float> t5 : count(1) = g1; // expected-error {{incompatible type}}
@@ -372,7 +374,8 @@ checked int f50(int **s : itype(ptr<ptr<int>>)) {
   *s += 5;            // expected-error {{arithmetic on _Ptr type}}
   s = s + 5;          // expected-error {{arithmetic on _Ptr type}}
 
-  array_ptr<int> t5 : count(1) = *s;
+  // TODO: bounds declaration checking needs to understand equality after assignment
+  array_ptr<int> t5 : count(1) = *s; // expected-warning {{cannot prove declared bounds for 't5' are valid after initialization}}
   *s = t5;
 
   array_ptr<float> t6 : count(1) = *s; // expected-error {{incompatible type}}


### PR DESCRIPTION
The compiler now always warns when it cannot prove a bounds
declaration true or false in a checked scope.   This adds warnings to tests
where this is the case.  Most of these warnings will disappear when we extend
bounds declaration checking to include facts about equality of
variables/expressions after assignments.

The compiler also understands equivalence of base expressions for
constant-sized regions better.  This lets the compiler deduce that
`*(_Dynamic_bounds_cast<array_ptr<int>>(r, 1) + 2) = 4` will always
fault at runtime.
