### PR TITLE
Test assignment to a variable with a bounds-safe interface.

### DIFF
--- a/tests/runtime_operations/README.md
+++ b/tests/runtime_operations/README.md
@@ -1,0 +1,5 @@
+# Runtime operations
+
+Test runtime operations fpr the Checked C extension that do not involve
+dynamic checking.  This covers operations such as assignments of
+checked pointer values and implicit conversion.

--- a/tests/runtime_operations/assignments.c
+++ b/tests/runtime_operations/assignments.c
@@ -1,0 +1,32 @@
+// The following lines are for the clang automated test suite
+//
+// RUN: %clang -fcheckedc-extension %s -o %t -Werror -Wno-check-memory-accesses
+// RUN: %t | FileCheck %s --check-prefixes=CHECK
+
+#include <stdchecked.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static char *test : itype(ptr<char>);
+char p = 5;
+static char *init : itype(ptr<char>) = &p;
+
+int testfn(char *buf : count(len), size_t len)
+_Checked {
+  test = init;
+  return 0;
+}
+
+
+int main(int argc, array_ptr<char*> argv : count(argc)) {
+  // CHECK: Starting test
+  puts("Starting test");
+  testfn(init, 1);
+  if (test && *test == 5) {
+    // CHECK: Finishing test successfully
+    puts("Finishing test successfully");
+    return EXIT_SUCCESS;
+  }
+  else
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Reading variables with bounds-safe interfaces works fine.  Writing
variables with bounds-interfaces caused a compiler crash. Add a
simple test for writing a variable.  We should add more tests
for writes at bounds-safe interfaces eventually.

I placed this test in a new subdirectory `runtime_operations`. This
will contain tests for checked type operations that are done at
runtime, but don't do dynamic runtime checks.

In this case, there is an implicit cast inserted at bounds-safe interfaces.
We want to make sure those casts operate correctly.