### PR TITLE
Update error messages to use the term "unknown bounds".

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -24,7 +24,7 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   // constants
   array_ptr<int> orig_arg4 : count(1) = arg4;
   arg4 = 0;
-  arg4 = (int *)0xabcd;  // expected-error {{expression has no bounds}}
+  arg4 = (int *)0xabcd;  // expected-error {{expression has unknown bounds}}
   arg4 = orig_arg4;
 
   // TODO: compound literals, assignments of variables with array types
@@ -34,7 +34,7 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   int tmp1 = 0;
   arg4 = &tmp1;
   arg4 = &*arg4;
-  arg4 = &*arg1;          // expected-error {{expression has no bounds}}
+  arg4 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg4 = &s.f;
   ptr<struct S1> ps = &s;
   arg4 = &(ps->f);
@@ -44,9 +44,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
 
   // globals assigned from a global
   g1 = g1;
-  g2 = g1;            // expected-error {{expression has no bounds}}
+  g2 = g1;            // expected-error {{expression has unknown bounds}}
   g3 = g1;
-  g4 = g1;            // expected-error {{expression has no bounds}}
+  g4 = g1;            // expected-error {{expression has unknown bounds}}
 
   g1 = g2;            // expected-error {{incompatible type}}
   g2 = g2;
@@ -54,20 +54,20 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   g4 = g2;
 
   g1 = g3;            // expected-error {{incompatible type}}
-  g2 = g3;            // expected-error {{expression has no bounds}}
+  g2 = g3;            // expected-error {{expression has unknown bounds}}
   g3 = g3;
-  g4 = g3;            // expected-error {{expression has no bounds}}
+  g4 = g3;            // expected-error {{expression has unknown bounds}}
 
-  g4 = g1;            // expected-error {{expression has no bounds}}
+  g4 = g1;            // expected-error {{expression has unknown bounds}}
   g4 = g2;
-  g4 = g3;            // expected-error {{expression has no bounds}}
+  g4 = g3;            // expected-error {{expression has unknown bounds}}
   g4 = g4;
 
   // parameters assigned from a global
   arg1 = g1;
-  arg2 = g1;            // expected-error {{expression has no bounds}}
+  arg2 = g1;            // expected-error {{expression has unknown bounds}}
   arg3 = g1;
-  arg4 = g1;            // expected-error {{expression has no bounds}}
+  arg4 = g1;            // expected-error {{expression has unknown bounds}}
 
   arg1 = g2;            // expected-error {{incompatible type}}
   arg2 = g2;
@@ -75,9 +75,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   arg4 = g4;
 
   arg1 = g3;            // expected-error {{incompatible type}}
-  arg2 = g3;            // expected-error {{expression has no bounds}}
+  arg2 = g3;            // expected-error {{expression has unknown bounds}}
   arg3 = g3;
-  arg4 = g3;            // expected-error {{expression has no bounds}}
+  arg4 = g3;            // expected-error {{expression has unknown bounds}}
 
   arg1 = g4;            // expected-error {{incompatible type}}
   arg2 = g4;
@@ -86,9 +86,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
 
   // globals assigned from parameters
   g1 = arg1;
-  g2 = arg1;            // expected-error {{expression has no bounds}}
+  g2 = arg1;            // expected-error {{expression has unknown bounds}}
   g3 = arg1;
-  g4 = arg1;            // expected-error {{expression has no bounds}}
+  g4 = arg1;            // expected-error {{expression has unknown bounds}}
 
   g1 = arg2;            // expected-error {{incompatible type}}
   g2 = arg2;
@@ -96,9 +96,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   g4 = arg2;
 
   g1 = arg3;            // expected-error {{incompatible type}}
-  g2 = arg3;            // expected-error {{expression has no bounds}}
+  g2 = arg3;            // expected-error {{expression has unknown bounds}}
   g3 = arg3;
-  g4 = arg3;            // expected-error {{expression has no bounds}}
+  g4 = arg3;            // expected-error {{expression has unknown bounds}}
 
   g1 = arg4;            // expected-error {{incompatible type}}
   g2 = arg4;
@@ -112,9 +112,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   array_ptr<int> t4 : count(1) = &tmp1;
 
   t1 = arg1;
-  t2 = arg1;            // expected-error {{expression has no bounds}}
+  t2 = arg1;            // expected-error {{expression has unknown bounds}}
   t3 = arg1;
-  t4 = arg1;            // expected-error {{expression has no bounds}}
+  t4 = arg1;            // expected-error {{expression has unknown bounds}}
 
   t1 = arg2;            // expected-error {{incompatible type}}
   t2 = arg2;
@@ -122,9 +122,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   t4 = arg4;
 
   t1 = arg3;            // expected-error {{incompatible type}}
-  t2 = arg3;            // expected-error {{expression has no bounds}}
+  t2 = arg3;            // expected-error {{expression has unknown bounds}}
   t3 = arg3;
-  t4 = arg3;            // expected-error {{expression has no bounds}}
+  t4 = arg3;            // expected-error {{expression has unknown bounds}}
 
   t1 = arg4;            // expected-error {{incompatible type}}
   t2 = arg4;
@@ -133,15 +133,15 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
 
   // spot-check locals assigned from globals
   t1 = g4;            // expected-error {{incompatible type}}
-  t2 = g3;            // expected-error {{expression has no bounds}}
+  t2 = g3;            // expected-error {{expression has unknown bounds}}
   t3 = g2;
-  t4 = g1;            // expected-error {{expression has no bounds}}
+  t4 = g1;            // expected-error {{expression has unknown bounds}}
 
   // spot-check globals assigned from locals
   g1 = t2;            // expected-error {{incompatible type}}
-  g2 = t3;            // expected-error {{expression has no bounds}}
+  g2 = t3;            // expected-error {{expression has unknown bounds}}
   g3 = t4;
-  g4 = t1;            // expected-error {{expression has no bounds}}
+  g4 = t1;            // expected-error {{expression has unknown bounds}}
 
   // expressions
 
@@ -149,50 +149,50 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   array_ptr<int> t5 : count(1) = 0;
   t5 = (arg4 = t4);
   t5 = (t4 = arg4);
-  t5 = (t4 = t3);     // expected-error 2 {{expression has no bounds}}
+  t5 = (t4 = t3);     // expected-error 2 {{expression has unknown bounds}}
 
   // assignment through pointer
   *t1 = 1;
   *t2 = 2;
-  *t3 = 3;            // expected-error {{expression has no bounds}}
+  *t3 = 3;            // expected-error {{expression has unknown bounds}}
   *t4 = 4;
 
   // read through a pointer
   int t6 = *t1;
   t6 = *t2;
-  t6 = *t3;           // expected-error {{expression has no bounds}}
+  t6 = *t3;           // expected-error {{expression has unknown bounds}}
   t6 = *t4;
 
   // assignment via subcript
   t1[0] = 1;
-  t3[0] = 3;          // expected-error {{expression has no bounds}}
+  t3[0] = 3;          // expected-error {{expression has unknown bounds}}
   t4[0] = 4;
 
   // read via subscript
 
   int t7 = t1[0];
-  t7 = t3[0];         // expected-error {{expression has no bounds}}
+  t7 = t3[0];         // expected-error {{expression has unknown bounds}}
   t7 = t4[0];
 
   // pre-increment/post-increment
   ++(*t1);
   ++(*t2);
-  ++(*t3);            // expected-error {{expression has no bounds}}
+  ++(*t3);            // expected-error {{expression has unknown bounds}}
   ++(*t4);
 
   --(*t1);
   --(*t2);
-  --(*t3);            // expected-error {{expression has no bounds}}
+  --(*t3);            // expected-error {{expression has unknown bounds}}
   --(*t4);
 
   (*t1)++;
   (*t2)++;
-  (*t3)++;            // expected-error {{expression has no bounds}}
+  (*t3)++;            // expected-error {{expression has unknown bounds}}
   (*t4)++;
 
   --(*t1);
   --(*t2);
-  --(*t3);            // expected-error {{expression has no bounds}}
+  --(*t3);            // expected-error {{expression has unknown bounds}}
   --(*t4);
 }
 
@@ -216,8 +216,8 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   arg2 = 0;
   arg3 = 0;
   arg1 = (nt_array_ptr<int>)0xabcd;
-  arg2 = (nt_array_ptr<int>)0xabcd;  // expected-error {{expression has no bounds}}
-  arg3 = (nt_array_ptr<int>)0xabcd;  // expected-error {{expression has no bounds}}
+  arg2 = (nt_array_ptr<int>)0xabcd;  // expected-error {{expression has unknown bounds}}
+  arg3 = (nt_array_ptr<int>)0xabcd;  // expected-error {{expression has unknown bounds}}
 
   // address-of
   arg1 = &*arg1;
@@ -225,10 +225,10 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   arg1 = &*arg3;
   arg1 = &*arr;           // TODO: investigate why this isn't a typechecking error.
   arg1 = &arr[1];         // expected-error {{incompatible type}}
-  arg2 = &*arg1;          // expected-error {{expression has no bounds}}
+  arg2 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg2 = &*arg2;
   arg2 = &*arg3;
-  arg3 = &*arg1;          // expected-error {{expression has no bounds}}
+  arg3 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg3 = &*arg2;          // expected-error {{declared bounds for arg3 are invalid after assignment}}
   arg3 = &*arg3;
 
@@ -236,8 +236,8 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // globals assigned from a global
   g11 = g11;
-  g12 = g11;           // expected-error {{expression has no bounds}}
-  g13 = g11;           // expected-error {{expression has no bounds}}
+  g12 = g11;           // expected-error {{expression has unknown bounds}}
+  g13 = g11;           // expected-error {{expression has unknown bounds}}
 
   g11 = g12;
   g12 = g12;
@@ -249,8 +249,8 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // parameters assigned from a global
   arg1 = g11;
-  arg2 = g11;           // expected-error {{expression has no bounds}}
-  arg3 = g11;           // expected-error {{expression has no bounds}}
+  arg2 = g11;           // expected-error {{expression has unknown bounds}}
+  arg3 = g11;           // expected-error {{expression has unknown bounds}}
 
   arg1 = g12;
   arg2 = g12;
@@ -263,8 +263,8 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // globals assigned from parameters
   g11 = arg1;
-  g12 = arg1;           // expected-error {{expression has no bounds}}
-  g13 = arg1;           // expected-error {{expression has no bounds}}
+  g12 = arg1;           // expected-error {{expression has unknown bounds}}
+  g13 = arg1;           // expected-error {{expression has unknown bounds}}
 
   g11 = arg2;
   g12 = arg2;
@@ -280,8 +280,8 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   nt_array_ptr<int> t3 : count(1) = 0;
 
   t1 = arg1;
-  t2 = arg1;            // expected-error {{expression has no bounds}}
-  t3 = arg1;            // expected-error {{expression has no bounds}}
+  t2 = arg1;            // expected-error {{expression has unknown bounds}}
+  t3 = arg1;            // expected-error {{expression has unknown bounds}}
 
   t1 = arg2;
   t2 = arg2;
@@ -294,12 +294,12 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   // spot-check locals assigned from globals
   t1 = g13;
   t2 = g12;
-  t3 = g11;            // expected-error {{expression has no bounds}}
+  t3 = g11;            // expected-error {{expression has unknown bounds}}
 
   // spot-check globals assigned from locals
   g11 = t2;
   g12 = t3;
-  g13 = t1;            // expected-error {{expression has no bounds}}
+  g13 = t1;            // expected-error {{expression has unknown bounds}}
 
   // expressions
 
@@ -308,43 +308,43 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   t4 = (arg3 = t3);
   t4 = (t3 = arg3);
   t4 = (t2 = arg3);
-  t4 = (t2 = t1);     // expected-error 2 {{expression has no bounds}}
+  t4 = (t2 = t1);     // expected-error 2 {{expression has unknown bounds}}
 
   // assignment through pointer
-  *t1 = 1;            // expected-error {{expression has no bounds}}
+  *t1 = 1;            // expected-error {{expression has unknown bounds}}
   *t2 = 2;            // expected-warning {{out-of-bounds memory access}}
   *t3 = 3;
 
   // read through a pointer
-  int t6 = *t1;       // expected-error {{expression has no bounds}}
+  int t6 = *t1;       // expected-error {{expression has unknown bounds}}
   t6 = *t2;
   t6 = *t3;
 
   // assignment via subcript
-  t1[0] = 1;          // expected-error {{expression has no bounds}}
+  t1[0] = 1;          // expected-error {{expression has unknown bounds}}
   t2[0] = 3;          // expected-warning {{out-of-bounds memory access}}
   t3[0] = 4;
 
   // read via subscript
 
-  int t7 = t1[0];     // expected-error {{expression has no bounds}}
+  int t7 = t1[0];     // expected-error {{expression has unknown bounds}}
   t7 = t2[0];
   t7 = t3[0];
 
   // pre-increment/post-increment
-  ++(*t1);            // expected-error {{expression has no bounds}}
+  ++(*t1);            // expected-error {{expression has unknown bounds}}
   ++(*t2);            // expected-warning {{out-of-bounds memory access}}
   ++(*t3);
 
-  --(*t1);            // expected-error {{expression has no bounds}}
+  --(*t1);            // expected-error {{expression has unknown bounds}}
   --(*t2);            // expected-warning {{out-of-bounds memory access}}
   --(*t3);
 
-  (*t1)++;            // expected-error {{expression has no bounds}}
+  (*t1)++;            // expected-error {{expression has unknown bounds}}
   (*t2)++;            // expected-warning {{out-of-bounds memory access}}
   (*t3)++;
 
-  --(*t1);            // expected-error {{expression has no bounds}}
+  --(*t1);            // expected-error {{expression has unknown bounds}}
   --(*t2);            // expected-warning {{out-of-bounds memory access}}
   --(*t3);
 
@@ -354,11 +354,11 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   s.f1 = t2;
   s.f1 = t3;
 
-  s.f2 = t1;          // expected-error {{expression has no bounds}}
+  s.f2 = t1;          // expected-error {{expression has unknown bounds}}
   s.f2 = t2;
   s.f2 = t3;
 
-  s.f3 = t1;          // expected-error {{expression has no bounds}}
+  s.f3 = t1;          // expected-error {{expression has unknown bounds}}
   s.f3 = t2;          // expected-error {{declared bounds for s.f3 are invalid after assignment}}
   s.f3 = t3;
 
@@ -366,17 +366,17 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   t1 = s.f2;
   t1 = s.f3;
 
-  t2 = s.f1;          // expected-error {{expression has no bounds}}
+  t2 = s.f1;          // expected-error {{expression has unknown bounds}}
   t2 = s.f2;
   t2 = s.f3;
 
-  t3 = s.f1;          // expected-error {{expression has no bounds}}
+  t3 = s.f1;          // expected-error {{expression has unknown bounds}}
   t3 = s.f2;          // expected-error {{declared bounds for t3 are invalid after assignment}}
   t3 = s.f3;
 
   nt_array_ptr<int> ntp = (int nt_checked[]) { 0, 1, 2, 3, 0 };
   ptr<nt_array_ptr<int>> pntp = &ntp;
-  *pntp = arg1;       // expected-error {{expression has no bounds}}
+  *pntp = arg1;       // expected-error {{expression has unknown bounds}}
   *pntp = arg2;
   *pntp = arg3;
   arg1 = *pntp;
@@ -394,10 +394,10 @@ extern void check_call_args(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
                             array_ptr<int> arg4 : count(1), 
                             array_ptr<int> arg5 : count(arglen), int arglen) {
   test_f1(arg1);
-  test_f2(arg1);     // expected-error {{expression has no bounds}}
+  test_f2(arg1);     // expected-error {{expression has unknown bounds}}
   test_f3(arg1);
-  test_f4(arg1);     // expected-error {{argument has no bounds}}
-  test_f5(arg1, 1);  // expected-error {{argument has no bounds}}
+  test_f4(arg1);     // expected-error {{argument has unknown bounds}}
+  test_f5(arg1, 1);  // expected-error {{argument has unknown bounds}}
 
   test_f1(arg2);     // expected-error {{incompatible type}}
   test_f2(arg2);
@@ -406,10 +406,10 @@ extern void check_call_args(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   test_f5(arg2, 1);
 
   test_f1(arg3);     // expected-error {{incompatible type}}
-  test_f2(arg3);     // expected-error {{expression has no bounds}}
+  test_f2(arg3);     // expected-error {{expression has unknown bounds}}
   test_f3(arg3);
-  test_f4(arg3);     // expected-error {{argument has no bounds}}
-  test_f5(arg3, 1);  // expected-error {{argument has no bounds}}
+  test_f4(arg3);     // expected-error {{argument has unknown bounds}}
+  test_f5(arg3, 1);  // expected-error {{argument has unknown bounds}}
   
   test_f1(arg4);     // expected-error {{incompatible type}}
   test_f2(arg4);
@@ -440,9 +440,9 @@ extern void check_nullterm_call_args(
   nt_array_ptr<char> arg3 : count(1),
   nt_array_ptr<char> arg4 : count(arglen), int arglen) {
   test_nullterm_f1(arg1);
-  test_nullterm_f2(arg1);     // expected-error {{argument has no bounds}}
-  test_nullterm_f3(arg1);     // expected-error {{argument has no bounds}}
-  test_nullterm_f4(arg1, 1);  // expected-error {{argument has no bounds}}
+  test_nullterm_f2(arg1);     // expected-error {{argument has unknown bounds}}
+  test_nullterm_f3(arg1);     // expected-error {{argument has unknown bounds}}
+  test_nullterm_f4(arg1, 1);  // expected-error {{argument has unknown bounds}}
 
   test_nullterm_f1(arg2);
   test_nullterm_f2(arg2);
@@ -495,10 +495,10 @@ extern void check_call_bsi(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   test_bsi_f5(arg2, 1);
 
   test_bsi_f1(arg3);     // expected-error {{incompatible type}}
-  test_bsi_f2(arg3);     // expected-error {{argument has no bounds}}                    
+  test_bsi_f2(arg3);     // expected-error {{argument has unknown bounds}}                    
   test_bsi_f3(arg3);     
-  test_bsi_f4(arg3);     // expected-error {{argument has no bounds}}
-  test_bsi_f5(arg3, 1);  // expected-error {{argument has no bounds}}
+  test_bsi_f4(arg3);     // expected-error {{argument has unknown bounds}}
+  test_bsi_f5(arg3, 1);  // expected-error {{argument has unknown bounds}}
 
   test_bsi_f1(arg4);     // expected-error {{incompatible type}}
   test_bsi_f2(arg4);
@@ -547,7 +547,7 @@ extern void check_nullterm_call_bsi(int *arg1 : itype(nt_array_ptr<int>),
   test_nullterm_bsi_f2(arg1);
 
   test_nullterm_bsi_f1(arg2);    // expected-error {{incompatible type}}
-  test_nullterm_bsi_f2(arg2);    // expected-error {{argument has no bounds}}
+  test_nullterm_bsi_f2(arg2);    // expected-error {{argument has unknown bounds}}
 
   test_nullterm_bsi_f1(arg3);    // expected-error {{incompatible type}}
   test_nullterm_bsi_f2(arg3);
@@ -565,9 +565,9 @@ extern void check_nullterm_call_bsi(int *arg1 : itype(nt_array_ptr<int>),
   _Checked{
     test_nullterm_bsi_f3(arg6);  // expected-error {{parameter used in a checked scope must have a checked type or a bounds-safe interface}}
     test_nullterm_bsi_f4(test_nullterm_cmp);
-    arg1 = arg2;                 // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
-    *arg7 = arg2;                // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
-    *arg8 = arg2;                // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
+    arg1 = arg2;                 // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds}}
+    *arg7 = arg2;                // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds}}
+    *arg8 = arg2;                // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds}}
 
     arg2 = arg1;
     arg2 = *arg7;
@@ -591,7 +591,7 @@ nt_array_ptr<char> nullterm_return2(void) : bounds(unknown);
 
 void check_nullterm_return_use(void) {
   nt_array_ptr<char> p = nullterm_return1();
-  p = nullterm_return2(); // expected-error {{expression has no bounds, right-hand side of assignment expected to have bounds}}
+  p = nullterm_return2(); // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds}}
 }
 
 // TODO: Github issue #401.  We need to check that return expressions have bounds when expected.

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -13,15 +13,15 @@ extern void f1() {
 
   int *p = 0;
   array_ptr<int> checkedc_p : bounds(checkedc_p, checkedc_p + 1) = 0;
-  c = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
-  c = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
+  c = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has unknown bounds}}
+  c = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has unknown bounds}}
   a = _Assume_bounds_cast<array_ptr<int>>(p, 4);
   checkedc_p = _Assume_bounds_cast<array_ptr<int>>(p, p, p + 1);
-  checkedc_p = _Dynamic_bounds_cast<array_ptr<int>>(p, p, p + 1); // expected-error {{expression has no bounds}}
+  checkedc_p = _Dynamic_bounds_cast<array_ptr<int>>(p, p, p + 1); // expected-error {{expression has unknown bounds}}
   a = _Assume_bounds_cast<array_ptr<int>>(p, 1);
   a = _Assume_bounds_cast<array_ptr<int>>(p, p, p + 1);
   array_ptr<int> d = _Assume_bounds_cast<array_ptr<int>>(p, 4); 
-  c = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
+  c = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has unknown bounds}}
 }
 
 struct S1 {
@@ -38,7 +38,7 @@ struct S1 {
 extern void f2() {
   array_ptr<int> a : count(2) = 0;
   struct S1 *p = 0;
-  a = _Dynamic_bounds_cast<array_ptr<int>>(p, 2); // expected-error {{expression has no bounds}}
+  a = _Dynamic_bounds_cast<array_ptr<int>>(p, 2); // expected-error {{expression has unknown bounds}}
 }
 
 extern void f3() {
@@ -47,23 +47,23 @@ extern void f3() {
   array_ptr<int> r = 0;
   array_ptr<int> s : bounds(r, r + 5) = 0;
   p = _Assume_bounds_cast<int *>(r);
-  p = _Dynamic_bounds_cast<int *>(r); // expected-error {{expression has no bounds}}  
+  p = _Dynamic_bounds_cast<int *>(r); // expected-error {{expression has unknown bounds}}  
   q = _Assume_bounds_cast<ptr<int>>(p);
-  q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
-  q = _Dynamic_bounds_cast<ptr<int>>(r); // expected-error {{expression has no bounds}}
+  q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has unknown bounds}}
+  q = _Dynamic_bounds_cast<ptr<int>>(r); // expected-error {{expression has unknown bounds}}
   q = _Dynamic_bounds_cast<ptr<int>>(r) + 3; // expected-error{{arithmetic on _Ptr type}}
 
   *(_Assume_bounds_cast<ptr<int>>(r) + 2) = 4; // expected-error{{arithmetic on _Ptr type}}
   // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
-  *(_Dynamic_bounds_cast<array_ptr<int>>(r, 1) + 2) = 4; // expected-error {{expression has no bounds}} \
+  *(_Dynamic_bounds_cast<array_ptr<int>>(r, 1) + 2) = 4; // expected-error {{expression has unknown bounds}} \
                                                          // expected-warning {{out-of-bounds memory access}}
-  s = _Dynamic_bounds_cast<array_ptr<int>>(p, 5); // expected-error {{expression has no bounds}}
+  s = _Dynamic_bounds_cast<array_ptr<int>>(p, 5); // expected-error {{expression has unknown bounds}}
   s = _Assume_bounds_cast<array_ptr<int>>(r, 5); 
 }
 
 extern ptr<int> f4(int arr checked[]) {
-  return _Dynamic_bounds_cast<ptr<int>>(arr); // expected-error{{expression has no bounds}}
+  return _Dynamic_bounds_cast<ptr<int>>(arr); // expected-error{{expression has unknown bounds}}
 }
 
 checked int *f5(int *p, ptr<int> q, array_ptr<int> r, array_ptr<int> s: count(2)) unchecked { // expected-error {{return in a checked scope must have a checked type or a bounds-safe interface}} \
@@ -79,7 +79,7 @@ checked int *f5(int *p, ptr<int> q, array_ptr<int> r, array_ptr<int> s: count(2)
       int b checked[5][5];
       for (int i = 0; i < 5; i++) {
         for (int j = 0; j < 5; j++) {
-          b[i][j] += *q + *(_Dynamic_bounds_cast<array_ptr<int>>(r, 1)); // expected-error {{expression has no bounds}}
+          b[i][j] += *q + *(_Dynamic_bounds_cast<array_ptr<int>>(r, 1)); // expected-error {{expression has unknown bounds}}
         }
       }
     }
@@ -99,7 +99,7 @@ extern void f6() {
 
 extern int *f7(int arr checked[]) {
   int k;
-  return _Dynamic_bounds_cast<int *>(k); // expected-error{{expression has no bounds}}
+  return _Dynamic_bounds_cast<int *>(k); // expected-error{{expression has unknown bounds}}
 }
 
 extern void f18(int i) {
@@ -111,11 +111,11 @@ extern void f18(int i) {
   array_ptr<int> r : count(5) = 0;
   array_ptr<char> cr = 0;
 
-  p = _Dynamic_bounds_cast<int *>(p); // expected-error{{expression has no bounds}}
-  p = _Dynamic_bounds_cast<char *>(p);   // expected-warning {{incompatible pointer type}} expected-error {{expression has no bounds}}
+  p = _Dynamic_bounds_cast<int *>(p); // expected-error{{expression has unknown bounds}}
+  p = _Dynamic_bounds_cast<char *>(p);   // expected-warning {{incompatible pointer type}} expected-error {{expression has unknown bounds}}
 
-  p = _Dynamic_bounds_cast<int *>(i); // expected-error {{expression has no bounds}}
-  p = _Dynamic_bounds_cast<char *>(i); // expected-error {{expression has no bounds}} expected-warning {{incompatible pointer}}
+  p = _Dynamic_bounds_cast<int *>(i); // expected-error {{expression has unknown bounds}}
+  p = _Dynamic_bounds_cast<char *>(i); // expected-error {{expression has unknown bounds}} expected-warning {{incompatible pointer}}
 
   p = _Dynamic_bounds_cast<int *>(q);
 
@@ -125,10 +125,10 @@ extern void f18(int i) {
   p = _Dynamic_bounds_cast<int *>(r, 1); // expected-error {{invalid bounds cast}}
   p = _Dynamic_bounds_cast<int *>(r, r, r + 1); // expected-error {{invalid bounds cast}}
 
-  q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
+  q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has unknown bounds}}
   q = _Dynamic_bounds_cast<ptr<char>>(p); // expected-error {{assigning to '_Ptr<int>'}}
 
-  q = _Dynamic_bounds_cast<ptr<int>>(i); // expected-error {{expression has no bounds}}
+  q = _Dynamic_bounds_cast<ptr<int>>(i); // expected-error {{expression has unknown bounds}}
   q = _Dynamic_bounds_cast<ptr<char>>(i); // expected-error{{assigning to '_Ptr<int>'}}
 
   q = _Dynamic_bounds_cast<ptr<int>>(q);
@@ -136,10 +136,10 @@ extern void f18(int i) {
 
   q = _Dynamic_bounds_cast<ptr<int>>(r);
 
-  r = _Dynamic_bounds_cast<array_ptr<int>>(p, 1); // expected-error {{expression has no bounds}} expected-error {{declared bounds for r are invalid after assignment}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(p, p, p + 1); // expected-error {{expression has no bounds}} expected-error {{declared bounds for r are invalid after assignment}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(p, 1); // expected-error {{expression has unknown bounds}} expected-error {{declared bounds for r are invalid after assignment}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(p, p, p + 1); // expected-error {{expression has unknown bounds}} expected-error {{declared bounds for r are invalid after assignment}}
 
-  r = _Dynamic_bounds_cast<array_ptr<int>>(i, 1); // expected-error {{expression has no bounds}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(i, 1); // expected-error {{expression has unknown bounds}}
   r = _Dynamic_bounds_cast<array_ptr<int>>(i, i, i + 1); // expected-error 2 {{expected expression with pointer}}
 
   int len;
@@ -150,14 +150,14 @@ extern void f18(int i) {
   r = _Dynamic_bounds_cast<array_ptr<int>>(r, 1);        // expected-error {{declared bounds for r are invalid after assignment}}
   r = _Dynamic_bounds_cast<array_ptr<int>>(r, r, r + 1); // expected-error {{declared bounds for r are invalid after assignment}}
 
-  p = _Dynamic_bounds_cast<char *>(p); // expected-warning{{incompatible pointer types assigning}} expected-error{{expression has no bounds}}
+  p = _Dynamic_bounds_cast<char *>(p); // expected-warning{{incompatible pointer types assigning}} expected-error{{expression has unknown bounds}}
 
   p = _Assume_bounds_cast<int *>(q);
   p = _Assume_bounds_cast<int *>(cq);
   p = _Assume_bounds_cast<int *>(cr);
-  p = _Dynamic_bounds_cast<int *>(cr); // expected-error{{expression has no bounds}}  
-  cp = _Dynamic_bounds_cast<char *>(p); // expected-error{{expression has no bounds}}
-  q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has no bounds}}
+  p = _Dynamic_bounds_cast<int *>(cr); // expected-error{{expression has unknown bounds}}  
+  cp = _Dynamic_bounds_cast<char *>(p); // expected-error{{expression has unknown bounds}}
+  q = _Dynamic_bounds_cast<ptr<int>>(p); // expected-error {{expression has unknown bounds}}
   p = _Assume_bounds_cast<int *>(r);
 }
 

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -136,7 +136,7 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   int *t6a = x;         // expected-error {{expression of incompatible type 'int _Nt_checked[10]'}}
     
   // Various forms of array_ptr<T> = T[]. Note that the rhs does not need to have known bounds
-  // because the lhs pointers have no bounds (and cannot be dereferenced).  
+  // because the lhs pointers have unknown bounds (and cannot be dereferenced).  
   //
   // Note if there need to be known bounds, the bounds of p and q are unknown
   // because C does not guarantee that array sizes match for parameter passing
@@ -1047,9 +1047,9 @@ extern void check_call_void(void) {
   // Expected to typecheck
   f1_void(p, val);    // param ptr<void>, arg int[10] OK.
   f3_void(r, val);    // param array_ptr<void>, arg int checked[10] OK.
-  f3_void(p, val);    // param array_ptr<void>, arg int[10] OK, provided that param has no bounds.
-  f3_void(r, val);    // param array_ptr<void>, arg int checked[10] OK, provided that param has no bounds.
-  f3_void(v, val);    // param array_ptr<void>, arg int nt+checked[10] OK, provided that param has no bounds.
+  f3_void(p, val);    // param array_ptr<void>, arg int[10] OK, provided that param has unknown bounds.
+  f3_void(r, val);    // param array_ptr<void>, arg int checked[10] OK, provided that param has unknown bounds.
+  f3_void(v, val);    // param array_ptr<void>, arg int nt+checked[10] OK, provided that param has unknown bounds.
 
   // Expected to not typecheck
   f1_void(r, val);    // expected-error {{incompatible type}}
@@ -1071,9 +1071,9 @@ extern void check_call_void(void) {
   f2(u, 0);           // expected-error {{incompatible type}}
 
   // f3(int p checked[10], int)
-  f3(s, 0);           // expected-error {{argument has no bounds}}
+  f3(s, 0);           // expected-error {{argument has unknown bounds}}
   f3(t, 0);           // expected-error {{incompatible type}}
-  f3(u, 0);           // expected-error {{argument has no bounds}}
+  f3(u, 0);           // expected-error {{argument has unknown bounds}}
 
   // f3a(int p nt_checked[10], int)
   f3a(s, 0);           // expected-error {{incompatible type}}
@@ -1221,7 +1221,7 @@ int *h15(int arr checked[]) {
 }
 
 ptr<int> h17(int arr checked[]) {
-  return arr;  // expected-error {{expression has no bounds}}, ptr<T> = array_ptr<T> OK
+  return arr;  // expected-error {{expression has unknown bounds}}, ptr<T> = array_ptr<T> OK
 }
 
 ptr<int> h17a(int arr nt_checked[]) {

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -427,14 +427,14 @@ checked int * func41(int *p, ptr<int> q, array_ptr<int> r, array_ptr<int> s : co
   checked {
     *p = 1;
     *q = 2;
-    *r = 3; // expected-error {{expression has no bounds}}
+    *r = 3; // expected-error {{expression has unknown bounds}}
   *s = 4;
   unchecked {
     ptr<int> pa = &a;
     int b checked[5][5];
     for (int i = 0; i < 5; i++) {
       for (int j = 0; j < 5; j++) {
-        b[i][j] += *q + *r; // expected-error {{expression has no bounds}}
+        b[i][j] += *q + *r; // expected-error {{expression has unknown bounds}}
         b[i][j] += *p + *q + *r + *s;
       }
     }
@@ -801,7 +801,7 @@ checked int func60(ptr<struct s0> st0, ptr<struct s1> st1) {
   sum += *(st0->b) + *(st1->b);
   sum += *(st0->pc) + *(st1->pc);
   sum += *(st0->pd) + *(st1->pd);
-  sum += *(st0->e) + *(st1->e);   // expected-error {{expression has no bounds}}
+  sum += *(st0->e) + *(st1->e);   // expected-error {{expression has unknown bounds}}
 
   struct s2 sta;
   ptr<struct s2> pstb = 0;
@@ -820,7 +820,7 @@ checked int func60(ptr<struct s0> st0, ptr<struct s1> st1) {
   sum += *(st2->e) + *(st2->e);
   sum += *(st2->d.a) + *(st3->d.a); // expected-error 2 {{member used in a checked scope must have a checked type or a bounds-safe interface}}
   sum += *(st2->d.b) + *(st3->d.b); // expected-error 2 {{member used in a checked scope must have a checked type or a bounds-safe interface}}
-  sum += *(st2->d.e) + *(st3->d.e); // expected-error 2 {{expression has no bounds}}
+  sum += *(st2->d.e) + *(st3->d.e); // expected-error 2 {{expression has unknown bounds}}
   return sum;
 }
 
@@ -838,17 +838,17 @@ void test_addrof_checked_scope(void) checked {
   ptr<int> x = &a[i]; // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int>'}} \
                          ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)
   ptr<int> y = &b[0]; // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>) \
-                      // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+                      // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   ptr<int> z = &i;    // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)
 
   x = &a[i];  // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int>'}} \
               // ImplicitCastExpr _Ptr (UnaryOperator _Array_ptr<int>)
   y = &b[1];  // ImplicitCastExpr _Ptr (UnaryOperator _Array_ptr<int>) \
-              // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+              // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   z = &i;     // ImplicitCastExpr _Ptr (UnaryOperator _Array_Ptr<int>)
 
   x = b;      // BinaryOperator (ImplicitCastExpr _Ptr (_Array_ptr)) \
-              // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+              // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
 
   array_ptr<int> ax = &a[i];
   array_ptr<int> ay = &b[2];
@@ -882,17 +882,17 @@ void test_addrof_unchecked_scope(void) unchecked {
   // checkSingleAssignmentConstraints(int * -> _Ptr<int> implicit casting)
   ptr<int> x = &a[i]; // ImplicitCastExpr _Ptr<int>(UnaryOperator int * prefix &)
   ptr<int> y = &b[0]; // ImplicitCastExpr _Ptr<int>(UnaryOperator int * prefix &) \
-                      // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+                      // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   ptr<int> z = &i;    // ImplicitCastExpr _Ptr<int>(UnaryOperator int * prefix &)
 
   // implicit cast for _Ptr<T> requires source bounds
   x = &a[i];  // BinaryOperator(ImplicitCastExpr _Ptr<int>(UnaryOperator int * prefix &))
   y = &b[0];  // BinaryOperator(ImplicitCastExpr _Ptr<int>(UnaryOperator int * prefix &)) \
-              // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+              // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
   z = &i;     // BinaryOperator(ImplicitCastExpr _Ptr<int>(UnaryOperator int * prefix &))
 
   x = b;      // BinaryOperator(ImplicitCastExpr()) \
-              // expected-error {{expression has no bounds, cast to ptr<T> expects source to have bounds}}
+              // expected-error {{expression has unknown bounds, cast to ptr<T> expects source to have bounds}}
 
   // checkSingleAssignmentConstraints(int * -> _Array_ptr<int> implicit casting)
   array_ptr<int> ax = &a[i];  // ImplicitCastExpr _Array_ptr<int>(UnaryOperator)
@@ -990,7 +990,7 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   t6 = u; // expected-error {{local variable used in a checked scope must have a checked type}}
 
   // Various forms of array_ptr<T> = T[]. Note that the rhs does not need to have known bounds
-  // because the lhs pointers have no bounds (and cannot be dereferenced).
+  // because the lhs pointers have unknown bounds (and cannot be dereferenced).
   //
   // Note if there need to be known bounds, the bounds of p and q are unknown
   // because C does not guarantee that array sizes match for parameter passing

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -54,10 +54,10 @@ checked int f2(int *s : count(len), int len) {
 
 checked int f3(int *s : itype(array_ptr<int>), int len) {
   array_ptr<int> t1 = s + 5; // allowed
-  int t2 = *s;                // expected-error {{expression has no bounds}}
-  int t3 = s[4];              // expected-error {{expression has no bounds}}
-  *(s + 4) = 0;               // expected-error {{expression has no bounds}}
-  s[4] = 0;                   // expected-error {{expression has no bounds}}
+  int t2 = *s;                // expected-error {{expression has unknown bounds}}
+  int t3 = s[4];              // expected-error {{expression has unknown bounds}}
+  *(s + 4) = 0;               // expected-error {{expression has unknown bounds}}
+  s[4] = 0;                   // expected-error {{expression has unknown bounds}}
 
   return 0;
 }
@@ -74,10 +74,10 @@ checked int f4(int *s : itype(int checked[4])) {
 
 checked int f5(int *s : itype(int checked[])) {
   array_ptr<int> t1 = s + 4;
-  int t2 = *s;                // expected-error {{expression has no bounds}}
-  int t3 = s[4];              // expected-error {{expression has no bounds}}
-  *(s + 4) = 0;               // expected-error {{expression has no bounds}}
-  s[4] = 0;                   // expected-error {{expression has no bounds}}
+  int t2 = *s;                // expected-error {{expression has unknown bounds}}
+  int t3 = s[4];              // expected-error {{expression has unknown bounds}}
+  *(s + 4) = 0;               // expected-error {{expression has unknown bounds}}
+  s[4] = 0;                   // expected-error {{expression has unknown bounds}}
 
   return 0;
 }
@@ -130,10 +130,10 @@ checked void test_globals(void) {
 
   // array_ptr<int> without bounds
   array_ptr<int> t21 = g3 + 4; // allowed
-  int t22 = *g3;                // expected-error {{expression has no bounds}}
-  int t23 = g3[4];              // expected-error {{expression has no bounds}}
-  *(g3 + 4) = 0;                // expected-error {{expression has no bounds}}
-  g3[4] = 0;                    // expected-error {{expression has no bounds}}
+  int t22 = *g3;                // expected-error {{expression has unknown bounds}}
+  int t23 = g3[4];              // expected-error {{expression has unknown bounds}}
+  *(g3 + 4) = 0;                // expected-error {{expression has unknown bounds}}
+  g3[4] = 0;                    // expected-error {{expression has unknown bounds}}
 
   // int checked[5]
   array_ptr<int> t31 = g4 + 4;
@@ -144,10 +144,10 @@ checked void test_globals(void) {
 
   // int checked[]
   array_ptr<int> t41 = g5+ 4;
-  int t42 = *g5;                // expected-error {{expression has no bounds}}
-  int t43 = g5[4];              // expected-error {{expression has no bounds}}
-  *(g5 + 4) = 0;               // expected-error {{expression has no bounds}}
-  g5[4] = 0;                   // expected-error {{expression has no bounds}}
+  int t42 = *g5;                // expected-error {{expression has unknown bounds}}
+  int t43 = g5[4];              // expected-error {{expression has unknown bounds}}
+  *(g5 + 4) = 0;               // expected-error {{expression has unknown bounds}}
+  g5[4] = 0;                   // expected-error {{expression has unknown bounds}}
 }
 
 //
@@ -170,15 +170,15 @@ checked int test_call_parameters(void) {
   int arr1 checked[4];
   f10(param1);
   f10(param2);
-  f10(param3);           // expected-error {{expression has no bounds}}
+  f10(param3);           // expected-error {{expression has unknown bounds}}
   f10(arr1);
-  f10(empty_global_arr); // expected-error {{expression has no bounds}}
+  f10(empty_global_arr); // expected-error {{expression has unknown bounds}}
 
   f11(param1);           // expected-error {{argument does not meet declared bounds for 1st parameter}}
   f11(param2);
-  f11(param3);           // expected-error {{argument has no bounds}}
+  f11(param3);           // expected-error {{argument has unknown bounds}}
   f11(arr1);
-  f11(empty_global_arr); // expected-error {{argument has no bounds}}
+  f11(empty_global_arr); // expected-error {{argument has unknown bounds}}
 
   f12(param1);
   f12(param2);
@@ -194,9 +194,9 @@ checked int test_call_parameters(void) {
 
   f14(param1);           // expected-error {{argument does not meet declared bounds for 1st parameter}}
   f14(param2);
-  f14(param3);           // expected-error {{argument has no bounds}}
+  f14(param3);           // expected-error {{argument has unknown bounds}}
   f14(arr1);             
-  f14(empty_global_arr); // expected-error {{argument has no bounds}}
+  f14(empty_global_arr); // expected-error {{argument has unknown bounds}}
 
   f15(param1, param2);
 }
@@ -336,7 +336,7 @@ checked int test_struct1(struct S1 *p : itype(ptr<struct S1>)) {
   int t1 = *(p->f1 + 4);   // expected-error {{arithmetic on _Ptr type}}
   int t2 = *(p->f2 + 4);
   int t3 = *(p->f3 + 4);
-  int t4 = *(p->f4 + 4);   // expected-error {{expression has no bounds}}
+  int t4 = *(p->f4 + 4);   // expected-error {{expression has unknown bounds}}
   int t5 = *(p->arr + 4);
   (*(p->fp1))(p->f1);
   (*(p->fp1))(0x5000);     // expected-error {{passing 'int' to parameter of incompatible type '_Ptr<int>'}}
@@ -491,7 +491,7 @@ checked void test1_array_of_function_pointers(ptr<int> arg1, ptr<ptr<int>> arg2,
 //   bounds, so it can be assigned a checked pointer type.
 unchecked void test2_array_of_function_pointers(ptr<int> arg1, ptr<ptr<int>> arg2, int num) {
   (*(table1[num]))(arg1, arg2); // expected-error {{passing '_Ptr<int>' to parameter of incompatible type 'int *'}}
-  ptr<int> result1 = (*(table1[num]))(0, 0) + 5; // expected-error {{expression has no bounds}}
+  ptr<int> result1 = (*(table1[num]))(0, 0) + 5; // expected-error {{expression has unknown bounds}}
   (*(table1[num]))(0, 0) + 5;
   (*(table2[num]))(arg1, arg2);
   (*(table2[num]))(arg1, arg2) + 5;

--- a/tests/typechecking/checked_scope_pragma.c
+++ b/tests/typechecking/checked_scope_pragma.c
@@ -203,14 +203,14 @@ ptr<int> checked_func_u1(int *p, ptr<int> q, array_ptr<int> r, array_ptr<int> s 
   int a = 5;
   *p = 1;
   *q = 2;
-  *r = 3; // expected-error {{expression has no bounds}}
+  *r = 3; // expected-error {{expression has unknown bounds}}
   *s = 4;
   unchecked {
     ptr<int> pa = &a;
     int b checked[5][5];
     for (int i = 0; i < 5; i++) checked {
       for (int j = 0; j < 5; j++) unchecked {
-        b[i][j] += *q + *r; // expected-error {{expression has no bounds}}
+        b[i][j] += *q + *r; // expected-error {{expression has unknown bounds}}
       }
       b[i][4] += *p + *q + *r + *s;
     }
@@ -222,7 +222,7 @@ ptr<int> checked_func_u1_pragma(int *p, ptr<int> q, array_ptr<int> r, array_ptr<
   int a = 5;
   *p = 1;
   *q = 2;
-  *r = 3; // expected-error {{expression has no bounds}}
+  *r = 3; // expected-error {{expression has unknown bounds}}
   *s = 4;
 #pragma BOUNDS_CHECKED OFF
   ptr<int> pa = &a;
@@ -231,7 +231,7 @@ ptr<int> checked_func_u1_pragma(int *p, ptr<int> q, array_ptr<int> r, array_ptr<
 #pragma BOUNDS_CHECKED ON
     for (int j = 0; j < 5; j++) {
 #pragma BOUNDS_CHECKED OFF
-      b[i][j] += *q + *r; // expected-error {{expression has no bounds}}
+      b[i][j] += *q + *r; // expected-error {{expression has unknown bounds}}
     }
     b[i][4] += *p + *q + *r + *s;
   }
@@ -413,7 +413,7 @@ unchecked int * unchecked_func_cu(int *p, ptr<int> q, array_ptr<int> r, array_pt
   int a = 5;
   *p = 1; // expected-error {{parameter used in a checked scope must have a checked type or a bounds-safe interface}}
   *q = 2;
-  *r = 3; // expected-error {{expression has no bounds}}
+  *r = 3; // expected-error {{expression has unknown bounds}}
   *s = 4;
 #pragma BOUNDS_CHECKED OFF
   ptr<int> pa = &a;
@@ -421,7 +421,7 @@ unchecked int * unchecked_func_cu(int *p, ptr<int> q, array_ptr<int> r, array_pt
   int c[5][5];
   for (int i = 0; i < 5; i++) {
     for (int j = 0; j < 5; j++) {
-      b[i][j] = *p + *q + *r + *s;  // expected-error {{expression has no bounds}}
+      b[i][j] = *p + *q + *r + *s;  // expected-error {{expression has unknown bounds}}
     }
   }
   return 0;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -118,7 +118,7 @@ extern void check_assign(int val, int *p, ptr<int> q, array_ptr<int> r,
                               // T * = array_ptr<T> not OK
     int *t7a = v;             // // expected-error {{incompatible type}}
                               // T * = nt_array_ptr<T> not OK
-    ptr<int> t8 = r;          // expected-error {{expression has no bounds}}
+    ptr<int> t8 = r;          // expected-error {{expression has unknown bounds}}
                               // ptr<T> = array_ptr<T> OK
     ptr<int> t8a = v;         // ptr<T> = nt_array_ptr<T> OK.
     array_ptr<int> t9 = q;    // array_ptr<T> = ptr<T> OK
@@ -393,9 +393,9 @@ extern void check_assign_cv(void) {
     q_const = &val; // ptr to const assigned unsafe pointer OK, provided unsafe pointer
                     // has known bounds.
     r_const = p_const; // array_ptr to const assigned unsafe pointer to const OK,
-                       // provided array_ptr has no bounds.
+                       // provided array_ptr has unknown bounds.
     r_const = &val; // array_ptr to const assigned unsafe pointer OK, provided array_ptr
-                    // has no bounds.
+                    // has unknown bounds.
     s_const = s;    //  nt_array_ptr to const assigned non-const OK.
 
     p = p_const;    // expected-warning {{discards qualifiers}}
@@ -415,9 +415,9 @@ extern void check_assign_cv(void) {
     q_volatile = &val; // ptr to volatile assigned unsafe pointer OK, provided unsafe pointer
                        // has known bounds.
     r_volatile = p_volatile; // array_ptr to volatile assigned unsafe pointer to volatile OK,
-                             // provided array_ptr has no bounds.
+                             // provided array_ptr has unknown bounds.
     r_volatile = &val; // array_ptr to volatile assigned unsafe pointer OK, provided array_ptr
-                       // has no bounds.
+                       // has unknown bounds.
     p = p_volatile;    // expected-warning {{discards qualifiers}}
     q = q_volatile;    // expected-warning {{discards qualifiers}}
                        // ptr assigned to ptr to volatile int
@@ -437,8 +437,8 @@ extern void check_condexpr(int val, int *p, ptr<int> q, array_ptr<int> r,
    int *t1 = val ? p : p;            // T * and T * OK;
    ptr<int> t2 = val ? &val : q;     // T * and ptr<T> OK when T has known bounds
    ptr<int> t3 = val ? q : &val;     // ptr<T> and T * OK when T has known bounds
-   array_ptr<int> t4 = val ? p : r;  // T * and array_ptr<T> OK when array_ptr<T> has no bounds
-   array_ptr<int> t5 = val ? r : p;  // array_ptr<T> and T * OK when array_ptr<T> has no bounds
+   array_ptr<int> t4 = val ? p : r;  // T * and array_ptr<T> OK when array_ptr<T> has unknown bounds
+   array_ptr<int> t5 = val ? r : p;  // array_ptr<T> and T * OK when array_ptr<T> has unknown bounds
    ptr<int> t6 = val ? q : q;        // ptr<T> and ptr<T> OK
    array_ptr<int> t8 = val ? r : r;  // array_ptr<T> and array_ptr<T> OK
    array_ptr<int> t8a = val ? v : v; // nt_array_ptr<T> and nt_array_ptr<T> OK
@@ -535,8 +535,8 @@ extern void check_condexpr_void(int val, int *p, ptr<int> q, array_ptr<int> r,
     void *t9 = val ? p : s;            // int * and void * OK
     ptr<void> t14 = val ? t : &val;    // ptr<void> and int * OK when int * has bounds of at least 1 byte
     ptr<void> t15 = val ? &val : t;    // int * and ptr<void> OK when int * has bounds of at least 1 byte
-    array_ptr<void> t17 = val ? u : p; // array_ptr<void> and int * OK when array_ptr has no bounds
-    array_ptr<void> t18 = val ? p : u; // int * and array_ptr<void> OK when array_ptr has no bounds
+    array_ptr<void> t17 = val ? u : p; // array_ptr<void> and int * OK when array_ptr has unknown bounds
+    array_ptr<void> t18 = val ? p : u; // int * and array_ptr<void> OK when array_ptr has unknown bounds
     ptr<void> t19 = val ? t : q;       // ptr<void> and ptr<int> OK
     ptr<void> t20 = val ? q : t;       // ptr<int> and ptr<void> OK
     array_ptr<void> t21 = val ? u : r; // array_ptr<void> and array_ptr<int> OK
@@ -793,7 +793,7 @@ extern void f2(ptr<int> p, int y) {
 }
 
 extern void f3(array_ptr<int> p, int y) {
-    // can't dereference p because is has no bounds
+    // can't dereference p because is has unknown bounds
     // just use p in a compare.
      p != 0;
 }
@@ -837,7 +837,7 @@ extern void g2(int y, ptr<int> p) {
 }
 
 extern void g3(int y, array_ptr<int> p) {
-    // can't dereference p because is has no bounds
+    // can't dereference p because is has unknown bounds
     // just use p in a compare.
     p != 0;
 }
@@ -897,10 +897,10 @@ extern void check_call(void) {
     f2(r, 0);      // param ptr<int>, arg array_ptr<int> OK, provided that arg has known bounds.
     f2(v, 0);      // param ptr<int>, arg nt_array_ptr<int> OK, provided that arg has known bounds.
     f3(r, val);    // param array_ptr<int>, arg array_ptr<int> OK.
-    f3(p, 0);      // param array_ptr<int>, arg int * OK, provided that param has no bounds.
+    f3(p, 0);      // param array_ptr<int>, arg int * OK, provided that param has unknown bounds.
     f3(q, 0);      // param array_ptr<int>, arg ptr<int> OK
-    f3(&val, 0);   // param array_ptr<int>, arg int * OK, when param has no bounds and arg has known bounds
-    f3(v, 0);      // param array_ptr<int>, arg nt_array_ptr<int> OK, when param has no bounds and arg has known bounds
+    f3(&val, 0);   // param array_ptr<int>, arg int * OK, when param has unknown bounds and arg has known bounds
+    f3(v, 0);      // param array_ptr<int>, arg nt_array_ptr<int> OK, when param has unknown bounds and arg has known bounds
 
     f3a(p, val);   // expected-error {{incompatible type}}
                    // param nt_array_ptr<int>, arg int * not OK
@@ -933,8 +933,8 @@ extern void check_call(void) {
     g2(val, q);    // param ptr<int>, arg ptr<int> OK.
     g2(0, &val);   // param ptr<int>, arg int * OK, provided that arg has known bounds.
     g3(val, r);    // param array_ptr<int>, arg array_ptr<int> OK.
-    g3(0, p);      // param array_ptr<int>, arg int * OK, provided that param has no bounds.
-    g3(0, &val);   // param array_ptr<int>, arg int * OK, when param has no bounds and arg has known bounds
+    g3(0, p);      // param array_ptr<int>, arg int * OK, provided that param has unknown bounds.
+    g3(0, &val);   // param array_ptr<int>, arg int * OK, when param has unknown bounds and arg has known bounds
     g3a(0, p);     // expected-error {{incompatible type}}
                    // param array_ptr<int>, arg int * not OK.
     g3a(0, &val);  // expected-error {{incompatible type}}
@@ -977,7 +977,7 @@ extern void check_call(void) {
     //
     int *t1 = h1();
     ptr<int> t2 = h1();
-    array_ptr<int> t3 = h1();  // OK, provided that t3 has no bounds.
+    array_ptr<int> t3 = h1();  // OK, provided that t3 has unknown bounds.
     ptr<int> t4 = h2();
     array_ptr<int> t5 = h3();
     nt_array_ptr<int> t5a = h3a();
@@ -1030,8 +1030,8 @@ extern void check_call_void(void) {
     f2_void(q, val);    // param ptr<void>, arg ptr<int> OK.
     f2_void(&val, val); // param ptr<void>, arg int * OK, provided that arg has known bounds.
     f3_void(r, val);    // param array_ptr<void>, arg array_ptr<int> OK.
-    f3_void(p, val);    // param array_ptr<void>, arg int * OK, provided that param has no bounds.
-    f3_void(&val, val); // param array_ptr<void>, arg int * OK, when param has no bounds and arg has known bounds
+    f3_void(p, val);    // param array_ptr<void>, arg int * OK, provided that param has unknown bounds.
+    f3_void(&val, val); // param array_ptr<void>, arg int * OK, when param has unknown bounds and arg has known bounds
 
     // Expected to not typecheck
     f1_void(q, val);   // expected-error {{incompatible type}}


### PR DESCRIPTION
We are changing the compiler to use the term "unknown bounds" in error messages instead of "no bounds" because "no bounds" is ambiguous (see https://github.com/Microsoft/checkedc-clang/pull/430).  It could mean unbounded or unknown bounds.   Update the error messages that are checked in tests.

Testing:
- Passed automated testing on Windows and Linux.
