### PR TITLE
Error messages for problems involving return statements. 

### DIFF
--- a/tests/static_checking/returns/falloff1.c
+++ b/tests/static_checking/returns/falloff1.c
@@ -1,0 +1,12 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+ptr<int> f21(int i) {
+}  // expected-error {{control reaches end of function with checked pointer return type}}

--- a/tests/static_checking/returns/falloff2.c
+++ b/tests/static_checking/returns/falloff2.c
@@ -1,0 +1,14 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+ptr<int> f22(int i) {
+  if (i)
+    return 0;
+} // expected-error {{control may reach end of function with checked pointer return type}}

--- a/tests/static_checking/returns/falloff3.c
+++ b/tests/static_checking/returns/falloff3.c
@@ -1,0 +1,13 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+int f23(array_ptr<int> p : count(1)) : bounds(p, p + 1) {
+} // expected-error {{control reaches end of function with return bounds}}
+

--- a/tests/static_checking/returns/falloff4.c
+++ b/tests/static_checking/returns/falloff4.c
@@ -1,0 +1,14 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+int f24(array_ptr<int> p : count(1)) : bounds(p, p + 1) {
+  if (p)
+    return 0;
+} // expected-error {{control may reach end of function with return bounds}}

--- a/tests/static_checking/returns/falloff5.c
+++ b/tests/static_checking/returns/falloff5.c
@@ -1,0 +1,12 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+int f25(void) checked {
+} // expected-error {{control reaches end of checked function body}}

--- a/tests/static_checking/returns/falloff6.c
+++ b/tests/static_checking/returns/falloff6.c
@@ -1,0 +1,14 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+int f25(int i) checked {
+  if (i)
+    return 0;
+}  // expected-error {{control may reach end of checked function body}}

--- a/tests/static_checking/returns/falloff7.c
+++ b/tests/static_checking/returns/falloff7.c
@@ -1,0 +1,12 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+checked int f27(void) {
+} // expected-error {{control reaches end of checked function body}}

--- a/tests/static_checking/returns/falloff8.c
+++ b/tests/static_checking/returns/falloff8.c
@@ -1,0 +1,14 @@
+// Test that falling off ends of functions is not allowed for checked code.
+// This is tested by a set of files because clang suppresses these analysis-based
+// errors after the first one occurs.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+checked int f28(int i) {
+  if (i)
+    return 0;
+} // expected-error {{control may reach end of checked function body}}

--- a/tests/static_checking/returns/funcbody.c
+++ b/tests/static_checking/returns/funcbody.c
@@ -1,0 +1,45 @@
+// Tests that incorrect returns in function bodies are not allowed for checked
+// code.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+// Returning a value when none is expected.
+void f1(void) checked {
+  return 5; // expected-error {{void function 'f1' cannot return a value in a checked scope}}
+}
+
+void f2(void) {
+  ptr<int> p = 0;
+  return p; // expected-error {{void function 'f2' cannot return a value in a checked scope}}
+}
+
+void f3(void) {
+  array_ptr<int> p = 0;
+  return p; // expected-error {{void function 'f3' cannot return a value in a checked scope}}
+}
+
+// Failing to return a value when one is expected.
+ptr<int> f10(void) {
+  return;  // expected-error {{function 'f10' with checked pointer return type must return a value}}
+}
+
+int f11(void) checked {
+  return; // expected-error {{non-void function 'f11' must return a value in a checked scope}}
+}
+
+int f12(array_ptr<int> p) : bounds(p, p + 1) checked {
+  return; // expected-error {{non-void function 'f12' must return a value when there are return bounds}}
+}
+
+
+array_ptr<int> f13(void) : count(5) checked {
+  return; // expected-error {{function 'f13' with checked pointer return type must return a value}}
+}
+
+array_ptr<int> f14(void) : count(5) {
+  return;  // expected-error {{function 'f14' with checked pointer return type must return a value}}
+}

--- a/tests/static_checking/returns/funcbody.c
+++ b/tests/static_checking/returns/funcbody.c
@@ -12,12 +12,12 @@ void f1(void) checked {
   return 5; // expected-error {{void function 'f1' cannot return a value in a checked scope}}
 }
 
-void f2(void) {
+checked void f2(void) {
   ptr<int> p = 0;
   return p; // expected-error {{void function 'f2' cannot return a value in a checked scope}}
 }
 
-void f3(void) {
+void f3(void) checked {
   array_ptr<int> p = 0;
   return p; // expected-error {{void function 'f3' cannot return a value in a checked scope}}
 }

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -294,7 +294,7 @@ int *f35(int *p : itype(ptr<int>)) {
 // Omit returning a value when one is expected.
 int *f36(void) : itype(ptr<int>) {
   checked{
-    return; // expected-error {{non-void function 'f36' should return a value}}
+    return; // expected-error {{non-void function 'f36' must return a value when there are return bounds}}
   }
   return 0;
 }


### PR DESCRIPTION
C programs can have problems with return statements that would result in undefined or incorrect program behavior. C compilers typically warn about these problems (in other languages, these would typically be compile-time errors because of the severity of the problem).  For Checked C, these problems need to result in errors when they occur in a checked scope or involve bounds or check pointer types.  This
change adds tests for these problems.