### PR TITLE
Add dynamic tests of reads/writes via pointers with null-terminated interface types.

### DIFF
--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -48,11 +48,16 @@ struct S {
 };
 
 void write_driver(int failure_point, int *a : count(10),
+                  char *b : itype(nt_array_ptr<char>),
                   struct S *s1 : itype(ptr<struct S>));
-void write_test(int failure_point, int *p : count(len), int len, struct S *s);
+void write_test(int failure_point, int *p : count(len), int len,
+                char *r : itype(nt_array_ptr<char>),
+                struct S *s : itype(ptr<struct S>));
 void read_driver(int failure_point, int *a : count(10),
+                 char *b : itype(nt_array_ptr<char>),
                  struct S *s1 : itype(ptr<struct S>));
 void read_test(int failure_point, int *p : count(len), int len,
+               char *r : itype(nt_array_ptr<char>),
                struct S *s : itype(ptr<struct S>));
 
 // This signature for main is exactly what we want here,
@@ -83,12 +88,13 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
   int read_target = atoi(argv[2]);
 
   int a[10] = { 0, 1, 2, 4, 5, 6, 7, 8, 9 };
-  int b[10] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
-  struct S s1 = { b, 10 };
+  char b nt_checked[5] = "abcd";
+  int tmp[10] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  struct S s1 = { tmp, 10 };
 
   // CHECK: Starting Test
   puts("Starting Test");
-  write_driver(write_target, a, &s1);
+  write_driver(write_target, a, b, &s1);
   if (write_target == 0) {
     // NO-BOUNDS-FAILURES: No bounds failure on write
     puts("No bounds failure on write");
@@ -98,7 +104,7 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
     puts("Expected bounds failure");
   }
 
-  read_driver(read_target, a, &s1);
+  read_driver(read_target, a, b, &s1);
   if (read_target == 0) {
     // NO-BOUNDS-FAILURES: No bounds failure on read
     puts("No bounds failure on read");
@@ -112,51 +118,52 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
 }
 
 void write_driver(int failure_point, int *a : count(10),
+                  char *b : itype(nt_array_ptr<char>),
                   struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
   switch (failure_point) {
     case 0: 
-      write_test(12, a, 10, s1);
+      write_test(13, a, 10, b, s1);
       break;
     case 1:
       global_arr_len = 0;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     case 2: 
       global_arr_len = 1;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     case 3:
       global_arr_len = 2;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     case 4:
       global_arr_len = 3;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     case 5:
-      write_test(failure_point, a, 0, s1);
+      write_test(failure_point, a, 0, b, s1);
       break;
     case 6:
-      write_test(failure_point, a, 1, s1);
+      write_test(failure_point, a, 1, b, s1);
       break;
     case 7:
-      write_test(failure_point, a, 2, s1);
+      write_test(failure_point, a, 2, b, s1);
       break;
     case 8:
-      write_test(failure_point, a, 3, s1);
+      write_test(failure_point, a, 3, b, s1);
       break;
     case 9:
       s1->len = 0;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     case 10:
       s1->len = 1;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     case 11:
       s1->len = 2;
-      write_test(failure_point, a, 10, s1);
+      write_test(failure_point, a, 10, b, s1);
       break;
     default:
       // CHECK-NOT Unexpected test case
@@ -167,6 +174,7 @@ void write_driver(int failure_point, int *a : count(10),
 }
 
 void write_test(int failure_point, int *p : count(len), int len,
+                char *r : itype(nt_array_ptr<char>),
                 struct S *s : itype(ptr<struct S>)) checked {
   *global_arr = 100;
   if (failure_point == 1) goto unexpected_success;
@@ -201,6 +209,14 @@ void write_test(int failure_point, int *p : count(len), int len,
   s->f[2] = 302;
   if (failure_point == 11) goto unexpected_success;
 
+  if (*r) {
+    int i = 1;
+    nt_array_ptr<char> tmp1 : count(i) = r;
+    *tmp1 = 'z';
+  }
+
+  if (failure_point == 12) goto unexpected_success;
+
   return;
 
 unexpected_success:
@@ -213,51 +229,52 @@ unexpected_success:
 }
 
 void read_driver(int failure_point, int *a : count(10),
-                  struct S *s1 : itype(ptr<struct S>)) {
+                 char *b : itype(nt_array_ptr<char>),
+                 struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
   switch (failure_point) {
     case 0:
-      read_test(12, a, 10, s1);
+      read_test(13, a, 13, b, s1);
       break;
     case 1:
       global_arr_len = 0;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     case 2:
       global_arr_len = 1;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     case 3:
       global_arr_len = 2;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     case 4:
       global_arr_len = 3;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     case 5:
-      read_test(failure_point, a, 0, s1);
+      read_test(failure_point, a, 0, b, s1);
       break;
     case 6:
-      read_test(failure_point, a, 1, s1);
+      read_test(failure_point, a, 1, b, s1);
       break;
     case 7:
-      read_test(failure_point, a, 2, s1);
+      read_test(failure_point, a, 2, b, s1);
       break;
     case 8:
-      read_test(failure_point, a, 3, s1);
+      read_test(failure_point, a, 3, b, s1);
       break;
     case 9:
       s1->len = 0;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     case 10:
       s1->len = 1;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     case 11:
       s1->len = 2;
-      read_test(failure_point, a, 10, s1);
+      read_test(failure_point, a, 10, b, s1);
       break;
     default:
       // CHECK-NOT Unexpected test case
@@ -267,6 +284,7 @@ void read_driver(int failure_point, int *a : count(10),
   }
 }
 void read_test(int failure_point, int *p : count(len), int len, 
+               char *r : itype(nt_array_ptr<char>),
                struct S *s : itype(ptr<struct S>)) checked {
   if (*global_arr != 100) goto fail;
   if (failure_point == 1) goto unexpected_success;
@@ -300,6 +318,9 @@ void read_test(int failure_point, int *p : count(len), int len,
 
   if (s->f[2] != 302) goto fail;
   if (failure_point == 11) goto unexpected_success;
+
+  if (*r != 'z') goto fail;
+  if (failure_point == 12) goto unexpected_success;
 
   return;
 

--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -1,7 +1,7 @@
 // Test bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang %s -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %s -o %t1 -Wno-unused-value
 // RUN:  %t1 0 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
 // RUN:  %t1 1 0 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 2 0 | FileCheck %s --check-prefixes=CHECK
@@ -14,6 +14,7 @@
 // RUN:  %t1 9 0 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 10 0 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 11 0 | FileCheck %s --check-prefixes=CHECK
+// RUN:  %t1 12 0 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 0 1 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 0 2 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 0 3 | FileCheck %s --check-prefixes=CHECK
@@ -25,6 +26,7 @@
 // RUN:  %t1 0 9 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 0 10 | FileCheck %s --check-prefixes=CHECK
 // RUN:  %t1 0 11 | FileCheck %s --check-prefixes=CHECK
+// RUN:  %t1 0 12 | FileCheck %s --check-prefixes=CHECK
 
 
 #include <assert.h>
@@ -51,13 +53,13 @@ void write_driver(int failure_point, int *a : count(10),
                   char *b : itype(nt_array_ptr<char>),
                   struct S *s1 : itype(ptr<struct S>));
 void write_test(int failure_point, int *p : count(len), int len,
-                char *r : itype(nt_array_ptr<char>),
+                char *r : itype(nt_array_ptr<char>), int pos,
                 struct S *s : itype(ptr<struct S>));
 void read_driver(int failure_point, int *a : count(10),
                  char *b : itype(nt_array_ptr<char>),
                  struct S *s1 : itype(ptr<struct S>));
 void read_test(int failure_point, int *p : count(len), int len,
-               char *r : itype(nt_array_ptr<char>),
+               char *r : itype(nt_array_ptr<char>), int pos,
                struct S *s : itype(ptr<struct S>));
 
 // This signature for main is exactly what we want here,
@@ -117,53 +119,59 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
   return EXIT_SUCCESS;
 }
 
+// Invoke write_test, setting up conditions to cause
+// a failure at the test specified by failure_point.
+// When failure_point is 0, all tests in write_test should pass.
 void write_driver(int failure_point, int *a : count(10),
                   char *b : itype(nt_array_ptr<char>),
                   struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
   switch (failure_point) {
     case 0: 
-      write_test(13, a, 10, b, s1);
+      write_test(13, a, 10, b, 0, s1);
       break;
     case 1:
       global_arr_len = 0;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b, 0, s1);
       break;
     case 2: 
       global_arr_len = 1;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b, 0, s1);
       break;
     case 3:
       global_arr_len = 2;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b, 0, s1);
       break;
     case 4:
       global_arr_len = 3;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b, 0, s1);
       break;
     case 5:
-      write_test(failure_point, a, 0, b, s1);
+      write_test(failure_point, a, 0, b, 0, s1);
       break;
     case 6:
-      write_test(failure_point, a, 1, b, s1);
+      write_test(failure_point, a, 1, b, 0, s1);
       break;
     case 7:
-      write_test(failure_point, a, 2, b, s1);
+      write_test(failure_point, a, 2, b, 0, s1);
       break;
     case 8:
-      write_test(failure_point, a, 3, b, s1);
+      write_test(failure_point, a, 3, b, 0, s1);
       break;
     case 9:
       s1->len = 0;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b, 0, s1);
       break;
     case 10:
       s1->len = 1;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b,  0, s1);
       break;
     case 11:
       s1->len = 2;
-      write_test(failure_point, a, 10, b, s1);
+      write_test(failure_point, a, 10, b, 0, s1);
+      break;
+    case 12:
+      write_test(failure_point, a, 10, b, 1, s1);
       break;
     default:
       // CHECK-NOT Unexpected test case
@@ -173,8 +181,23 @@ void write_driver(int failure_point, int *a : count(10),
   }
 }
 
+// Executes a sequences of tests, expects to fail on the nth test
+// specified by failure_point. If failure_point is 0, no tests should
+// fail.
+//
+// For tests of array_ptrs, the appropriate parameter, global variable, or
+// structure member should be to set to provoke failure:
+// - len is the bounds for p.
+// - global_arr_len is the bounds for global_arr
+// - S is pointer to a struct with a pointer whose bounds is
+// is given by a member.
+//
+// For nt_array_ptr, we can't specify the length yet. The length
+// is inferred to be 0, which means we can read the 0th element and
+// write a null value to the the 0th element.  We intead specify
+// a position about 0 to write as a means of forcing a failure.
 void write_test(int failure_point, int *p : count(len), int len,
-                char *r : itype(nt_array_ptr<char>),
+                char *r : itype(nt_array_ptr<char>), int pos,
                 struct S *s : itype(ptr<struct S>)) checked {
   *global_arr = 100;
   if (failure_point == 1) goto unexpected_success;
@@ -209,12 +232,7 @@ void write_test(int failure_point, int *p : count(len), int len,
   s->f[2] = 302;
   if (failure_point == 11) goto unexpected_success;
 
-  if (*r) {
-    int i = 1;
-    nt_array_ptr<char> tmp1 : count(i) = r;
-    *tmp1 = 'z';
-  }
-
+  r[pos] = '\0';
   if (failure_point == 12) goto unexpected_success;
 
   return;
@@ -228,53 +246,58 @@ unexpected_success:
   return;
 }
 
+// Invoke read_test, setting up conditions to cause
+// a failure at the test specified by failure_point.
 void read_driver(int failure_point, int *a : count(10),
                  char *b : itype(nt_array_ptr<char>),
                  struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
   switch (failure_point) {
     case 0:
-      read_test(13, a, 13, b, s1);
+      read_test(13, a, 13, b, 0, s1);
       break;
     case 1:
       global_arr_len = 0;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
       break;
     case 2:
       global_arr_len = 1;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
       break;
     case 3:
       global_arr_len = 2;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
       break;
     case 4:
       global_arr_len = 3;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
       break;
     case 5:
-      read_test(failure_point, a, 0, b, s1);
+      read_test(failure_point, a, 0, b, 0, s1);
       break;
     case 6:
-      read_test(failure_point, a, 1, b, s1);
+      read_test(failure_point, a, 1, b, 0, s1);
       break;
     case 7:
-      read_test(failure_point, a, 2, b, s1);
+      read_test(failure_point, a, 2, b, 0, s1);
       break;
     case 8:
-      read_test(failure_point, a, 3, b, s1);
+      read_test(failure_point, a, 3, b, 0, s1);
       break;
     case 9:
       s1->len = 0;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
       break;
     case 10:
       s1->len = 1;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
       break;
     case 11:
       s1->len = 2;
-      read_test(failure_point, a, 10, b, s1);
+      read_test(failure_point, a, 10, b, 0, s1);
+      break;
+    case 12:
+      read_test(failure_point, a, 10, b, 1, s1);
       break;
     default:
       // CHECK-NOT Unexpected test case
@@ -283,8 +306,12 @@ void read_driver(int failure_point, int *a : count(10),
 
   }
 }
+
+// Like write_test, but does read operations instead.  It also verify
+// that the data read is what is expected to be written by write_test,
+// if it succeeds.
 void read_test(int failure_point, int *p : count(len), int len, 
-               char *r : itype(nt_array_ptr<char>),
+               char *r : itype(nt_array_ptr<char>), int pos,
                struct S *s : itype(ptr<struct S>)) checked {
   if (*global_arr != 100) goto fail;
   if (failure_point == 1) goto unexpected_success;
@@ -319,7 +346,7 @@ void read_test(int failure_point, int *p : count(len), int len,
   if (s->f[2] != 302) goto fail;
   if (failure_point == 11) goto unexpected_success;
 
-  if (*r != 'z') goto fail;
+  if (r[pos] != 0) goto fail;
   if (failure_point == 12) goto unexpected_success;
 
   return;


### PR DESCRIPTION
Add runtime testing of reads and writes through pointers with null-terminated interface types.  A pointer with a null-terminated type with no bounds information has a bounds of count(0).  A program can read the element at the pointer and write null.   Other reads/writes will cause bounds checking failures.   This covers https://github.com/microsoft/checkedc-clang/issues/449 and more.

I extended bounds-safe-interfaces.c, which runs a sequence of read/tests, expecting conditions to be set properly for the nth test in the sequence to fail.   For bounds-safe interfaces for null-terminated types, we currently have no way to specify a length.  In this case, the bounds are fixed.  Instead, we vary the position where the read/write occurs to force a failure.
