### PR TITLE
Checked C typing rules for literals.  Also describe handling of initializers.

### DIFF
--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -730,19 +730,42 @@ ptr<int> p = 0;
 int arr1 checked[5] = { 0, 1, 2, 3, 4 };
 int arr2 checked[3] = { 0, 1, 2 };
 
-struct Pair {
+// Initialize pointers to checked arrays
+array_ptr<int> ap1 = arr1;
+array_ptr<int> ap2 = (int checked[4]) { 0, 0, 0, 0 };
+
+// Initialize a multi-dimensional checked array
+float unit_transform checked[2][2] = { { 1.0f, 0.0f}, { 0.0f, 1.0f }};
+
+// A ragged 2-dimensional array, where the inner dimension size varies.
+struct inner_array {
+  int len;
+  array_ptr<double> elems; // bounds declaration missing because we
+                           // haven't described them yet.
+};
+
+typedef struct inner_array ragged_2d_arr[];
+
+ragged_2d_arr data = 
+  { { 3, (double checked[]) { 1.0, 0.0, 0.0 } },
+    { 1, (double checked[]) { 5.0 } },
+    { 0, 0 },
+    { 2, (double checked[]) { 6.0, 7.0 } } 
+  };
+
+struct BufferPair {
   int len1;
   array_ptr<int> buf1;
   int len2;
   array_ptr<int> buf2;
 };
 
-// Initialize all members of an instance of Pair.
-struct Pair p1 = { 5, arr1, 3, arr2 };
+// Initialize all members.
+struct BufferPair p1 = { 5, arr1, 3, arr2 };
 
-// Declare a partial initializer for an instance of Pair.
+// Declare a partial initializer.
 // len2 and buf2 are initialized to 0.
-struct Pair p2 =  { 0, arr1 };
+struct BufferPair p2 =  { 0, arr1 };
 
 // Strings and initialized arrays of characters.
 
@@ -757,10 +780,7 @@ nt_array_ptr<char> colors checked[] = { "red", "green", "blue", "purple" };
 // Null-terminated arrays of checked strings
 nt_array_ptr<char> more_colors nt_checked[] = { "white", "black", "grey", 0 };
 
-// Multi-dimensional checked arrays
-float unit_transform checked[2][2] = { { 1.0f, 0.0f}, { 0.0f, 1.0f }};
-
-// A null-terminated array of pointers to null-terminated arrays
+// A null-terminated array of ponters to null-terminated arrays
 // of strings.
 nt_array_ptr<nt_array_ptr<char>> sentences nt_checked[4] = 
   {  (nt_array_ptr<char> nt_checked[]) { "this", "is", "the", "first sentence", 0 },
@@ -770,19 +790,7 @@ nt_array_ptr<nt_array_ptr<char>> sentences nt_checked[4] =
    };
 \end{verbatim}
 
-% TODO - rethink this example, as it isn't legal C code.
-% // A ragged 2-dimensional array, where the inner dimension size varies.
-% struct counted_arr {
-%  int len;
-%  double elems checked[];  // bounds declaration missing because we
-%                           // haven't described them yet.
-%};
 
-% typedef ptr<counted_arr> ragged_arr[];
-% count_arr dim1 = { 3, { 5.0, 6.0, 7.0} };
-% count_arr dim2 = { 2, { 5.0, 6.0} };
-% count_arr dim3 = { 1, { 5.0 } };
-% ragged_arr data = { &dim1, &dim2, &dim3 };
 
 \section{Relative alignment of \arrayptr\ values}
 \label{section:relative-alignment}

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -711,7 +711,7 @@ ptr<struct string_with_count> S =
 \end{verbatim}
 
 \subsection{Initializers}
-C allows declarations to be initialized using initializers.  An initializer
+C allows declared variables to be initialized using initializers.  An initializer
 is either an expression or a brace-enclosed list of initialization values.
 The brace-enclosed list may be a partial list and specify values only for
 part of an object or array.  In that case, the remaining part of the

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -470,6 +470,223 @@ using a separate analysis.   A use includes taking the address of a variable
 or member of a variable.  It is often unclear when the resulting pointer is used,
 so the variable must be initialized when its address is taken.
 
+\section{Program scopes for checked pointer types}
+
+To improve program reliability and to simplify understanding programs,
+it is desirable to limit code to using only checked pointers. To support
+this, we introduce checked program scopes. The \keyword{checked} keyword
+can be attached to blocks and function definitions. In checked program
+scopes, the declared types of variables are allowed to be or use
+checked pointer types or checked array types; unchecked pointer types
+and unchecked array types are not allowed.  Similarly, for functions,
+return types and parameter types are allowed to be or use checked pointer
+types or checked array types.  
+
+On the other hand,  declarations in checked scopes can use unchecked pointer
+types and unchecked array types, provided that the declarations provide a
+bounds-safe interface.   These are described in
+Section~\ref{section:function-bounds-safe-interfaces}.
+Variables and functions used in checked scopes are 
+allowed to have or use checked pointer types, checked array types, or
+unchecked pointer types and unchecked array types with bounds declarations.
+
+A new pragma directive \texttt{BOUNDS\_CHECKED} is introduced to control whether
+the top-level scope is a checked scope:
+\begin{alltt}
+#pragma BOUNDS_CHECKED \textit{on-off-switch}
+\end{alltt}
+
+Where \texttt{\textit{on-off-switch}} is one of \verb|ON OFF DEFAULT|
+
+By default, function definitions are not checked. A block inherits the
+checking properties of its parent. This preserves the meaning of
+existing C code.
+
+A checked block is introduced by placing  \keyword{checked} before a
+compound block:
+\begin{verbatim}
+checked 
+{
+    int a = 5;
+    ptr<int> pa = &a;
+
+    int b checked[5][5];
+    for (int i = 0; i < 5; i++) {
+        for (int j = 0; j < 5; j++) {
+            // all references are bounds checked
+            b[i][j] = -1;
+        }
+    }
+}
+\end{verbatim}
+
+It is rarer for a programmer to need to introduce an unchecked scope. It
+is needed usually to allow the use of unchecked pointers within a checked
+block. The \keyword{unchecked} keyword can be used in all the places where the
+checked keyword can be used. This example shows the use of an unchecked
+block:
+
+\begin{verbatim}
+checked 
+{
+    int a = 5;
+    unchecked 
+    {
+        int *upa = &a;	
+        int b[5][5];
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                // not bounds checked
+                b[i][j] = -1;
+            }
+        }     
+    }
+ ...
+}
+\end{verbatim}
+
+In a checked function definition, the body of the function is a 
+checked  block. A checked function definition is declared by placing the
+\keyword{checked} keyword before the definition. Here are examples of checked and
+unchecked function definitions:
+
+\begin{verbatim}
+// checked at the function level: no unchecked pointers can appear in argument
+// types, the return type, or the body of the function.
+checked int f(ptr<int> p) 
+{
+    int a = 5;
+    ptr<int> pa = &a;
+    ...
+}
+
+// unchecked at the function level: checked and unchecked pointer types can
+// occur in argument types, the return type, or the body of the function
+unchecked int f(int *p, ptr<int> r)
+{
+    int a = 5;
+    int *pa = &a;
+    ...
+}
+
+// f is unchecked by default
+int f(int *p, ptr<int> r)
+{
+    int a = 5;
+    int *pa = &a;
+    ...
+}
+\end{verbatim}
+
+When a function call occurs in a checked block, the function being
+called does not have to be declared as checked. The notion of whether a
+scope is checked or not checked is lexical and the function definition
+is a separate lexical scope.
+
+C allows declarations of functions without prototypes, where the types 
+of the arguments to functions are not specified.  These
+functions are dangerous to use because there can be mismatches 
+between argument types and parameter types at function
+calls.  This can corrupt data or the call stack.  In checked scopes, 
+the use or declaration of  functions without prototypes is not allowed.
+
+As we add different notions of checking to Checked C, we will use the
+checked and unchecked keywords for all the different notions of
+checking. We may introduce additional keywords to control specific kinds
+of checking.
+
+\section{String literals, compound literals, and initializer expressions}
+
+C programs can declare string literals and compound literals.  Examples
+of string literals are expressions such as \keyword{"hello"} and \keyword{L"hello"}
+(in the latter case, the modifier `L' changes the type of the characters in the string).
+A compound literal is an expression that declares an array literal or object literal.
+It consists of a parenthesized type name followed by list of initializers in braces.
+A compound literal has static storage if its at the top level of a file and automatic
+storage if it occurs within a block.  Here are examples of compound literals:
+\begin{verbatim}
+int *arr = (int []) { 0, 1, 2};
+struct Point {
+  int x;
+  int y;
+}
+struct S *zero_coord = &((struct Point) { 0, 0 };
+\end{verbatim}
+
+A string literal has an array type with an element type that is one of \keyword{char},
+\verb+wchar_t+,  \verb+char16_t+, or \verb+char32_t+.   For Checked C, there is a question
+about whether the array type should be an unchecked or checked array.
+The type of a string literal with an element type \var{T} depends on whether the literal occurs
+in a checked scope or an unchecked scope:
+\begin{itemize}
+\item In a checked scope, the type is ``null-terminated checked array of \var{T}``.
+\item In an unchecked scope, the type is ``unchecked array of \var{T}''.
+\end{itemize}
+
+This creates an issue in unchecked scopes when a string literal is used where
+a null-terminated checked pointer type is expected.  It makes sense to allow
+this because string literals has known bounds.  However, a literal would have the type
+``unchecked array of \var{T}'' and convert to ``unchecked pointer to \var{T}''.
+There is no conversion from the unchecked pointer type to
+``unchecked null-terminated pointer to \var{T}''.
+To allow this, we alter the rule for implicit conversion of array types to pointer types:
+\begin{itemize}
+\item If the type of a string literal or compound literal expression with type
+``array of \var{T}'' has been altered to be ``\var{T} \keyword{*}'', and the expression
+appears in a context where a checked pointer type is expected, the type of the expression
+is further altered to be ``checked pointer to \var{T}''.  The kind of the checked
+pointer shall match the kind of the expected pointer type. The contexts where this
+is allowed are the right-hand side of an assignment, an argument to a function call, or in
+an initializer.
+\item The string literal or compound literal may be possibly parenthesized.
+\item The type ``checked pointer to \var{T}'' must be a valid type.  Null-terminated array pointers
+to non-scalar and non-integer types are not allowed.
+\end{itemize}.
+This rule is not strictly necessary for compound array literals.  The type name in the
+compound array literal could be modified, of course.  We allow this rule anyway to reduce
+the amount of code changes required to modify code to be checked code.
+
+Note that some C compilers common together string literals that have the same characters
+sequence.  The meaning of modifying a string literal is implementation-dependent.
+For bounds safety, an implementation should either
+\begin{itemize}
+\item not common together string literals whose modified pointer types differ in whether they are null-terminated, or
+\item make string literals read-only.
+\end{itemize}
+
+\subsection{Examples}
+
+\section{Relative alignment of \arrayptr\ values}
+\label{section:relative-alignment}
+
+\arrayptrT\ pointers provide
+pointer arithmetic on arrays. The bounds for these pointers usually
+describe a range of memory that is exactly the size of some array of \var{T}.
+The pointers point to an element of the array. In other words, the lower
+bound, the upper bound, and pointer are  relatively aligned to the type
+\var{T}. Given a lower bound \var{lb}, an upper bound \var{ub}, and a
+pointer \var{p}, there should exist some integer \var{count} such that
+\var{ub} = \var{lb} + \var{count}. In addition, there is either some
+integer \var{index} such that \var{p} = \var{lb} + \var{index},
+where addition is C pointer arithmetic, or \var{p} is null.
+
+The type to which a pointer and its bounds are relatively aligned is
+called the relative alignment type. By default, the relative alignment
+type for a pointer and its bounds is the referent type. However, the
+relative alignment type can be overridden by specifying it explicitly as
+part of the bounds.  This is described in 
+Section~\ref{section:representing-relative-alignment}.
+This can be used for bounds for the results of pointers casts and 
+for  \arrayptrvoid\ pointers. The type
+\texttt{void} has no defined size, so the default relative alignment is
+undefined for \texttt{void}.
+
+We considered removing the entire concept of relative alignment from the
+design to simplify the design.  We decided against that because it would 
+increase the cost of bounds checking throughout the program.  
+Section~\ref{section:design-alternatives:always-unaligned} explains
+this choice in more detail.
+
 \section{Pointer arithmetic error conditions}
 \label{section:pointer-arithmetic-errors}
 
@@ -701,162 +918,6 @@ the check \texttt{p < hi} implies that the increment cannot
 overflow. The checks are also inexpensive on superscalar processors:
 they can be placed so that they are statically predicted by 
 processors to never fail.
-
-\section{Relative alignment of \arrayptr\ values}
-\label{section:relative-alignment}
-
-\arrayptrT\ pointers provide
-pointer arithmetic on arrays. The bounds for these pointers usually
-describe a range of memory that is exactly the size of some array of \var{T}.
-The pointers point to an element of the array. In other words, the lower
-bound, the upper bound, and pointer are  relatively aligned to the type
-\var{T}. Given a lower bound \var{lb}, an upper bound \var{ub}, and a
-pointer \var{p}, there should exist some integer \var{count} such that
-\var{ub} = \var{lb} + \var{count}. In addition, there is either some
-integer \var{index} such that \var{p} = \var{lb} + \var{index},
-where addition is C pointer arithmetic, or \var{p} is null.
-
-The type to which a pointer and its bounds are relatively aligned is
-called the relative alignment type. By default, the relative alignment
-type for a pointer and its bounds is the referent type. However, the
-relative alignment type can be overridden by specifying it explicitly as
-part of the bounds.  This is described in 
-Section~\ref{section:representing-relative-alignment}.
-This can be used for bounds for the results of pointers casts and 
-for  \arrayptrvoid\ pointers. The type
-\texttt{void} has no defined size, so the default relative alignment is
-undefined for \texttt{void}.
-
-We considered removing the entire concept of relative alignment from the
-design to simplify the design.  We decided against that because it would 
-increase the cost of bounds checking throughout the program.  
-Section~\ref{section:design-alternatives:always-unaligned} explains
-this choice in more detail.
-
-\section{Program scopes for checked pointer types}
-
-To improve program reliability and to simplify understanding programs,
-it is desirable to limit code to using only checked pointers. To support
-this, we introduce checked program scopes. The \keyword{checked} keyword
-can be attached to blocks and function definitions. In checked program
-scopes, the declared types of variables are allowed to be or use
-checked pointer types or checked array types; unchecked pointer types
-and unchecked array types are not allowed.  Similarly, for functions,
-return types and parameter types are allowed to be or use checked pointer
-types or checked array types.  
-
-On the other hand,  declarations in checked scopes can use unchecked pointer
-types and unchecked array types, provided that the declarations provide a
-bounds-safe interface.   These are described in
-Section~\ref{section:function-bounds-safe-interfaces}.
-Variables and functions used in checked scopes are 
-allowed to have or use checked pointer types, checked array types, or
-unchecked pointer types and unchecked array types with bounds declarations.
-
-A new pragma directive \texttt{BOUNDS\_CHECKED} is introduced to control whether
-the top-level scope is a checked scope:
-\begin{alltt}
-#pragma BOUNDS_CHECKED \textit{on-off-switch}
-\end{alltt}
-
-Where \texttt{\textit{on-off-switch}} is one of \verb|ON OFF DEFAULT|
-
-By default, function definitions are not checked. A block inherits the
-checking properties of its parent. This preserves the meaning of
-existing C code.
-
-A checked block is introduced by placing  \keyword{checked} before a
-compound block:
-\begin{verbatim}
-checked 
-{
-    int a = 5;
-    ptr<int> pa = &a;
-
-    int b checked[5][5];
-    for (int i = 0; i < 5; i++) {
-        for (int j = 0; j < 5; j++) {
-            // all references are bounds checked
-            b[i][j] = -1;
-        }
-    }
-}
-\end{verbatim}
-
-It is rarer for a programmer to need to introduce an unchecked scope. It
-is needed usually to allow the use of unchecked pointers within a checked
-block. The \keyword{unchecked} keyword can be used in all the places where the
-checked keyword can be used. This example shows the use of an unchecked
-block:
-
-\begin{verbatim}
-checked 
-{
-    int a = 5;
-    unchecked 
-    {
-        int *upa = &a;	
-        int b[5][5];
-        for (int i = 0; i < 5; i++) {
-            for (int j = 0; j < 5; j++) {
-                // not bounds checked
-                b[i][j] = -1;
-            }
-        }     
-    }
- ...
-}
-\end{verbatim}
-
-In a checked function definition, the body of the function is a 
-checked  block. A checked function definition is declared by placing the
-\keyword{checked} keyword before the definition. Here are examples of checked and
-unchecked function definitions:
-
-\begin{verbatim}
-// checked at the function level: no unchecked pointers can appear in argument
-// types, the return type, or the body of the function.
-checked int f(ptr<int> p) 
-{
-    int a = 5;
-    ptr<int> pa = &a;
-    ...
-}
-
-// unchecked at the function level: checked and unchecked pointer types can
-// occur in argument types, the return type, or the body of the function
-unchecked int f(int *p, ptr<int> r)
-{
-    int a = 5;
-    int *pa = &a;
-    ...
-}
-
-// f is unchecked by default
-int f(int *p, ptr<int> r)
-{
-    int a = 5;
-    int *pa = &a;
-    ...
-}
-\end{verbatim}
-
-When a function call occurs in a checked block, the function being
-called does not have to be declared as checked. The notion of whether a
-scope is checked or not checked is lexical and the function definition
-is a separate lexical scope.
-
-C allows declarations of functions without prototypes, where the types 
-of the arguments to functions are not specified.  These
-functions are dangerous to use because there can be mismatches 
-between argument types and parameter types at function
-calls.  This can corrupt data or the call stack.  In checked scopes, 
-the use or declaration of  functions without prototypes is not allowed.
-
-As we add different notions of checking to Checked C, we will use the
-checked and unchecked keywords for all the different notions of
-checking. We may introduce additional keywords to control specific kinds
-of checking.
 
 \section{Programmer-inserted dynamic checks}
 \label{section:programmer-dynamic-checks}

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -600,7 +600,7 @@ of checking.
 C programs can declare string literals and compound literals.  Examples
 of string literals are expressions such as \keyword{"hello"} and \keyword{L"hello"}
 (in the latter case, the modifier `L' changes the type of the characters in the string).
-A compound literal is an expression that declares an array literal or object literal.
+A compound literal is an expression that declares an array literal or an object literal.
 It consists of a parenthesized type name followed by list of initializers in braces.
 A compound literal has static storage if its at the top level of a file and automatic
 storage if it occurs within a block.  Here are examples of compound literals:
@@ -625,8 +625,9 @@ in a checked scope or an unchecked scope:
 
 This creates an issue in unchecked scopes when a string literal is used where
 a null-terminated checked pointer type is expected.  It makes sense to allow
-this because string literals has known bounds.  However, a literal would have the type
-``unchecked array of \var{T}'' and convert to ``unchecked pointer to \var{T}''.
+this because string literals has known bounds.  However, a string
+literal would have the type ``unchecked array of \var{T}'', which
+would convert to ``unchecked pointer to \var{T}''.
 There is no conversion from the unchecked pointer type to
 ``unchecked null-terminated pointer to \var{T}''.
 To allow this, we alter the rule for implicit conversion of array types to pointer types:
@@ -641,20 +642,69 @@ an initializer.
 \item The string literal or compound literal may be possibly parenthesized.
 \item The type ``checked pointer to \var{T}'' must be a valid type.  Null-terminated array pointers
 to non-scalar and non-integer types are not allowed.
-\end{itemize}.
+\end{itemize}
 This rule is not strictly necessary for compound array literals.  The type name in the
 compound array literal could be modified, of course.  We allow this rule anyway to reduce
-the amount of code changes required to modify code to be checked code.
+the amount of code changes required to modify code to be checked.
 
-Note that some C compilers common together string literals that have the same characters
+Note that some C compilers use the same memory to represent different
+occurrenes of string literals that have the same characters
 sequence.  The meaning of modifying a string literal is implementation-dependent.
 For bounds safety, an implementation should either
 \begin{itemize}
-\item not common together string literals whose modified pointer types differ in whether they are null-terminated, or
+\item not do this for string literals whose modified pointer types differ in whether they are null-terminated, or
 \item make string literals read-only.
 \end{itemize}
 
 \subsection{Examples}
+\begin{verbatim}
+checked void f(void) {
+  // "hello" has type char nt_checked[6]. The type is altered during type checking
+  // to nt_array_ptr<char>.
+  nt_array_ptr<char> p = "hello";
+
+  // "goodbye" has type char nt_checked[8]. The type is altered during type checking
+  // checking to the pointer type array_ptr.
+  array_ptr<char> r = "goodbye";
+
+  // Use compound array literals instead.
+  p = (char nt_checked[6]) { 'h', 'e', 'l', 'l', 'o', '\0' };
+  r = (char checked[8] { 'g', 'o', 'o', 'd', 'b', 'y', 'e', '\0' };
+}
+
+checked char lookup(int i) {
+  // "abcdef" has type char nt_checked[7]. The type is altered during type checking
+  // to nt_array_ptr<char>. The subscript operation will be bounds checked.
+  return "abcdef"[i];
+}
+
+unchecked char unsafe_lookup(int i) {
+  // "abcdef" has type char[7]. The type is altered during type checking
+  // to char *. The subscript operation will not be bounds checked.
+  return "abcdef"[i];
+}
+
+// find pattern in str
+extern int find(nt_array_ptr<char> pattern, nt_array_ptr<char> str);
+
+int g(void) {
+  // "brown" has type char[6]. The type is altered during type checking
+  // to the type char *. It is then further altered to have the type
+  // nt_array_ptr<char>, matching the argument type for pattern.
+  // A similar alteration happens for the second argument string literal.
+
+  int r = find("brown", "the brown fox jumped over the fence");
+}
+
+// Declare a string with a count.
+struct string_with_count {
+  nt_array_ptr<char> buf;
+  int len;
+}
+
+ptr<struct string_with_count> S =
+   &((struct string_with_count) { "hello world", 11 });
+\end{verbatim}
 
 \section{Relative alignment of \arrayptr\ values}
 \label{section:relative-alignment}

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -583,8 +583,12 @@ called does not have to be declared as checked. The notion of whether a
 scope is checked or not checked is lexical and the function definition
 is a separate lexical scope.
 
-C allows declarations of functions without prototypes, where the types 
-of the arguments to functions are not specified.  These
+C allows declarations of functions without prototypes\footnote{These are sometimes
+referred to as K\&R-style function declarations because this is the only way
+functions were  declared in the first edition of the C Programming Language book
+by Brian Kernigan and Dennis Ritchie. The second edition incorporated changes from the
+C ANSI Standard and introduced function prototypes.}, where the types
+of the arguments to functions are not specified .  These
 functions are dangerous to use because there can be mismatches 
 between argument types and parameter types at function
 calls.  This can corrupt data or the call stack.  In checked scopes, 
@@ -718,7 +722,11 @@ For Checked C, no modifications are needed to initializers.
 the value of the initializer is interpreted based on the type of the
 declared variable and its members.  A checked array or pointer is initialized
 the same way that an unchecked array or pointer is initialized.  For
-null-terminated checked arrays, we require that
+null-terminated checked arrays, we require that the last element in the
+array be initialized to a null terminator.\footnote{There does not need to
+be a full list of initialization values. An initializer with a partial list of
+initialization values will still meet this requirement.   The default for integers
+and pointers is 0,  which is the null terminator for those values.}
 
 A variety of interesting and complex initialized checked data structures can be
 declared:

--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -706,6 +706,84 @@ ptr<struct string_with_count> S =
    &((struct string_with_count) { "hello world", 11 });
 \end{verbatim}
 
+\subsection{Initializers}
+C allows declarations to be initialized using initializers.  An initializer
+is either an expression or a brace-enclosed list of initialization values.
+The brace-enclosed list may be a partial list and specify values only for
+part of an object or array.  In that case, the remaining part of the
+array or object is initialized with default values (0 for integers or
+pointers).
+
+For Checked C, no modifications are needed to initializers.
+the value of the initializer is interpreted based on the type of the
+declared variable and its members.  A checked array or pointer is initialized
+the same way that an unchecked array or pointer is initialized.  For
+null-terminated checked arrays, we require that
+
+A variety of interesting and complex initialized checked data structures can be
+declared:
+\begin{verbatim}
+// Initialize a checked pointer to the null pointer.
+ptr<int> p = 0;
+
+// Initialize a checked array.
+int arr1 checked[5] = { 0, 1, 2, 3, 4 };
+int arr2 checked[3] = { 0, 1, 2 };
+
+struct Pair {
+  int len1;
+  array_ptr<int> buf1;
+  int len2;
+  array_ptr<int> buf2;
+};
+
+// Initialize all members of an instance of Pair.
+struct Pair p1 = { 5, arr1, 3, arr2 };
+
+// Declare a partial initializer for an instance of Pair.
+// len2 and buf2 are initialized to 0.
+struct Pair p2 =  { 0, arr1 };
+
+// Strings and initialized arrays of characters.
+
+nt_array_ptr<char> red = "red";
+char green checked[] = "green";
+char blue nt_checked[] = "blue";
+char purple nt_checked[7] = "purple";
+
+// Checked arrays of checked strings
+nt_array_ptr<char> colors checked[] = { "red", "green", "blue", "purple" };
+
+// Null-terminated arrays of checked strings
+nt_array_ptr<char> more_colors nt_checked[] = { "white", "black", "grey", 0 };
+
+// Multi-dimensional checked arrays
+float unit_transform checked[2][2] = { { 1.0f, 0.0f}, { 0.0f, 1.0f }};
+
+// A null-terminated array of pointers to null-terminated arrays
+// of strings.
+nt_array_ptr<nt_array_ptr<char>> sentences nt_checked[4] = 
+  {  (nt_array_ptr<char> nt_checked[]) { "this", "is", "the", "first sentence", 0 },
+     (nt_array_ptr<char> nt_checked[]) { "here", "is", "another", 0 },
+     (nt_array_ptr<char> nt_checked[]) { "this", "is", "the", "last", "one", 0 },
+     0
+   };
+\end{verbatim}
+
+% TODO - rethink this example, as it isn't legal C code.
+% // A ragged 2-dimensional array, where the inner dimension size varies.
+% struct counted_arr {
+%  int len;
+%  double elems checked[];  // bounds declaration missing because we
+%                           // haven't described them yet.
+%};
+
+% typedef ptr<counted_arr> ragged_arr[];
+% count_arr dim1 = { 3, { 5.0, 6.0, 7.0} };
+% count_arr dim2 = { 2, { 5.0, 6.0} };
+% count_arr dim3 = { 1, { 5.0 } };
+% ragged_arr data = { &dim1, &dim2, &dim3 };
+
 \section{Relative alignment of \arrayptr\ values}
 \label{section:relative-alignment}
 


### PR DESCRIPTION
Describe extensions to C typing rules that allow literals to be used in checked scopes or where expressions with checked pointers are expected.   This completes the work for issue #207.   For checked scopes, string literals are given the type "null-terminated checked array of character", where "character" is the character type for the string literal.   For contexts where an expression with a checked pointer type is expected but not found, convert string literals and compound array literals to checked pointer types.

Also describe the rules for initializers.   The types of initializers are determined by the  type of the variable being declared, so there isn't any change need for checked C.  

Add examples.

Move the section describing checked scopes earlier in Chapter 2, so that it precedes the discussion of literals (this is most of the change diff shown on GitHub).

