### PR TITLE
Tests for inferred return bounds.

### DIFF
--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -139,7 +139,7 @@ char *strstr(const char *s1 : itype(_Nt_array_ptr<const char>),
 // https://github.com/Microsoft/checkedc-clang/issues/424 is addressed
 char *strtok(char * restrict s1 : itype(restrict _Nt_array_ptr<char>),
              const char * restrict s2 : itype(restrict _Nt_array_ptr<const char>)) :
-  itype(_Nt_array_ptr<char>) count(0);
+  itype(_Nt_array_ptr<char>);
 
 char *strerror(int errnum) : itype(_Nt_array_ptr<char>);
 size_t strlen(const char *s : itype(_Nt_array_ptr<const char>));


### PR DESCRIPTION
Remove inferred return bounds workarounds. Add inferred parameter bounds tests:
- Update tests now that the compiler properly infers return bounds of count(0)
  for nt_array_ptr return types.
- Remove workaround for strtok from checked header files.
- Add more tests of inference of bounds/itypes for parameters.  This includes
  tests that mix parameter types that are pointers and arrays, as well as
  tests of inferred bounds of nt_checked arrays parameters.

The tests are for the compiler change at https://github.com/Microsoft/checkedc-clang.