### PR TITLE
Fix typos found during review of literals section.

### DIFF
--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -651,15 +651,15 @@ of string literals are expressions such as \keyword{"hello"} and \keyword{L"hell
 (in the latter case, the modifier `L' changes the type of the characters in the string).
 A compound literal is an expression that declares an array literal or an object literal.
 It consists of a parenthesized type name followed by list of initializers in braces.
-A compound literal has static storage if its at the top level of a file and automatic
+A compound literal has static storage if it is at the top level of a file and automatic
 storage if it occurs within a block.  Here are examples of compound literals:
 \begin{verbatim}
 int *arr = (int []) { 0, 1, 2};
 struct Point {
   int x;
   int y;
-}
-struct S *zero_coord = &((struct Point) { 0, 0 };
+};
+struct Point *zero_coord = &((struct Point) { 0, 0 });
 \end{verbatim}
 
 A string literal has an array type with an element type that is one of \keyword{char},
@@ -674,7 +674,7 @@ in a checked scope or an unchecked scope:
 
 This creates an issue in unchecked scopes when a string literal is used where
 a null-terminated checked pointer type is expected.  It makes sense to allow
-this because string literals has known bounds.  However, a string
+this because string literals have known bounds.  However, a string
 literal would have the type ``unchecked array of \var{T}'', which
 would convert to ``unchecked pointer to \var{T}''.
 There is no conversion from the unchecked pointer type to
@@ -697,7 +697,7 @@ compound array literal could be modified, of course.  We allow this rule anyway 
 the amount of code changes required to modify code to be checked.
 
 Note that some C compilers use the same memory to represent different
-occurrenes of string literals that have the same characters
+occurrences of string literals that have the same characters
 sequence.  The meaning of modifying a string literal is implementation-dependent.
 For bounds safety, an implementation should either
 \begin{itemize}
@@ -718,7 +718,7 @@ checked void f(void) {
 
   // Use compound array literals instead.
   p = (char nt_checked[6]) { 'h', 'e', 'l', 'l', 'o', '\0' };
-  r = (char checked[8] { 'g', 'o', 'o', 'd', 'b', 'y', 'e', '\0' };
+  r = (char checked[8]) { 'g', 'o', 'o', 'd', 'b', 'y', 'e', '\0' };
 }
 
 checked char lookup(int i) {
@@ -743,13 +743,14 @@ int g(void) {
   // A similar alteration happens for the second argument string literal.
 
   int r = find("brown", "the brown fox jumped over the fence");
+  return r;
 }
 
 // Declare a string with a count.
 struct string_with_count {
   nt_array_ptr<char> buf;
   int len;
-}
+};
 
 ptr<struct string_with_count> S =
    &((struct string_with_count) { "hello world", 11 });
@@ -833,7 +834,7 @@ nt_array_ptr<char> colors checked[] = { "red", "green", "blue", "purple" };
 // Null-terminated arrays of checked strings
 nt_array_ptr<char> more_colors nt_checked[] = { "white", "black", "grey", 0 };
 
-// A null-terminated array of ponters to null-terminated arrays
+// A null-terminated array of pointers to null-terminated arrays
 // of strings.
 nt_array_ptr<nt_array_ptr<char>> sentences nt_checked[4] = 
   {  (nt_array_ptr<char> nt_checked[]) { "this", "is", "the", "first sentence", 0 },
@@ -842,8 +843,6 @@ nt_array_ptr<nt_array_ptr<char>> sentences nt_checked[4] =
      0
    };
 \end{verbatim}
-
-
 
 \section{Relative alignment of \arrayptr\ values}
 \label{section:relative-alignment}

--- a/spec/bounds_safety/related-work.tex
+++ b/spec/bounds_safety/related-work.tex
@@ -370,7 +370,7 @@ the program is free of pointer type
 cast or memory management errors, Checked C provides a strong
 guarantee about memory reads and writes. Any pointer must have been constructed
 via a  series of operations from a pointer to an object.   Checked C ensures 
-that the constructed ponter only accesses memory within that object.  
+that the constructed pointer only accesses memory within that object.
 
 Checked C programs 
 remain vulnerable  to incorrect pointer type casts, memory management errors, 


### PR DESCRIPTION
Fix typographical errors in the specification found during a review of the new section on string literals and compound literals.
