### PR TITLE
Remove -fcheckedc-extension flag.

### DIFF
--- a/samples/find-pattern.c
+++ b/samples/find-pattern.c
@@ -4,10 +4,10 @@
 // It reads a series of lines and check whether a string occurs in a line.
 // If it does, it prints the line.
 //
-// To compile the file using clang, on Unix/Mac use
-//  clang -o find-pattern -fcheckedc-extension find-pattern.c
+// To compile the file using the Checked C version of clang, on Unix/Mac use
+//  clang -o find-pattern find-pattern.c
 // On Windows use:
-//  clang -o find-pattern.exe -fcheckedc-extension find-pattern.c
+//  clang -o find-pattern.exe find-pattern.c
 //
 // To run it, create a file with some lines of text in it that contain a
 // pattern you wish to match.  Then run:

--- a/samples/string-helpers.c
+++ b/samples/string-helpers.c
@@ -3,10 +3,10 @@
 // The examples are adapted from "The C Programming Language", Second Edition,
 // by Brian Kernighan and Dennis Ritchie.
 //
-// To compile the file using clang, on Unix/Mac use
-//  clang -o string-helpers -fcheckedc-extension string-helper.c
+// To compile the file using the Checked C version of clang, on Unix/Mac use
+//  clang -o string-helpers string-helper.c
 // On Windows use:
-//  clang -o string-helpers.exe -fcheckedc-extension string-helpers.c
+//  clang -o string-helpers.exe string-helpers.c
 // 
 // Then run the program with 6 string arguments, the 3rd of which should
 // be an integer  For example:

--- a/tests/dynamic_checking/bounds/array-bounds-decls.c
+++ b/tests/dynamic_checking/bounds/array-bounds-decls.c
@@ -3,7 +3,7 @@
 // override bounds based on the size of the 1st 
 // dimension of the array.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value
 // RUN:  %t1 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
 // RUN:  %t1 1 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 2 | FileCheck %s --check-prefixes=CHECK

--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -1,7 +1,7 @@
 // Test bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value
 // RUN:  %t1 0 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
 // RUN:  %t1 1 0 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 2 0 | FileCheck %s --check-prefixes=CHECK

--- a/tests/dynamic_checking/bounds/deref.c
+++ b/tests/dynamic_checking/bounds/deref.c
@@ -7,7 +7,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-memory-accesses
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-memory-accesses
 // RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -16,7 +16,7 @@
 // RUN: %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang -fcheckedc-extension %s -o %t2 -DTEST_WRITE -Werror -Wno-check-memory-accesses
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror -Wno-check-memory-accesses
 // RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -25,7 +25,7 @@
 // RUN: %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-memory-accesses
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-memory-accesses
 // RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -34,7 +34,7 @@
 // RUN: %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses
 // RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_arith.c
+++ b/tests/dynamic_checking/bounds/deref_arith.c
@@ -15,7 +15,7 @@
 //
 // The following lines are for the clang automated test suite
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_READ -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %S/subscript.c -DTEST_READ -o %t1 -Werror -Wno-unused-value
 // RUN: %t1 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t1 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t1 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -40,7 +40,7 @@
 // RUN: %t1 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t1 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_WRITE -o %t2 -Werror
+// RUN: %clang %S/subscript.c -DTEST_WRITE -o %t2 -Werror
 // RUN: %t2 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t2 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t2 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -65,7 +65,7 @@
 // RUN: %t2 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t2 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror
+// RUN: %clang %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror
 // RUN: %t3 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t3 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t3 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -90,7 +90,7 @@
 // RUN: %t3 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t3 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror
+// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror
 // RUN: %t4 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t4 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t4 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c

--- a/tests/dynamic_checking/bounds/deref_arith_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arith_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_READ -o %t1 -Werror  -Wno-unused-value -O3
+// RUN: %clang %S/subscript.c -DTEST_READ -o %t1 -Werror  -Wno-unused-value -O3
 // RUN: %t1 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t1 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t1 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -38,7 +38,7 @@
 // RUN: %t1 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t1 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_WRITE -o %t2 -Werror -O3
+// RUN: %clang %S/subscript.c -DTEST_WRITE -o %t2 -Werror -O3
 // RUN: %t2 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t2 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t2 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -63,7 +63,7 @@
 // RUN: %t2 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t2 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror -O3
+// RUN: %clang %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror -O3
 // RUN: %t3 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t3 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t3 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -88,7 +88,7 @@
 // RUN: %t3 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t3 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror -O3
+// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror -O3
 // RUN: %t4 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t4 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t4 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c

--- a/tests/dynamic_checking/bounds/deref_arrow_member_expr.c
+++ b/tests/dynamic_checking/bounds/deref_arrow_member_expr.c
@@ -11,7 +11,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value
+// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value
 // RUN: %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
@@ -23,7 +23,7 @@
 // RUN: %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror
+// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror
 // RUN: %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
@@ -35,7 +35,7 @@
 // RUN: %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror
+// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror
 // RUN: %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
@@ -47,7 +47,7 @@
 // RUN: %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror
+// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror
 // RUN: %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_arrow_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arrow_member_expr_opt.c
@@ -11,7 +11,7 @@
 // `subscript_dot_member_expr.c`. This is run as a separate test so we know
 // if optimisation is breaking some dynamic checks.
 //
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value -O3
 // RUN: %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
@@ -23,7 +23,7 @@
 // RUN: %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3
 // RUN: %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
@@ -35,7 +35,7 @@
 // RUN: %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3
 // RUN: %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
@@ -47,7 +47,7 @@
 // RUN: %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3
 // RUN: %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_dot_member_expr.c
+++ b/tests/dynamic_checking/bounds/deref_dot_member_expr.c
@@ -19,7 +19,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -DTEST_READ -Werror -Wno-unused-value
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value
 // RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -31,7 +31,7 @@
 // RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t1 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %s -o %t2 -DTEST_WRITE -Werror
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror
 // RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -43,7 +43,7 @@
 // RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t2 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %s -o %t3 -DTEST_INCREMENT -Werror
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror
 // RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -55,7 +55,7 @@
 // RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t3 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
 // RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_dot_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_dot_member_expr_opt.c
@@ -14,7 +14,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3
 // RUN: %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -26,7 +26,7 @@
 // RUN: %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3
 // RUN: %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -38,7 +38,7 @@
 // RUN: %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror -O3
 // RUN: %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -50,7 +50,7 @@
 // RUN: %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
+// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
 // RUN: %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_opt.c
+++ b/tests/dynamic_checking/bounds/deref_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -O3
+// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -O3
 // RUN: %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -22,7 +22,7 @@
 // RUN: %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -O3
+// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -O3
 // RUN: %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -31,7 +31,7 @@
 // RUN: %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -O3
+// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -O3
 // RUN: %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -40,7 +40,7 @@
 // RUN: %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang -fcheckedc-extension %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -O3
+// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -O3
 // RUN: %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/nullterm_pointers.c
+++ b/tests/dynamic_checking/bounds/nullterm_pointers.c
@@ -1,7 +1,7 @@
 // Test runtime bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses
 // RUN:  %t1 1 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-1
 // RUN:  %t1 2 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 3 | FileCheck %s --check-prefixes=CHECK

--- a/tests/dynamic_checking/bounds/subscript.c
+++ b/tests/dynamic_checking/bounds/subscript.c
@@ -18,7 +18,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %s -DTEST_READ -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %s -DTEST_READ -o %t1 -Werror -Wno-unused-value
 // RUN: %t1 0 0 0 0  0 0   0 0 0  | FileCheck %s
 // RUN: %t1 1 2 4 4  1 2   1 1 1  | FileCheck %s
 // RUN: %t1 2 4 8 8  2 1   2 2 2  | FileCheck %s
@@ -43,7 +43,7 @@
 // RUN: %t1 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
 // RUN: %t1 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %s -DTEST_WRITE -o %t2 -Werror
+// RUN: %clang %s -DTEST_WRITE -o %t2 -Werror
 // RUN: %t2 0 0 0 0  0 0   0 0 0  | FileCheck %s
 // RUN: %t2 1 2 4 4  1 2   1 1 1  | FileCheck %s
 // RUN: %t2 2 4 8 8  2 1   2 2 2  | FileCheck %s
@@ -68,7 +68,7 @@
 // RUN: %t2 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
 // RUN: %t2 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %s -DTEST_INCREMENT -o %t3 -Werror
+// RUN: %clang %s -DTEST_INCREMENT -o %t3 -Werror
 // RUN: %t3 0 0 0 0  0 0   0 0 0  | FileCheck %s
 // RUN: %t3 1 2 4 4  1 2   1 1 1  | FileCheck %s
 // RUN: %t3 2 4 8 8  2 1   2 2 2  | FileCheck %s
@@ -93,7 +93,7 @@
 // RUN: %t3 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
 // RUN: %t3 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %s -DTEST_COMPOUND_ASSIGN -o %t4 -Werror
+// RUN: %clang %s -DTEST_COMPOUND_ASSIGN -o %t4 -Werror
 // RUN: %t4 0 0 0 0  0 0   0 0 0  | FileCheck %s
 // RUN: %t4 1 2 4 4  1 2   1 1 1  | FileCheck %s
 // RUN: %t4 2 4 8 8  2 1   2 2 2  | FileCheck %s

--- a/tests/dynamic_checking/bounds/subscript_arrow_member_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_arrow_member_expr.c
@@ -11,7 +11,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror
 // RUN: %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
@@ -22,7 +22,7 @@
 // RUN: %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror
 // RUN: %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
@@ -33,7 +33,7 @@
 // RUN: %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror
 // RUN: %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
@@ -44,7 +44,7 @@
 // RUN: %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror
 // RUN: %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/subscript_arrow_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_arrow_member_expr_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror  -Wno-unused-value -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror  -Wno-unused-value -O3
 // RUN: %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
@@ -24,7 +24,7 @@
 // RUN: %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3
 // RUN: %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
@@ -35,7 +35,7 @@
 // RUN: %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3
 // RUN: %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
@@ -46,7 +46,7 @@
 // RUN: %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
 // RUN: %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3
 // RUN: %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/subscript_dot_member_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_dot_member_expr.c
@@ -18,7 +18,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %s -o %t1 -DTEST_READ -Werror
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror
 // RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -29,7 +29,7 @@
 // RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t1 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %s -o %t2 -DTEST_WRITE -Werror
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror
 // RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -40,7 +40,7 @@
 // RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t2 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %s -o %t3 -DTEST_INCREMENT -Werror
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror
 // RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -51,7 +51,7 @@
 // RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t3 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
 // RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/subscript_dot_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_dot_member_expr_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -Werror  -Wno-unused-value -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -Werror  -Wno-unused-value -O3
 // RUN: %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -24,7 +24,7 @@
 // RUN: %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3
 // RUN: %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -35,7 +35,7 @@
 // RUN: %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror  -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror  -O3
 // RUN: %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -46,7 +46,7 @@
 // RUN: %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 // RUN: %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang -fcheckedc-extension %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
 // RUN: %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/subscript_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_READ -o %t1 -Werror -Wno-unused-value -O3
+// RUN: %clang %S/subscript.c -DTEST_READ -o %t1 -Werror -Wno-unused-value -O3
 // RUN: %t1 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t1 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t1 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -38,7 +38,7 @@
 // RUN: %t1 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t1 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_WRITE -o %t2 -Werror -O3
+// RUN: %clang %S/subscript.c -DTEST_WRITE -o %t2 -Werror -O3
 // RUN: %t2 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t2 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t2 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -63,7 +63,7 @@
 // RUN: %t2 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t2 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror -O3
+// RUN: %clang %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror -O3
 // RUN: %t3 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t3 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t3 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c
@@ -88,7 +88,7 @@
 // RUN: %t3 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 // RUN: %t3 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang -fcheckedc-extension %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror -O3
+// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror -O3
 // RUN: %t4 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
 // RUN: %t4 1 2 4 4  1 2   1 1 1  | FileCheck %S/subscript.c
 // RUN: %t4 2 4 8 8  2 1   2 2 2  | FileCheck %S/subscript.c

--- a/tests/dynamic_checking/dynamic_check/arith-fail.c
+++ b/tests/dynamic_checking/dynamic_check/arith-fail.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
+// RUN: %clang -Xclang -verify -o %t.exe %s
 // LLVM thinks that exiting via llvm.trap() is a crash.
 // RUN: %t.exe
 

--- a/tests/dynamic_checking/dynamic_check/arith-pass.c
+++ b/tests/dynamic_checking/dynamic_check/arith-pass.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
+// RUN: %clang -Xclang -verify -o %t.exe %s
 // RUN: %t.exe
 
 // expected-no-diagnostics

--- a/tests/dynamic_checking/dynamic_check/simple-fail.c
+++ b/tests/dynamic_checking/dynamic_check/simple-fail.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
+// RUN: %clang -Xclang -verify -o %t.exe %s
 // RUN: %t.exe
 
 #include <stdbool.h>

--- a/tests/dynamic_checking/dynamic_check/simple-pass.c
+++ b/tests/dynamic_checking/dynamic_check/simple-pass.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -Xclang -verify -o %t.exe %s
+// RUN: %clang -Xclang -verify -o %t.exe %s
 // RUN: %t.exe
 
 // expected-no-diagnostics

--- a/tests/parsing/checked_array_types.c
+++ b/tests/parsing/checked_array_types.c
@@ -9,7 +9,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension  -Wno-unused-value %s
+// RUN: %clang_cc1 -verify  -Wno-unused-value %s
 // expected-no-diagnostics
 
 //

--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/interop_types.c
+++ b/tests/parsing/interop_types.c
@@ -4,7 +4,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/parameter_bounds.c
+++ b/tests/parsing/parameter_bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -1,7 +1,7 @@
 // Feature tests of parsing new Checked C dynamic and assume bounds
 // cast. The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/pointer_types.c
+++ b/tests/parsing/pointer_types.c
@@ -10,7 +10,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify %s
 // expected-no-diagnostics
 
 #include <stdchecked.h>

--- a/tests/parsing/rel_align.c
+++ b/tests/parsing/rel_align.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify %s
 
 #include <stdchecked.h>
 
@@ -193,11 +193,11 @@ extern void f16(void) {
       : bounds(arr, arr + len) rel_align(char);
 }
 
-extern array_ptr<int> f17(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align(1) { // expected-error {{expected bounds expression}} expected-error {{expected a type}}
+extern array_ptr<int> f17(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align(1) { // expected-error {{expected bounds expression}}
 													    }
 extern array_ptr<int> f18(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align(char) { // expected-error {{expected bounds expression}}
 }
-extern array_ptr<int> f19(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align_value(len) { // expected-error {{expected bounds expression}} expected-error {{expression is not an integer constant expression}}
+extern array_ptr<int> f19(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align_value(len) { // expected-error {{expected bounds expression}}
 }
 
 int f20(void) {
@@ -225,9 +225,9 @@ extern void f23(int *p : iitype(ptr<int>) rel_alive(1), int y) {// expected-erro
 extern array_ptr<int> f24(array_ptr<int> arr : bounds(arr, arr + 5) rel_align(1))// expected-error {{expected a type}}
   : bounds(arr, arr + 5) rel_align(1);// expected-error {{expected a type}}
 
-extern array_ptr<int> f25(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align(1){} // expected-error {{expected bounds expression or bounds-safe interface type}} expected-error {{expected a type}}
+extern array_ptr<int> f25(int len, array_ptr<int> arr : count(len)) : boounds(arr, arr + len) rel_align(1){} // expected-error {{expected bounds expression or bounds-safe interface type}}
 
-extern array_ptr<int> f26(int len, array_ptr<int> arr : count(len)) : boounds() rel_align(1) {} // expected-error {{expected bounds expression or bounds-safe interface type}} expected-error {{expected a type}}
+extern array_ptr<int> f26(int len, array_ptr<int> arr : count(len)) : boounds() rel_align(1) {} // expected-error {{expected bounds expression or bounds-safe interface type}}
 
 extern array_ptr<int> f27(int len, array_ptr<int> arr : count(len)) : boounds() rel_alive(1) { // expected-error {{expected bounds expression or bounds-safe interface type}}
 }

--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -3,7 +3,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/typevariable/forany_parsing.c
+++ b/tests/parsing/typevariable/forany_parsing.c
@@ -6,7 +6,7 @@
 //    or definition is registered to a correct scope.
 // For this test file, we expect that there are no errors.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -verify %s
 // expected-no-diagnostics
 
 // Testing for function declaration with function body, with parameters

--- a/tests/parsing/typevariable/forany_parsing_error.c
+++ b/tests/parsing/typevariable/forany_parsing_error.c
@@ -5,7 +5,7 @@
 // 2) Make sure type declaration syntax error is caught.
 // 3) _For_any scope should be confined within function declaration.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -verify %s
 
 _For_any(R) _Ptr<R> foo(void);
 // Testing scope created by for any specifier is exited successfully.

--- a/tests/parsing/typevariable/generic_func_parsing.c
+++ b/tests/parsing/typevariable/generic_func_parsing.c
@@ -7,7 +7,7 @@
 // 2) An expression that may be ambiguous to generic function call is a
 //    comparison expression. ex) foo < bar; Make sure this isn't going to break
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -verify %s
 // expected-no-diagnostics
 
 _For_any(T) _Ptr<T> foo(_Ptr<T> a, _Ptr<T> b) {

--- a/tests/parsing/typevariable/generic_func_parsing_error.c
+++ b/tests/parsing/typevariable/generic_func_parsing_error.c
@@ -1,7 +1,7 @@
 // Tests to make sure parsing errors for generic function calls are detected
 // properly.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -verify %s
 
 _For_any(T) _Ptr<T> Foo(_Ptr<T> a, _Ptr<T> b) {
   return a;

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -1,7 +1,7 @@
 // Feature tests of static checking of bounds declarations.
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/static_checking/lexical_equality.c
+++ b/tests/static_checking/lexical_equality.c
@@ -2,7 +2,7 @@
 // It is difficult to test this directly, so we test it indirectly
 // by redeclaring functions with different bounds expressions.
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 //--------------------------------------------------------------------------//
 // Check the cross product of different kinds of expressions.               //

--- a/tests/static_checking/nme_bounds.c
+++ b/tests/static_checking/nme_bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -1,7 +1,7 @@
 // Feature tests of static checking of Pointer Bounds Cast
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note  -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note  %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 // Test expressions with standard signed and unsigned integers types as
 // arguments to count and byte_count.

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1,7 +1,7 @@
 // Unit tests for typechecking new Checked C array types
 //
 // The following line is for the LLVM test harness:
-// RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
 #include <stdchecked.h>

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
 #include <stdchecked.h>

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
 // General outline:

--- a/tests/typechecking/checked_scope_pragma.c
+++ b/tests/typechecking/checked_scope_pragma.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
 // Top level scope is a checked scope.

--- a/tests/typechecking/function_casts.c
+++ b/tests/typechecking/function_casts.c
@@ -1,7 +1,7 @@
 // Unit tests for typechecking new Checked C function pointers
 //
 // The following line is for the LLVM test harness:
-// RUN: %clang_cc1 -fcheckedc-extension -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 //
 
 #include <stdchecked.h>

--- a/tests/typechecking/generic_functions.c
+++ b/tests/typechecking/generic_functions.c
@@ -1,6 +1,6 @@
 // Test type checking of generic function calls.
 //
-// RUN: %clang_cc1 -fcheckedc-extension -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 //
 // Test mismatches between the number of type variables and type arguments.

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -3,7 +3,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/interop_type_annotations.c
+++ b/tests/typechecking/interop_type_annotations.c
@@ -3,7 +3,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/malloc_free.c
+++ b/tests/typechecking/malloc_free.c
@@ -3,7 +3,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -fsyntax-only -Werror %s
+// RUN: %clang -fsyntax-only -Werror %s
 
 #include <stdchecked.h>
 #include <stdlib_checked.h>

--- a/tests/typechecking/no_prototype_functions.c
+++ b/tests/typechecking/no_prototype_functions.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/pointer-sized-long/function_casts.c
+++ b/tests/typechecking/pointer-sized-long/function_casts.c
@@ -2,7 +2,7 @@
 // the tests in ../function_casts.c
 //
 // The following line is for the LLVM test harness:
-// RUN: %clang_cc1 -fcheckedc-extension -verify %s
+// RUN: %clang_cc1 -verify %s
 //
 
 #include <stdchecked.h>

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -4,7 +4,7 @@
 // To configure the list of platforms, change lit.local.cfg in this directory
 // to make the 'pointer-sized-long' feature available
 
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -1,7 +1,7 @@
 // Unit tests for typechecking new Checked C pointer types.
 //
 // The following line is for the LLVM test harness:
-// RUN: %clang_cc1 -fcheckedc-extension -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note %s
 //
 
 #include <stdchecked.h>

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -3,7 +3,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note -fcheckedc-extension %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -3,10 +3,10 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -fcheckedc-extension -fsyntax-only %s
-// RUN: %clang -fcheckedc-extension -fsyntax-only -D_FORTIFY_SOURCE=0 %s
-// RUN: %clang -fcheckedc-extension -fsyntax-only -D_FORTIFY_SOURCE=1 %s
-// RUN: %clang -fcheckedc-extension -fsyntax-only -D_FORTIFY_SOURCE=2 %s
+// RUN: %clang -fsyntax-only %s
+// RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=0 %s
+// RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=1 %s
+// RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=2 %s
 
 // C Standard
 #include "../../include/fenv_checked.h"

--- a/tests/typechecking/type_check_bounds_cast.c
+++ b/tests/typechecking/type_check_bounds_cast.c
@@ -1,7 +1,7 @@
 // Feature tests of parsing new Checked C dynamic and assume bounds
 // cast. The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -fcheckedc-extension -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 


### PR DESCRIPTION
The -fcheckedc-extension flag is now set by default for C files in the Checked C version of clang.  Remove the flag from the command lines for the test harness.

Also update a few error messages that changed after fixing bugs in the compiler.  The bugs were found after building the clang test suite with -fcheckedc-extension on by default.