### PR TITLE
Test interface types combined with bounds expressions.

### DIFF
--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -135,9 +135,11 @@ size_t strspn(const char *s1 : itype(_Nt_array_ptr<const char>),
 char *strstr(const char *s1 : itype(_Nt_array_ptr<const char>),
              const char *s2 : itype(_Nt_array_ptr<const char>)) :
   itype(_Nt_array_ptr<char>);
+// TODO: remove count(0) on return value after
+// https://github.com/Microsoft/checkedc-clang/issues/424 is addressed
 char *strtok(char * restrict s1 : itype(restrict _Nt_array_ptr<char>),
              const char * restrict s2 : itype(restrict _Nt_array_ptr<const char>)) :
-  itype(_Nt_array_ptr<char>);
+  itype(_Nt_array_ptr<char>) count(0);
 
 char *strerror(int errnum) : itype(_Nt_array_ptr<char>);
 size_t strlen(const char *s : itype(_Nt_array_ptr<const char>));

--- a/tests/parsing/interop_and_bounds.c
+++ b/tests/parsing/interop_and_bounds.c
@@ -1,0 +1,147 @@
+// Feature tests of parsing Checked C bounds annotations where an interop type
+// and bounds annotation are declared for a variable or member with unchecked
+// pointer type.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+//
+// parameters with interop type annotations
+//
+
+// First parameter has bounds annotations that use second parameter.
+extern void f1(int **p : count(y) itype(array_ptr<ptr<int>>), int y) {
+}
+
+extern void f2(int **p : itype(array_ptr<ptr<int>>) count(y), int y) {
+}
+
+extern void f3(int **p : bounds(p, p + y) itype(array_ptr<ptr<int>>), int y) {
+}
+
+extern void f4(int **p : itype(array_ptr<ptr<int>>) bounds(p, p + y), int y) {
+}
+
+extern void f5(int **p : byte_count(y) itype(array_ptr<ptr<int>>), int y) {
+}
+
+extern void f6(int **p : itype(array_ptr<ptr<int>>) byte_count(y), int y) {
+}
+
+
+extern void f10(int **p : count(y) itype(ptr<int> checked[]), int y) {
+}
+
+extern void f11(int **p : itype(ptr<int> checked[]) count(y), int y) {
+}
+
+extern void f12(int **p : itype(ptr<int> checked[10]) count(10), int y) {
+}
+
+extern void f13(int **p : count(10) itype(ptr<int> checked[10]), int y) {
+}
+
+// Second parameter has interop type annotation
+extern void g1(int y, int **p : count(y) itype(array_ptr<ptr<int>>)) {
+}
+
+extern void g2(int y, int **p : itype(array_ptr<ptr<int>>) count(y)) {
+}
+
+extern void g3(int y, int **p : bounds(p, p + y) itype(array_ptr<ptr<int>>)) {
+}
+
+extern void g4(int y, int **p : itype(array_ptr<ptr<int>>) bounds(p, p + y)) {
+}
+
+extern void g5(int y, int **p : byte_count(y) itype(array_ptr<ptr<int>>)) {
+}
+
+extern void g6(int y, int **p : itype(array_ptr<ptr<int>>) byte_count(y)) {
+}
+
+
+extern void g10(int y, int **p : count(y) itype(ptr<int> checked[])) {
+}
+
+extern void g11(int y, int **p : itype(ptr<int> checked[]) count(y)) {
+}
+
+extern void g12(int y, int **p : itype(ptr<int> checked[10]) count(10)) {
+}
+
+extern void g13(int y, int **p : count(10) itype(ptr<int> checked[10])) {
+}
+
+//
+// returns an unchecked pointer type with an
+// interop type annotation.
+//
+
+extern int **h1(int y, ptr<int> p) : itype(array_ptr<ptr<int>>) byte_count(y) {
+   *p = y;
+   return 0;
+}
+
+extern int **h2(int y, ptr<int> p) :  count(y) itype(array_ptr<ptr<int>>) {
+   *p = y;
+   return 0;
+}
+
+
+//
+// Global variables with interop type and bounds annotations
+//
+
+int size;
+int **a1 : itype(array_ptr<ptr<int>>) count(size) = 0;
+int **a2 : count(size) itype(array_ptr<array_ptr<int>>) = 0;
+int a3[10] : itype(int checked[10]) byte_count(10 * sizeof(int));
+extern int a4[] : count(size) itype(int checked[]);
+
+//
+// Structure members with interop pointer type annotations
+//
+
+struct S1 {
+  int len;
+  float *data1 : count(len) itype(array_ptr<float>);
+  float *data2 : itype(array_ptr<float>) count(len);
+  float **data3 : bounds(data3, data3 + len) itype(array_ptr<ptr<float>>);
+  float **data4 : itype(array_ptr<ptr<float>>) bounds(data3, data3 + len);
+  float data5[4] : itype(float checked[4]) count(3);
+  float data6[4] :  count(3) itype(float checked[4]);
+  float *data7[] : itype(ptr<float> checked[]) count(len);
+};
+
+struct S2 {
+  int len;
+  // Test another case a flexible array member at the end of struct 
+  float *data7[] : count(len) itype(ptr<float> checked[]);
+};
+
+///
+/// Typedef'ed names can be used as interop types
+///
+
+typedef array_ptr<ptr<int>> ppint;
+typedef ptr<const int> pcint;
+
+extern void f40(int **x : itype(ppint) bounds(x, x + len), int len) {
+}
+
+extern void f41(int **x : count(len) itype(ppint), int len) {
+}
+
+/// Test some error condtions
+
+extern void f50(int **x : itype(ppint) itype(ppint));   // expected-error {{only one itype expression allowed}}
+
+extern void f51(int **x : count(5) count(6));           // expected-error {{only one bounds expression allowed}}
+
+extern void f53(int ** x : itype(ppint) count(5) itype(ppint));  // expected-error {{only one itype expression allowed}}
+
+extern void f53(int ** x : count(5) itype(ppint) count(5));      // expected-error {{only one bounds expression allowed}}

--- a/tests/parsing/rel_align.c
+++ b/tests/parsing/rel_align.c
@@ -234,7 +234,7 @@ extern array_ptr<int> f27(int len, array_ptr<int> arr : count(len)) : boounds() 
 extern void f28(void) {
   array_ptr<int> arg : bo0unds(arg, arg + 5) rel_alive(1) = 0;  // expected-error {{expected bounds expression or bounds-safe interface type}}
   array_ptr<int> arg1 : bo0unds rel_alive(1) = 0;  // expected-error {{expected bounds expression or bounds-safe interface type}}
-  array_ptr<int> arg2 : bo0unds rel_align(1) = 0;  // expected-error {{expected bounds expression or bounds-safe interface type}}  expected-error {{expected a type}}
+  array_ptr<int> arg2 : bo0unds rel_align(1) = 0;  // expected-error {{expected bounds expression or bounds-safe interface type}}
 }
 
 struct S1 {

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -239,9 +239,11 @@ checked void f10a(int *p : itype(ptr<int>));
 checked void f11a(int *p : count(4));
 checked void f11b(int *p : bounds(p, p + 4));
 checked void f11c(int *p : byte_count(4 * sizeof(int)));
-checked void f12d(int *lower : itype(array_ptr<int>),
+checked void f11d(int *lower : itype(array_ptr<int>),
                   int *upper : itype(array_ptr<int>),
                   int buf : bounds(lower, upper));
+checked void f11e(char *buf : bounds(buf, end),
+                  char *end : itype(_Array_ptr<char>));
 checked void f12a(int *p : itype(array_ptr<int>));
 checked void f13a(int *p : itype(int checked[]));
 checked void f14a(int *p : itype(int checked[4]));

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -24,6 +24,8 @@ void f3(int *p : byte_count(len * sizeof(int)), int len);
 void f4(int *p, int len);
 void f4(int *p : itype(ptr<int>), int len);
 
+void f4a(char *p : itype(nt_array_ptr<char>), int len);
+
 // Order doesn't matter for declarations
 void f5(int *p : count(len), int len);
 void f5(int *p, int len);
@@ -36,6 +38,9 @@ void f7(int *p, int len);
 
 void f8(int *p : itype(ptr<int>), int len);
 void f8(int *p, int len);
+
+void f8a(char * : itype(nt_array_ptr<char>), int len);
+void f8a(char *, int len);
 
 //---------------------------------------------------------------------------//
 // Declarations of functions that return unchecked types are compatible      //
@@ -51,6 +56,9 @@ int *f21(int len) : byte_count(len * sizeof(int));
 int *f22(int len);
 int *f22(int len) : itype(ptr<int>);
 
+char *f22a(int len);
+char *f22a(int len) : itype(nt_array_ptr<char>);
+
 // Order doesn't matter
 int *f23(int len) : count(len);
 int *f23(int len);
@@ -61,10 +69,17 @@ int *f24(int len);
 int *f25(int len) : itype(ptr<int>);
 int *f25(int len);
 
+char *f25a(int len) : itype(nt_array_ptr<char>);
+char *f25a(int len);
+
 //---------------------------------------------------------------------------//
-// Redeclarations of functions that have parameters that have bounds-safe    //
-// interfaces must have matching interfaces.                                 //
+// Redeclarations of functions that have parameters with unchecked types     //
+// that have bounds-safe interfaces must have matching interfaces.            //
 //---------------------------------------------------------------------------//
+
+//
+// Only bounds declarations
+//
 
 void f30(int *p : count(len), int len);
 void f30(int *p : count(len), int len);
@@ -93,6 +108,53 @@ void f34(int *p : count(len), int len);  // expected-error {{added bounds for pa
 
 void f35(int *p : count(len), int len);
 void f35(int *p : itype(ptr<int>), int len); // expected-error {{dropped bounds for parameter}}
+
+//
+// Bounds declarations plus interface types
+//
+
+// Identical declarations and interface types.
+void f30a(int **p : count(len) itype(array_ptr<ptr<int>>), int len);
+void f30a(int **p : count(len) itype(array_ptr<ptr<int>>), int len);
+
+void f30b(int **p : count(len) itype(nt_array_ptr<ptr<int>>), int len);
+void f30b(int **p : count(len) itype(nt_array_ptr<ptr<int>>), int len);
+
+// Implied interface type.
+void f30c(int **p : count(len) itype(array_ptr<int *>), int len);
+void f30c(int **p : count(len), int len);
+
+void f30d(int **p : count(len), int len);
+void f30d(int **p : count(len) itype(array_ptr<int *>), int len);
+
+// Mismatched bounds declaration.
+void f30e(int **p : count(len) itype(array_ptr<ptr<int>>), int len);
+void f30e(int **p : count(len + 1) itype(array_ptr<ptr<int>>), int len);  // expected-error {{conflicting parameter bounds}}
+
+// Mismatched interface type declaration.
+void f30f(int **p : count(len) itype(array_ptr<ptr<int>>), int len);
+void f30f(int **p : count(len) itype(array_ptr<int *>), int len);  // expected-error {{conflicting parameter interop type}}
+
+// Dropped bounds declaration.
+void f30g(int **p : count(len) itype(array_ptr<ptr<int>>), int len);
+void f30g(int **p : itype(array_ptr<ptr<int>>), int len);  // expected-error {{dropped bounds for parameter}}
+
+// Added bounds declaration.
+void f30h(int **p : itype(array_ptr<ptr<int>>), int len);
+void f30h(int **p : count(len) itype(array_ptr<ptr<int>>), int len);  // expected-error {{added bounds for parameter}}
+
+// Dropped interface type.
+void f30i(int **p : count(len) itype(array_ptr<ptr<int>>), int len);
+void f30i(int **p : count(len), int len);  // expected-error {{conflicting parameter interop type}}
+
+// Added interface type.
+void f30j(int **p : count(len), int len);
+void f30j(int **p : count(len) itype(array_ptr<ptr<int>>), int len);    // expected-error {{conflicting parameter interop type}}
+
+// nt_array_ptr type implies count(0)
+void f30k(char *p : itype(nt_array_ptr<char>));
+void f30k(char *p : itype(nt_array_ptr<char>) count(0));
+void f30k(char *p : itype(nt_array_ptr<char>) count(1));  // expected-error {{conflicting parameter bounds}}
 
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have parameters that have bounds         //
@@ -150,6 +212,54 @@ int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // exp
 int *f54(int len) : itype(ptr<int>);
 int *f54(int len) : count(len);  // expected-error {{added return bounds}}
 
+//
+// Bounds declarations plus interface types
+//
+
+// Identical declarations and interface types.
+int **f50a(int len) : count(len) itype(array_ptr<ptr<int>>);
+int **f50a(int len) : count(len) itype(array_ptr<ptr<int>>);
+
+int **f50b(int len) : count(len) itype(nt_array_ptr<ptr<int>>);
+int **f50b(int len) : count(len) itype(nt_array_ptr<ptr<int>>);
+
+// Implied interface type.
+int **f50c(int len) : count(len);
+int **f50c(int len) : count(len) itype(array_ptr<int *>);
+
+int **f50d(int len) : count(len) itype(array_ptr<int *>);
+int **f50d(int len) : count(len);
+
+// Mismatched bounds declaration.
+int **f50e(int len) : count(len) itype(array_ptr<ptr<int>>);
+int **f50e(int len) : count(len+1) itype(array_ptr<ptr<int>>);  // expected-error {{conflicting return bounds}}
+
+// Mismatched interface type declaration.
+int **f50f(int len) : count(len) itype(array_ptr<ptr<int>>);
+int **f50f(int len) : count(len) itype(array_ptr<int *>);  // expected-error {{conflicting return interop type}}
+
+// Dropped bounds declaration.
+int **f50g(int len) : count(len) itype(array_ptr<ptr<int>>);
+int **f50g(int len) : itype(array_ptr<ptr<int>>);  // expected-error {{dropped return bounds}}
+
+// Added bounds declaration.
+int **f50h(int len) : itype(array_ptr<ptr<int>>);
+int **f50h(int len) : count(len) itype(array_ptr<ptr<int>>);  // expected-error {{added return bounds}}
+
+// Dropped interface type.
+int **f50i(int len) : count(len) itype(array_ptr<ptr<int>>);
+int **f50i(int len) : count(len);  // expected-error {{conflicting return interop type}}
+
+// Added interface type.
+int **f50j(int len) : count(len);
+int **f50j(int len) : count(len) itype(array_ptr<ptr<int>>); // expected-error {{conflicting return interop type}}
+
+// nt_array_ptr type implies count(0)
+char *f50k(int len) : itype(nt_array_ptr<char>) count(0);
+// TODO: inference of inferring return bounds isn't working properly.
+// char *f50k(int len) : itype(nt_array_ptr<char>);
+char *f50k(int len) : itype(nt_array_ptr<char>) count(1);  // expected-error {{conflicting return bounds}}
+
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have bounds declarations for returns     //
 // must have matching declarations.                                          //
@@ -170,7 +280,6 @@ array_ptr<int> f62(int len) : count(len);   // expected-error {{function redecla
 array_ptr<int> f63(int len) : count(len);
 array_ptr<int> f63(int len);                // expected-error {{function redeclaration dropped return bound}}
 
-
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have parameters with function pointer    //
 // types that have bounds-safe interfaces must have matching bounds-safe     //
@@ -188,14 +297,14 @@ void f70(int * (fn(int *, int *)) :
 void f70(int * (fn(int * : itype(ptr<int>), int * : itype(ptr<int>))) :
   itype(array_ptr<int>(ptr<int>, ptr<int>)));
 // return type of itype differs.
-void f70(int (*fn(int *, int *)) : itype(ptr<int> (ptr<int>, ptr<int>))); // expected-error {{function redeclaration has conflicting parameter bounds}}
+void f70(int (*fn(int *, int *)) : itype(ptr<int> (ptr<int>, ptr<int>))); // expected-error {{function redeclaration has conflicting parameter interop type}}
 // changed interface types for parameters of function pointer
 void f70(int * (fn(int * : itype(array_ptr<int>), int * : itype(array_ptr<int>)))); // expected-error {{conflicting bounds}}
 
 // Interface type on parameters of a function pointer type
 void f71(int * fn(int *, int *));
 void f71(int * fn(int * : count(5), int *: count(5)));
-void f71(int * fn(int * : count(6), int * : count(6))); // expected-error {{conflicting bounds for 'f71'}}
+void f71(int * fn(int * : count(6), int * : count(6))); // expected-error {{conflicting bounds annotations for 'f71'}}
 
 // Interface type on return value of a function pointer type
 void f72(int * fn(int *, int *));
@@ -222,19 +331,19 @@ void f81(int *p : bounds(p, p + len), int len);  // expected-error {{conflicting
 
 void f90(void (*fnptr)(array_ptr<int> p1 : count(5)));
 void f90(void (*fnptr)(array_ptr<int> p2 : count(5)));
-void f90(void (*fnptr)(array_ptr<int> p1 : count(6)));  // expected-error {{conflicting bounds for 'f90'}}
+void f90(void (*fnptr)(array_ptr<int> p1 : count(6)));  // expected-error {{conflicting bounds annotations for 'f90'}}
 
 void f91(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 5), array_ptr<int> p1)> fnptr);
 void f91(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 5), array_ptr<int> p1)> fnptr);
-void f91(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 6), array_ptr<int> p1)> fnptr);  // expected-error {{conflicting bounds for 'f91'}}
+void f91(ptr<int(array_ptr<int> mid : bounds(p1, p1 + 6), array_ptr<int> p1)> fnptr);  // expected-error {{conflicting bounds annotations for 'f91'}}
 
 void f92(array_ptr<int>(*fnptr)(int i, int k) : count(i));
 void f92(array_ptr<int>(*fnptr)(int j, int k) : count(j));
-void f92(array_ptr<int>(*fnptr)(int j, int k) : count(k)); // expected-error {{conflicting bounds for 'f92'}}
+void f92(array_ptr<int>(*fnptr)(int j, int k) : count(k)); // expected-error {{conflicting bounds annotations for 'f92'}}
 
 void f93(array_ptr<int>(*fnptr)(void) : count(5));
 void f93(array_ptr<int>(*f)(void) : count(5));
-void f93(array_ptr<int>(*f)(void) : count(6));          // expected-error {{conflicting bounds for 'f93'}}
+void f93(array_ptr<int>(*f)(void) : count(6));          // expected-error {{conflicting bounds annotations for 'f93'}}
 
 //---------------------------------------------------------------------------//
 // Declarations of variables with unchecked pointer or array types are       //
@@ -331,6 +440,9 @@ extern int g35[] : count(len);
 extern int g35[] : count(len + 1);  // expected-error {{conflicting bounds}}
 
 extern int g36[] : count(len);
+
+
+
 // A redeclaration without a bounds-safe interface is compatible with the
 // original declaration, but the variable retains its original bounds-safe
 // interface.
@@ -350,6 +462,53 @@ int g38[] : bounds(g38, g38 + 6);  // expected-error {{conflicting bounds}}
 
 int g39[5] : itype(int checked[5]);
 int g39[5] : count(5);             // expected-error {{added bounds}}
+
+//
+// Bounds declarations plus interface types
+//
+
+// Identical declarations and interface types.
+int **g31a : count(len) itype(array_ptr<ptr<int>>);
+int **g31a : count(len) itype(array_ptr<ptr<int>>);
+
+char *g31b : count(len) itype(nt_array_ptr<char>);
+char *g31b : count(len) itype(nt_array_ptr<char>);
+
+// Implied interface type.
+int **g31c : count(len);
+int **g31c : count(len) itype(array_ptr<int *>);
+
+int **g31d : bounds(g31c, g31c + len) itype(array_ptr<int *>);
+int **g31d : bounds(g31c, g31c + len);
+
+// Mismatched bounds declaration.
+int **g31e : count(len) itype(array_ptr<ptr<int>>);
+int **g31e : count(len+1) itype(array_ptr<ptr<int>>);  // expected-error {{conflicting bounds}}
+
+// Mismatched interface type declaration.
+int **g31f : bounds(g31e, g31e + len) itype(array_ptr<ptr<int>>);
+int **g31f : bounds(g31e, g31e + len) itype(array_ptr<int *>);  // expected-error {{conflicting interop type}}
+
+// Dropped bounds declaration.
+int **g31g : byte_count(len * sizeof(int *)) itype(array_ptr<ptr<int>>);
+int **g31g : itype(array_ptr<ptr<int>>);  // expected-error {{dropped bounds}}
+
+// Added bounds declaration.
+int **g31h : itype(array_ptr<ptr<int>>);
+int **g31h: count(len) itype(array_ptr<ptr<int>>);  // expected-error {{added bounds}}
+
+// Dropped interface type.
+int **g31i : count(len) itype(array_ptr<ptr<int>>);
+int **g31i : count(len);  // expected-error {{conflicting interop type}}
+
+// Added interface type.
+int **g31j : count(len);
+int **g31j : count(len) itype(array_ptr<ptr<int>>); // expected-error {{conflicting interop type}}
+
+// nt_array_ptr type implies count(0)
+char *g31k : itype(nt_array_ptr<char>);
+char *g31k : itype(nt_array_ptr<char>) count(0);
+char *g31k : itype(nt_array_ptr<char>) count(1);  // expected-error {{conflicting bounds}}
 
 //---------------------------------------------------------------------------//
 // Redeclarations of variables that have bounds declarations must have       //

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -89,7 +89,10 @@ void f33(int *p, int len);
 void f33(int *p : bounds(p, p + len + 1), int len);  // expected-error {{conflicting parameter bounds}}
 
 void f34(int *p : itype(ptr<int>), int len);
-void f34(int *p : count(len), int len);  // expected-error {{conflicting parameter bounds}}
+void f34(int *p : count(len), int len);  // expected-error {{added bounds for parameter}}
+
+void f35(int *p : count(len), int len);
+void f35(int *p : itype(ptr<int>), int len); // expected-error {{dropped bounds for parameter}}
 
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have parameters that have bounds         //
@@ -145,7 +148,7 @@ int *f53(int *p, int len);
 int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // expected-error {{conflicting return bounds}}
 
 int *f54(int len) : itype(ptr<int>);
-int *f54(int len) : count(len);  // expected-error {{conflicting return bounds}}
+int *f54(int len) : count(len);  // expected-error {{added return bounds}}
 
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have bounds declarations for returns     //
@@ -320,7 +323,7 @@ int *g33;
 int *g33 : bounds(g33, g33 + len + 1);  // expected-error {{conflicting bounds}}
 
 int *g34 : itype(ptr<int>);
-int *g34 : count(1);      // expected-error {{conflicting bounds}}
+int *g34 : count(1);      // expected-error {{added bounds}}
 
 // Unchecked arrays
 extern int g35[] : count(len);
@@ -346,7 +349,7 @@ int g38[];
 int g38[] : bounds(g38, g38 + 6);  // expected-error {{conflicting bounds}}
 
 int g39[5] : itype(int checked[5]);
-int g39[5] : count(5);             // expected-error {{conflicting bounds}}
+int g39[5] : count(5);             // expected-error {{added bounds}}
 
 //---------------------------------------------------------------------------//
 // Redeclarations of variables that have bounds declarations must have       //


### PR DESCRIPTION
- Test parsing and typechecking of bounds-safe interfaces with interface types and bounds expressions.
- Test redeclarations of functions and variables with bounds-safe interfaces with interface typese and bounds expressions.
- Add tests of bounds-safe interface in checked scopes that cover the different forms of bounds expressions.  This includes a test case that covers https://github.com/Microsoft/checkedc-clang/issues/443.
- Add tests of redeclarations involving `nt_array_ptr`.
- Fix bounds-safe interface for `strtok`: the compiler isn't properly inferring that return types of the form `nt_array_ptr<char>` have bounds of `count(0)`.  We can just declare the bounds of `count(0)` for now.

