### PR TITLE
Update to new syntax for bounds_cast expressions.

### DIFF
--- a/samples/string-helpers.c
+++ b/samples/string-helpers.c
@@ -207,14 +207,13 @@ int main(int argc, nt_array_ptr<char> argv checked[] : count(argc)) {
     printf("Usage: %s arg1 arg2 <integer> ... arg6", argv[0]);
     return 0;
   }
-  // Temporary scaffolding pending Checked C compiler change to
-  // set default bounds for nt_array_ptr<char> to count(0);
-  nt_array_ptr<char> arg1 : count(0) = assume_bounds_cast<nt_array_ptr<char>>(argv[1], 0);
-  nt_array_ptr<char> arg2 : count(0) = assume_bounds_cast<nt_array_ptr<char>>(argv[2], 0);
-  nt_array_ptr<char> arg3 : count(0) = assume_bounds_cast<nt_array_ptr<char>>(argv[3], 0);
-  nt_array_ptr<char> arg4 : count(0) = assume_bounds_cast<nt_array_ptr<char>>(argv[4], 0);
-  nt_array_ptr<char> arg5 : count(0) = assume_bounds_cast<nt_array_ptr<char>>(argv[5], 0);
-  nt_array_ptr<char> arg6 : count(0) = assume_bounds_cast<nt_array_ptr<char>>(argv[6], 0);
+
+  nt_array_ptr<char> arg1 = assume_bounds_cast<nt_array_ptr<char>>(argv[1], count(0));
+  nt_array_ptr<char> arg2 = assume_bounds_cast<nt_array_ptr<char>>(argv[2], count(0));
+  nt_array_ptr<char> arg3 = assume_bounds_cast<nt_array_ptr<char>>(argv[3], count(0));
+  nt_array_ptr<char> arg4 = assume_bounds_cast<nt_array_ptr<char>>(argv[4], count(0));
+  nt_array_ptr<char> arg5 = assume_bounds_cast<nt_array_ptr<char>>(argv[5], count(0));
+  nt_array_ptr<char> arg6 = assume_bounds_cast<nt_array_ptr<char>>(argv[6], count(0));
   printf("strlen(\"%s\") = %d\n", arg1, my_strlen(arg1));
   printf("squeeze(\"%s\",'e') = ", arg2);
   squeeze(arg2, 'e');

--- a/tests/dynamic_checking/dynamic-bounds-cast-check.c
+++ b/tests/dynamic_checking/dynamic-bounds-cast-check.c
@@ -155,13 +155,13 @@ void passing_test_1(void) {
   q = _Dynamic_bounds_cast<ptr<int>>(r);
   printf("Printable0\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r, 3);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r, count(3));
   printf("Printable1\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r+3, 3);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r+3, count(3));
   printf("Printable2\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r, s, s+3);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(s, s+3));
   printf("Printable3\n");
 
   puts("Expected Success");
@@ -178,14 +178,14 @@ void passing_test_2(void) {
   q = _Dynamic_bounds_cast<ptr<int>>(NULL);
   printf("Printable0\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(NULL, r, r+5);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(NULL, bounds(r, r+5));
   printf("Printable1\n");
 
   s = NULL;
   q = _Dynamic_bounds_cast<ptr<int>>(s);
   printf("Printable2\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(s, r, r+5);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(s, bounds(r, r+5));
   printf("Printable3\n");
 
   puts("Expected Success");
@@ -214,7 +214,7 @@ void passing_test_3(void) {
 void failing_test_1(void) {
   ptr<int> q = 0;
   int r checked[10] = {0,1,2,3,4,5,6,7,8,9};
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r, 15);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r, count(15));
   
   printf("Unprintable\n");
   
@@ -225,7 +225,7 @@ void failing_test_1(void) {
 void failing_test_2(void) {
   ptr<int> q = 0;
   int r checked[10] = {0,1,2,3,4,5,6,7,8,9};
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r+8, 3);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r+8, count(3));
 
   printf("Unprintable\n");
   
@@ -241,14 +241,14 @@ void failing_test_3(void) {
   q = _Dynamic_bounds_cast<ptr<int>>(r);
   printf("Printable0\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r, 5);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r, count(5));
   printf("Printable1\n");
 
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r, s, s+3);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(s, s+3));
   printf("Printable2\n");
 
   s = 0;
-  q = _Dynamic_bounds_cast<array_ptr<int>>(r, s, s+3);
+  q = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(s, s+3));
   
   printf("Unprintable\n");
   
@@ -259,7 +259,7 @@ void failing_test_3(void) {
 // dereference insert dynamic_check(s <= s+5 && (s+5) < s+3) -> FAIL
 void failing_test_4(void) {
   int r checked[10] = {0,1,2,3,4,5,6,7,8,9};
-  array_ptr<int> s : count(3) = _Dynamic_bounds_cast<array_ptr<int>>(r, 5);
+  array_ptr<int> s : count(3) = _Dynamic_bounds_cast<array_ptr<int>>(r, count(5));
   
   printf("Printable1\n");
   printf("Unprintable2: %d\n", *(s+5));

--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -8,28 +8,28 @@
 extern void f1() {
   array_ptr<int> a : count(1) = 0;
   int b[10];
-  a = _Dynamic_bounds_cast<array_ptr<int>>(b, 10);
+  a = _Dynamic_bounds_cast<array_ptr<int>>(b, count(10));
 }
 
 extern void f2() {
   char p[10];
   array_ptr<int> a : count(1) = 0;
-  array_ptr<int> d : count(10) = _Dynamic_bounds_cast<array_ptr<int>>(a, 5); // expected-error {{declared bounds for 'd' are invalid after initialization}}
-  a = _Assume_bounds_cast<array_ptr<int>) (p, p, p+1); // expected-error {{expected '>'}}
+  array_ptr<int> d : count(10) = _Dynamic_bounds_cast<array_ptr<int>>(a, count(5)); // expected-error {{declared bounds for 'd' are invalid after initialization}}
+  a = _Assume_bounds_cast<array_ptr<int>) (p, bounds(p, p+1)); // expected-error {{expected '>'}}
 }
 
 extern void f3() {
   array_ptr<int> a : count(2) = 0;
   array_ptr<char> b : count(2) = 0;
 
-  b = _Assume_bounds_cast<array_ptr<char>>(a, 2);
+  b = _Assume_bounds_cast<array_ptr<char>>(a, count(2));
 }
 
 extern void f4() {
   array_ptr<int> a : count(2) = 0;
   array_ptr<char> b : count(2) = 0;
 
-  a = _Asume_bounds_cast<array_ptr<int>>(b, 2); // expected-error{{use of undeclared identifier}} expected-error {{expected expression}}
+  a = _Asume_bounds_cast<array_ptr<int>>(b, count(2)); // expected-error{{use of undeclared identifier}} expected-error {{expected expression}}
   a = _Dssume_bounds_cast<int>(b); // expected-error{{use of undeclared identifier}} expected-error {{expected expression}}
 }
 
@@ -67,7 +67,7 @@ extern array_ptr<int> h4(void) : count(3) {
 extern void f7() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>>(h4(), 3);
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), count(3));
   q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 
@@ -97,8 +97,8 @@ extern void f10() {
 extern void f11() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>, rel_align(int)>(h4(), r, r + 4);
-  q = _Assume_bounds_cast<ptr<int>, rel_align_value(sizeof(int))>(h4());
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4)  rel_align(int));
+  q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 
 extern void f12() {
@@ -108,30 +108,17 @@ extern void f12() {
   ptr<int *> s = 0;
   ptr<ptr<int>> t = 0;
   array_ptr<int> qq : count(4) = 0;
-  r = _Assume_bounds_cast<ptr<int>, rel_align(int)>(q);
-  p = _Assume_bounds_cast<int *, rel_align_value(sizeof(int))>(q);
+  r = _Assume_bounds_cast<ptr<int>>(q);
+  p = _Assume_bounds_cast<int *>(q);
 
-  s = _Assume_bounds_cast<ptr<int *>, rel_align(int)>(q);
-  t = _Assume_bounds_cast<ptr<ptr<int>>, rel_align_value(sizeof(int))>(q);
+  s = _Assume_bounds_cast<ptr<int *>>(q);
+  t = _Assume_bounds_cast<ptr<ptr<int>>>(q);
 
-  qq = _Assume_bounds_cast<array_ptr<int>, rel_align(int)>(q, q, q + 4);
-  p = _Assume_bounds_cast<int *, rel_align_value(sizeof(int))>(q);
+  qq = _Assume_bounds_cast<array_ptr<int>>(q, bounds(q, q + 4) rel_align(int));
+  p = _Assume_bounds_cast<int *>(q);
 }
 
-extern void f13() {
-  int *p;
-  int len = 5;
-  array_ptr<int> q : count(2) = 0;
-  ptr<int> r = 0;
-  r = _Dynamic_bounds_cast<ptr<int>, rel_align(len)>(q); // expected-error {{unknown type name 'len'}}
-  p = _Dynamic_bounds_cast<int *, rel_align_value(len)>(q); // expected-error {{expression is not an integer constant expression}}
-  p = _Dynamic_bounds_cast<int *, rel_align_value(1)>(q);
-
-  p = _Dynamic_bounds_cast<int *, rel_align_value(1)>(q);
-  p = _Dynamic_bounds_cast<int *, rel_align(int)>(q);
-}
-
-extern void f14(array_ptr<int> arr : count(5)) {
+extern void f13(array_ptr<int> arr : count(5)) {
   int p[10];
   array_ptr<int> x : count(10) = 0;
   array_ptr<int> q : count(10) = 0;

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -1545,8 +1545,8 @@ checked void check_cast_operator(void) {
                                                 // expected-error {{type in a checked scope must be a checked pointer or array type}} \
 
   q = _Assume_bounds_cast<ptr<int>>(r);             // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
-  r = _Assume_bounds_cast<array_ptr<int>>(r,4);     // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
-  r = _Assume_bounds_cast<array_ptr<int>>(r,r,r+1); // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
+  r = _Assume_bounds_cast<array_ptr<int>>(r,count(4));     // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
+  r = _Assume_bounds_cast<array_ptr<int>>(r,bounds(r,r+1)); // expected-error {{_Assume_bounds_cast not allowed in a checked scope or function}}
 
   vpa = _Dynamic_bounds_cast<ptr<int(int,...)>>(r);   // expected-error {{type in a checked scope cannot have variable arguments}}
   vpa = _Dynamic_bounds_cast<ptr<int(int,ptr<int(int, ...)>)>>(r);  // expected-error {{type in a checked scope cannot have variable arguments}}

--- a/tests/typechecking/type_check_bounds_cast.c
+++ b/tests/typechecking/type_check_bounds_cast.c
@@ -13,8 +13,8 @@ extern void f1() {
   int p[10];
 
   array_ptr<int> checkedc_p : bounds(checkedc_p, checkedc_p + 1) = 0;
-  a = _Dynamic_bounds_cast<array_ptr<int>>(b, 10);
-  c = _Dynamic_bounds_cast<int>(p); // expected-error {{invalid bounds cast}}
+  a = _Dynamic_bounds_cast<array_ptr<int>>(b, count(10));
+  c = _Dynamic_bounds_cast<int>(p); // expected-error {{expected _Ptr or * type}}
 }
 
 extern void f2() {
@@ -22,24 +22,24 @@ extern void f2() {
   array_ptr<int> a : count(1) = 0;
   int b checked[10];
   array_ptr<int> c : count(10) = (array_ptr<int>)a; // expected-error {{declared bounds for 'c' are invalid after initialization}}
-  array_ptr<int> d : count(10) = _Dynamic_bounds_cast<array_ptr<int>>(a, 5); // expected-error {{declared bounds for 'd' are invalid after initialization}}
-  a = _Assume_bounds_cast<array_ptr<int>>(p); // expected-error {{invalid bounds cast}}
+  array_ptr<int> d : count(10) = _Dynamic_bounds_cast<array_ptr<int>>(a, count(5)); // expected-error {{declared bounds for 'd' are invalid after initialization}}
+  a = _Assume_bounds_cast<array_ptr<int>>(p); // expected-error {{expected _Ptr or * type}}
 }
 
 extern void f3() {
   char p[10];
   ptr<int> c = 0;
   array_ptr<int> a : count(2) = 0;
-  a = _Assume_bounds_cast<array_ptr<int>>(p, p + 2); // expected-error {{invalid argument type 'char *' to count expression}}
-  c = _Assume_bounds_cast<ptr<int>>(p, 1); // expected-error {{invalid bounds cast}}
+  a = _Assume_bounds_cast<array_ptr<int>>(p, count(p + 2)); // expected-error {{invalid argument type 'char *' to count expression}}
+  c = _Assume_bounds_cast<ptr<int>>(p, count(1)); // expected-error {{expected _Array_ptr type}}
 }
 
 extern void f4() {
   array_ptr<int> a : count(2) = 0;
   array_ptr<char> b : count(2) = 0;
 
-  b = _Assume_bounds_cast<array_ptr<char>>(a, 2);
-  a = _Assume_bounds_cast<array_ptr<int>>(b); // expected-error {{invalid bounds cast}}
+  b = _Assume_bounds_cast<array_ptr<char>>(a, count(2));
+  a = _Assume_bounds_cast<array_ptr<int>>(b); // expected-error {{expected _Ptr or * type}}
 }
 
 struct S1 {
@@ -80,16 +80,16 @@ extern void f6() {
        *char_unchecked_ptr_ub = (char *)i + 1;
 
   array_ptr<int> t20 : bounds(int_array_ptr_lb, char_array_ptr_ub) = // expected-error {{pointer type mismatch}}
-        _Assume_bounds_cast<array_ptr<int>>(i, int_array_ptr_lb, char_array_ptr_ub); // expected-error {{pointer type mismatch}}
+        _Assume_bounds_cast<array_ptr<int>>(i, bounds(int_array_ptr_lb, char_array_ptr_ub)); // expected-error {{pointer type mismatch}}
 
   array_ptr<int> t21 : bounds(int_ptr_lb, char_array_ptr_ub) = // expected-error {{pointer type mismatch}}
-        _Assume_bounds_cast<array_ptr<int>>(i, int_ptr_lb, int_array_ptr_ub);
+        _Assume_bounds_cast<array_ptr<int>>(i, bounds(int_ptr_lb, int_array_ptr_ub));
 }
 
 extern void f7() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>>(h4(), 3);
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), count(3));
   q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 
@@ -114,8 +114,8 @@ extern void f8() {
 extern void f9() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>, rel_align(int)>(h4(), r, r + 4);
-  q = _Assume_bounds_cast<ptr<int>, rel_align_value(sizeof(int))>(h4(), r, r + 4); // expected-error {{invalid bounds cast}}
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4) rel_align(int));
+  q = _Assume_bounds_cast<ptr<int>>(h4(), bounds(r, r + 4) rel_align_value(sizeof(int))); // expected-error {{expected _Array_ptr type}}
 }
 
 extern void f10() {
@@ -125,14 +125,14 @@ extern void f10() {
   ptr<int *> s = 0;
   ptr<ptr<int>> t = 0;
   array_ptr<int> qq : count(4) = 0;
-  r = _Assume_bounds_cast<ptr<int>, rel_align(int)>(q, q, q + 4); // expected-error {{invalid bounds cast}}
-  p = _Assume_bounds_cast<int *, rel_align_value(sizeof(int))>(q, q, q + 4); // expected-error {{invalid bounds cast}}
+  r = _Assume_bounds_cast<ptr<int>>(q, bounds(q, q + 4) rel_align(int)); // expected-error {{expected _Array_ptr type}}
+  p = _Assume_bounds_cast<int *>(q, bounds(q, q + 4) rel_align_value(sizeof(int))); // expected-error {{expected _Array_ptr type}}
 
-  s = _Assume_bounds_cast<ptr<int *>, rel_align(int)>(q, q, q + 4); // expected-error {{invalid bounds cast}}
-  t = _Assume_bounds_cast<ptr<ptr<int>>, rel_align_value(sizeof(int))>(q, q, q + 4); // expected-error {{invalid bounds cast}}
+  s = _Assume_bounds_cast<ptr<int *>>(q, bounds(q, q + 4) rel_align(int)); // expected-error {{expected _Array_ptr type}}
+  t = _Assume_bounds_cast<ptr<ptr<int>>>(q, bounds(q, q + 4) rel_align_value(sizeof(int))); // expected-error {{expected _Array_ptr type}}
 
-  qq = _Assume_bounds_cast<array_ptr<int>, rel_align(int)>(q, q, q + 4);
-  p = _Assume_bounds_cast<int *, rel_align_value(sizeof(int))>(q, q, q + 4); // expected-error {{invalid bounds cast}}
+  qq = _Assume_bounds_cast<array_ptr<int>>(q, bounds(q, q + 4)  rel_align(int)) ;
+  p = _Assume_bounds_cast<int *>(q, bounds(q, q + 4) rel_align_value(sizeof(int))); // expected-error {{expected _Array_ptr type}}
 }
 
 extern void f11() {
@@ -145,39 +145,37 @@ extern void f11() {
   array_ptr<char> rr;
   array_ptr<int> rrr;
   
-  r = _Dynamic_bounds_cast<ptr<int>, rel_align(len)>(q, q, q + 4); // expected-error {{unknown type name 'len'}}
-  p = _Dynamic_bounds_cast<int *, rel_align_value(len)>(q, q, q + 4); // expected-error {{expression is not an integer constant expression}} expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<int *, rel_align_value(1)>(q, q, q + 4); // expected-error {{invalid bounds cast}}
+  r = _Dynamic_bounds_cast<ptr<int>>(q, bounds(q, q + 4) rel_align(len)); // expected-error {{unknown type name 'len'}}
+  p = _Dynamic_bounds_cast<int *>(q, bounds(q, q + 4) rel_align_value(len)); // expected-error {{expression is not an integer constant expression}} expected-error {{expected _Array_ptr type}}
+  p = _Dynamic_bounds_cast<int *>(q, bounds(q, q + 4) rel_align_value(1)); // expected-error {{expected _Array_ptr type}}
 
-  p = _Dynamic_bounds_cast<int *, rel_align_value(1)>(q);
-  p = _Dynamic_bounds_cast<int *, rel_align(int)>(q);
-  c = _Assume_bounds_cast<int>(cq); // expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<char>(p, p, p + 2); // expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<char>(p); // expected-error {{invalid bounds cast}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(r); // expected-error{{invalid bounds cast}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(q); // expected-error {{invalid bounds cast}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(i); // expected-error {{invalid bounds cast}}
-  r = _Dynamic_bounds_cast<array_ptr<char>>(i); // expected-error {{invalid bounds cast}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(p); // expected-error {{invalid bounds cast}}
-  rr = _Dynamic_bounds_cast<array_ptr<int>>(p); // expected-error {{invalid bounds cast}}
-  rrr = _Dynamic_bounds_cast<array_ptr<int>>(p); // expected-error {{invalid bounds cast}}
-  r = _Dynamic_bounds_cast<array_ptr<char>>(p); // expected-error {{invalid bounds cast}}
-  q = _Dynamic_bounds_cast<ptr<int>>(rr, 1); // expected-error{{invalid bounds cast}}
-  q = _Dynamic_bounds_cast<ptr<int>>(rr, rr, rr + 1); // expected-error{{invalid bounds cast}}
+  c = _Assume_bounds_cast<int>(cq); // expected-error {{expected _Ptr or * type}}
+  p = _Dynamic_bounds_cast<char>(p, bounds(p, p + 2)); // expected-error {{expected _Array_ptr type}}
+  p = _Dynamic_bounds_cast<char>(p); // expected-error {{expected _Ptr or * type}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(r); // expected-error{{expected _Ptr or * type}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(q); // expected-error {{expected _Ptr or * type}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(i); // expected-error {{expected _Ptr or * type}}
+  r = _Dynamic_bounds_cast<array_ptr<char>>(i); // expected-error {{expected _Ptr or * type}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(p); // expected-error {{expected _Ptr or * type}}
+  rr = _Dynamic_bounds_cast<array_ptr<int>>(p); // expected-error {{expected _Ptr or * type}}
+  rrr = _Dynamic_bounds_cast<array_ptr<int>>(p); // expected-error {{expected _Ptr or * type}}
+  r = _Dynamic_bounds_cast<array_ptr<char>>(p); // expected-error {{expected _Ptr or * type}}
+  q = _Dynamic_bounds_cast<ptr<int>>(rr, count(1)); // expected-error{{expected _Array_ptr type}}
+  q = _Dynamic_bounds_cast<ptr<int>>(rr, bounds(rr, rr + 1)); // expected-error{{expected _Array_ptr type}}
 
-  p = _Dynamic_bounds_cast<int *>(q, 1); // expected-error {{invalid bounds cast}}
-  q = _Dynamic_bounds_cast<ptr<int>>(q, 1); // expected-error {{invalid bounds cast}}
-  q = _Dynamic_bounds_cast<ptr<int>>(i, 1); // expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<int *>(i, 1); // expected-error {{invalid bounds cast}}  
-  q = _Dynamic_bounds_cast<ptr<int>>(i, i, i + 1); // expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<int *>(i, i, i + 1); // expected-error {{invalid bounds cast}}  
+  p = _Dynamic_bounds_cast<int *>(q, count(1)); // expected-error {{expected _Array_ptr type}}
+  q = _Dynamic_bounds_cast<ptr<int>>(q, count(1)); // expected-error {{expected _Array_ptr type}}
+  q = _Dynamic_bounds_cast<ptr<int>>(i, count(1)); // expected-error {{expected _Array_ptr type}}
+  p = _Dynamic_bounds_cast<int *>(i, count(1)); // expected-error {{expected _Array_ptr type}}
+  q = _Dynamic_bounds_cast<ptr<int>>(i, bounds(i, i + 1)); // expected-error 2 {{expected expression with pointer type}}
+  p = _Dynamic_bounds_cast<int *>(i, bounds(i, i + 1)); // expected-error 2 {{expected expression with pointer type}}
 
-  q = _Dynamic_bounds_cast<ptr<int>>(p, 1); // expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<int *>(p, 1); // expected-error {{invalid bounds cast}}  
-  q = _Dynamic_bounds_cast<ptr<int>>(p, p, p + 1); // expected-error {{invalid bounds cast}}
-  p = _Dynamic_bounds_cast<int *>(p, p, p + 1); // expected-error {{invalid bounds cast}}
+  q = _Dynamic_bounds_cast<ptr<int>>(p, count(1)); // expected-error {{expected _Array_ptr type}}
+  p = _Dynamic_bounds_cast<int *>(p, count(1)); // expected-error {{expected _Array_ptr type}}
+  q = _Dynamic_bounds_cast<ptr<int>>(p, bounds(p, p + 1)); // expected-error {{expected _Array_ptr type}}
+  p = _Dynamic_bounds_cast<int *>(p, bounds(p, p + 1)); // expected-error {{expected _Array_ptr type}}
   
-  q = _Assume_bounds_cast<ptr<int>>(r, 1) + 3; // expected-error{{invalid bounds cast}}
-  c = _Dynamic_bounds_cast<ptr<int>>(p, 4); // expected-error{{invalid bounds cast}}  
+  q = _Assume_bounds_cast<ptr<int>>(r, count(1)) + 3; // expected-error{{expected _Array_ptr type}}
+  c = _Dynamic_bounds_cast<ptr<int>>(p, count(4)); // expected-error{{expected _Array_ptr type}}
 }
 


### PR DESCRIPTION
Update tests and examples to the new syntax for bounds cast expressions.

We changed bounds cast expressions to take a bounds expression as the
second argument, instead of implicitly inferring the type of bounds
expression from the number of arguments.  This is more verbose but
clearer.  Bounds cast expressions now have two forms:

Op<T>(e1)
Op<T>(e1, bounds-expression)

where Op is one of _Assume_bounds_cast or _Dynamic_bounds_cast
and T must be a pointer type.