### PR TITLE
Checking of bounds declarations everywhere, expression equality facts.

### DIFF
--- a/tests/dynamic_checking/bounds/deref.c
+++ b/tests/dynamic_checking/bounds/deref.c
@@ -179,7 +179,7 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
 // Bounds Describe Valid Pointer, within array, deref is fine
 void passing_test_1(void) {
   int a checked[10] = { 9, 8, 7, 6, 5, 4, 3, 2, 1};
-  array_ptr<int> b : count(5) = &a[2];
+  array_ptr<int> b : bounds(a, a + 10) = &a[2];
 
   TEST_OP(*b, 1);
   printf("Result: %d\n", *b);

--- a/tests/parsing/declaration_bounds.c
+++ b/tests/parsing/declaration_bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify %s
+// RUN: %clang_cc1 -Wno-check-bounds-decls -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -64,10 +64,10 @@ extern array_ptr<int> h4(void) : count(3) {
   return p;
 }
 
-extern void f7() {
+extern void f7(void *p) {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>>(h4(), count(3));
+  r = _Assume_bounds_cast<array_ptr<int>>(p, count(3));
   q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 
@@ -128,8 +128,8 @@ extern void f13(array_ptr<int> arr : count(5)) {
   x = _Dynamic_bounds_cast<array_ptr<int>>(p, count(10));
   x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(p, p + 10));
   x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(cache1 - 2, cache1 + 3)); // expected-error {{declared bounds for x are invalid after assignment}}
-  x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr, arr + len));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr, arr + len));  // expected-warning {{cannot prove declared bounds for x are valid after assignment}}
   x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr)); // expected-error {{expected ','}}
   x = _Dynamic_bounds_cast<array_ptr<int>>(x, count(3 + 2));// expected-error {{declared bounds for x are invalid after assignment}}
-  x = _Dynamic_bounds_cast<array_ptr<int>>(x, count(len));
+  x = _Dynamic_bounds_cast<array_ptr<int>>(x, count(len));  // expected-warning {{cannot prove declared bounds for x are valid after assignment}}
 }

--- a/tests/parsing/rel_align.c
+++ b/tests/parsing/rel_align.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify %s
+// RUN: %clang_cc1 -Wno-check-bounds-decls -verify %s
 
 #include <stdchecked.h>
 

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -85,9 +85,8 @@ void f4(void) checked {
   char t33 = g33[4];
   char t34 = g34[4];
   char t35 = g35[1];
-  // TODO: bounds declaration checking needs to understand equality after assignment
-  nt_array_ptr<char> t36 = g36[1][0];  // expected-warning {{cannot prove declared bounds for 't36' are valid after initialization}}
-  nt_array_ptr<char> t37 = g37[1];     // expected-warning {{cannot prove declared bounds for 't37' are valid after initialization}}
+  nt_array_ptr<char> t36 = g36[1][0];
+  nt_array_ptr<char> t37 = g37[1];
 
 
   f3("abc");   // expected-error {{passing 'char _Nt_checked[4]' to parameter of incompatible type 'char *'}}

--- a/tests/static_checking/lexical_equality.c
+++ b/tests/static_checking/lexical_equality.c
@@ -1072,8 +1072,7 @@ extern int f211_1(_Array_ptr<int> b : bounds(*&(arr), arr + 5));
 extern int f211_1(_Array_ptr<int> b : bounds(*(&arr), arr + 5));
 
 // address-of an array does nothing at runtime  However, we have to make sure
-// the types match.
+// the types are compatible.
 extern int f211_2(_Array_ptr<int> b : bounds(&arr, &arr));
 extern int f211_2(_Array_ptr<int> b : bounds((int (*) _Checked[10]) arr, (int (*) _Checked[10]) arr));
-// TODO: this gives a type error when it shouldn't.
-// extern int f211_2(_Array_ptr<int> b : bounds(&arr, (int (*) _Checked[10]) arr));
+extern int f211_2(_Array_ptr<int> b : bounds(&arr, (int (*) _Checked[10]) arr));

--- a/tests/static_checking/lexical_equality.c
+++ b/tests/static_checking/lexical_equality.c
@@ -913,7 +913,7 @@ extern int f80_2(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds((_Array_p
 // cast expression so that the function declaration type checks.
 
 extern int f80_3(int a, _Array_ptr<int> b,
-                 _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) ((_Array_ptr<int>) b + a))); 
+                 _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) ((_Array_ptr<int>) b + a)));
 extern int f80_3(int a, _Array_ptr<int> b,
                  _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) ((_Array_ptr<char>) b + a))); // expected-error {{conflicting parameter bounds}}
 
@@ -994,3 +994,86 @@ extern int f93_2(struct S *a, _Array_ptr<int> b : count(c->f1), struct S *c);  /
 extern int f93_3(struct S *a, _Array_ptr<int> b : count(a->f1), struct S *c);
 extern int f93_3(struct S *a, _Array_ptr<int> b : count(c->f2), struct S *c);  // expected-error {{conflicting parameter bounds}}
 
+//
+// Check equality of canonicalized expressions
+//
+
+// Casts that preserve values are ignored.
+
+// Identity casts to/from the same type.
+extern int f200_1(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + a));
+extern int f200_1(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) b + a));
+
+extern int f200_2(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + a));
+extern int f200_2(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + (int) a));
+
+// Casts between pointer types.
+extern int f201_1(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + a));
+extern int f201_1(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (int *) b + a));
+
+extern int f201_2(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (void *) b + a));
+extern int f201_2(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (int *) b + a));
+
+// Casts between signed/unsigned integers that have the same bit size.
+//
+// Note: it is an implementation-specific assumption that casts between signed
+// and unsigned integers with the same bit size preserve values.  It's correct
+// in the following cases:
+// - signed-to-unsigned conversions, and integers are represented in
+//   two's complement (based on the C specification).
+// - unsigned-to-signed, and integers are represented in two's complement,
+//   and the implementation chooses to preserve the bits for unsigned integers
+//   too large to fit into the signed integer.
+// C does not require that integers be two's complement.  It allows 1's complement
+// and sign/magnitude representations.  We don't have an implementation of Checked C
+// that uses these representations. If we did we'd likely have to make these
+// tests implementation specific.
+extern int f202_1(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + a));
+extern int f202_1(int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + (int) (unsigned) a));
+
+extern int f202_2(unsigned int a,
+                   _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
+extern int f202_2(unsigned int a, _Array_ptr<int> b,
+                  _Array_ptr<char> p : bounds(b, b + (unsigned) (int) a));
+
+// C-style casts and implicit casts to/from the same types.
+extern int f203_1(short int a, _Array_ptr<int> b : count(a + 1));
+extern int f203_1(short int a, _Array_ptr<int> b : count((int) a + 1));
+
+extern int f203_2(short int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
+extern int f203_2(short int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + (int) a));
+
+//
+// & and * operations that cancel are ignored.
+//
+// & of an lvalue
+extern int f210_1(int a, _Array_ptr<int> b : count(*&a));
+extern int f210_1(int a, _Array_ptr<int> b : count(a));
+
+extern _Checked int f210_2(_Ptr<int> lb, _Ptr<int> ub,
+                           _Array_ptr<int> b : bounds(lb, ub));
+extern _Checked int f210_2(_Ptr<int> lb, _Ptr<int> ub,
+                           _Array_ptr<int> b : bounds(&*lb, ub));
+// & of an array.
+int arr _Checked[10];
+extern int f211_1(_Array_ptr<int> b : bounds(arr, arr + 5));
+extern int f211_1(_Array_ptr<int> b : bounds(*&arr, arr + 5));
+extern int f211_1(_Array_ptr<int> b : bounds(*&(arr), arr + 5));
+extern int f211_1(_Array_ptr<int> b : bounds(*(&arr), arr + 5));
+
+// address-of an array does nothing at runtime  However, we have to make sure
+// the types match.
+extern int f211_2(_Array_ptr<int> b : bounds(&arr, &arr));
+extern int f211_2(_Array_ptr<int> b : bounds((int (*) _Checked[10]) arr, (int (*) _Checked[10]) arr));
+// TODO: this gives a type error when it shouldn't.
+// extern int f211_2(_Array_ptr<int> b : bounds(&arr, (int (*) _Checked[10]) arr));

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -45,7 +45,8 @@ extern void f3() {
   int *p = 0;
   ptr<int> q = 0;
   array_ptr<int> r = 0;
-  array_ptr<int> s : bounds(r, r + 5) = 0;
+  array_ptr<int> s1 = 0;
+  array_ptr<int> s2 : bounds(r, r + 5) = 0;
   p = _Assume_bounds_cast<int *>(r);
   p = _Dynamic_bounds_cast<int *>(r); // expected-error {{expression has unknown bounds}}  
   q = _Assume_bounds_cast<ptr<int>>(p);
@@ -58,8 +59,8 @@ extern void f3() {
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
   *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} \
                                                          // expected-warning {{out-of-bounds memory access}}
-  s = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
-  s = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
+  s1 = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
+  s2 = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
 }
 
 extern ptr<int> f4(int arr checked[]) {
@@ -139,12 +140,12 @@ extern void f18(int i) {
   r = _Dynamic_bounds_cast<array_ptr<int>>(p, count(1)); // expected-error {{expression has unknown bounds}} expected-error {{declared bounds for r are invalid after assignment}}
   r = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(p, p + 1)); // expected-error {{expression has unknown bounds}} expected-error {{declared bounds for r are invalid after assignment}}
 
-  r = _Dynamic_bounds_cast<array_ptr<int>>(i, count(1)); // expected-error {{expression has unknown bounds}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(i, count(5)); // expected-error {{expression has unknown bounds}}
   r = _Dynamic_bounds_cast<array_ptr<int>>(i, bounds(i, i + 1)); // expected-error 2 {{expected expression with pointer}}
 
   int len;
 
-  r = _Dynamic_bounds_cast<array_ptr<int>>(q, count(len));
+  r = _Dynamic_bounds_cast<array_ptr<int>>(q, count(len));       // expected-warning {{cannot prove declared bounds for r are valid after assignment}}
   r = _Dynamic_bounds_cast<array_ptr<int>>(q, bounds(q, q + 1)); // expected-error {{arithmetic on _Ptr type}}
 
   r = _Dynamic_bounds_cast<array_ptr<int>>(r, count(1));        // expected-error {{declared bounds for r are invalid after assignment}}

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -2,7 +2,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-check-bounds-decls -verify -verify-ignore-unexpected=note %s
 
 // Test expressions with standard signed and unsigned integers types as
 // arguments to count and byte_count.

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -153,12 +153,12 @@ extern void check_assign(int val, int p[10], int q[], int r checked[10], int s c
   nt_array_ptr<int> t12b = u;      // expected-error {{expression of incompatible type 'int _Checked[10]'}}
   array_ptr<int> t13 = s2d[0];
   array_ptr<int> t13a = w2d[0];
-  nt_array_ptr<int> t13b = w2d[0];
+  nt_array_ptr<int> t13b : bounds(unknown) = w2d[0];
   nt_array_ptr<int> t13c = s2d[0]; // expected-error {{expression of incompatible type 'int _Checked[10]'}}
   array_ptr<int> t14 = t2d[0];
   array_ptr<int> t15 = u2d[0];
   array_ptr<int> t15a = x2d[0];
-  nt_array_ptr<int> t15b = x2d[0];
+  nt_array_ptr<int> t15b : bounds(unknown) = x2d[0];
   nt_array_ptr<int> t15c = u2d[0]; // expected-error {{expression of incompatible type 'int _Checked[10]'}}
 
   // Multi-dimensional array type conversions to pointer types.
@@ -1316,7 +1316,9 @@ void check_pointer_arithmetic(void) {
 
   int *p_tmp;
   array_ptr<int> r_tmp;
-  nt_array_ptr<int> s_tmp = 0;
+  // s_tmp has default bounds of count(0).  We don't to test bounds
+  // declaration checking here, so set the bounds to unknown.
+  nt_array_ptr<int> s_tmp : bounds(unknown) = 0;
 
   p_tmp = p + 5;
   p_tmp = 5 + p;

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1316,8 +1316,8 @@ void check_pointer_arithmetic(void) {
 
   int *p_tmp;
   array_ptr<int> r_tmp;
-  // s_tmp has default bounds of count(0).  We don't to test bounds
-  // declaration checking here, so set the bounds to unknown.
+  // s_tmp has default bounds of count(0).  We don't to test bounds declaration
+  // checking at the assignments to s_tmp below, so set the bounds to unknown.
   nt_array_ptr<int> s_tmp : bounds(unknown) = 0;
 
   p_tmp = p + 5;

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -29,8 +29,7 @@ checked int f1(int *s : itype(ptr<int>)) {
   *(s+ 4) = 0;        // expected-error {{arithmetic on _Ptr type}}
   s[4] = 0;           // expected-error {{subscript of '_Ptr<int>'}}
 
-  // TODO: bounds declaration checking needs to understand equality after assignment
-  array_ptr<int> t4 : count(1) = s;  // expected-warning {{cannot prove declared bounds for 't4' are valid after initialization}}
+  array_ptr<int> t4 : count(1) = s;
   s = t4;
 
   array_ptr<float> t5 : count(1) = s; // expected-error {{incompatible type}}
@@ -65,9 +64,9 @@ checked int f3(int *s : itype(array_ptr<int>), int len) {
 checked int f4(int *s : itype(int checked[4])) {
   array_ptr<int> t1 = s + 4;
   int t2 = *s;
-  int t3 = s[4];
-  *(s + 4) = 0;
-  s[4] = 0;
+  int t3 = s[3];
+  *(s + 3) = 0;
+  s[3] = 0;
 
   return 0;
 }
@@ -145,8 +144,7 @@ checked void test_globals(void) {
   *(g1 + 4) = 0;       // expected-error {{arithmetic on _Ptr type}}
   g1[4] = 0;           // expected-error {{subscript of '_Ptr<int>'}}
 
-  // TODO: bounds declaration checking needs to understand equality after assignment
-  array_ptr<int> t4 : count(1) = g1;  // expected-warning {{cannot prove declared bounds for 't4' are valid after initialization}}
+  array_ptr<int> t4 : count(1) = g1;
   g1 = t4;
 
   array_ptr<float> t5 : count(1) = g1; // expected-error {{incompatible type}}
@@ -451,8 +449,7 @@ checked int f50(int **s : itype(ptr<ptr<int>>)) {
   *s += 5;            // expected-error {{arithmetic on _Ptr type}}
   s = s + 5;          // expected-error {{arithmetic on _Ptr type}}
 
-  // TODO: bounds declaration checking needs to understand equality after assignment
-  array_ptr<int> t5 : count(1) = *s; // expected-warning {{cannot prove declared bounds for 't5' are valid after initialization}}
+  array_ptr<int> t5 : count(1) = *s;
   *s = t5;
 
   array_ptr<float> t6 : count(1) = *s; // expected-error {{incompatible type}}

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -3,7 +3,7 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-check-bounds-decls -verify -verify-ignore-unexpected=note %s
 
 #include <stdchecked.h>
 

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -33,11 +33,6 @@ extern void f4();
 // a checked value.
 //
 
-// I don't understand the cast here either.
-struct S20 {
-  ptr<int>(*f)(); // expected-error {{function with no prototype cannot have a return type that is a checked type}}
-};
-
 enum E1 {
   EnumVal1,
   EnumVal2
@@ -62,3 +57,14 @@ long long int g26 : bounds(s1, s1 + 5) = (long long)s1;
 unsigned long long int g27 : bounds(s1, s1 + 5) = (long long)s1;
 // TODO: Enum size is implementation-defined
 // enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
+
+extern int f10(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
+extern int f10(int a, _Array_ptr<int> b,
+                _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (long long) b + a));
+extern int f10(int a, _Array_ptr<int> b,
+               _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (short) b + a)); // expected-error {{function redeclaration has conflicting parameter bounds}} \
+                                                                                 // expected-warning 2 {{cast to '_Array_ptr<int>' from smaller integer type 'short'}}
+
+extern int f11(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
+extern int f11(int a, _Array_ptr<int> b,
+                _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (void *) (long long) b + a));

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -58,3 +58,17 @@ long int g26 : bounds(s1, s1 + 5) = (long)s1;
 unsigned long int g27 : bounds(s1, s1 + 5) = (long)s1;
 // TODO: Enum size is implementation-defined
 // enum E1 g28 : bounds(s1, s1 + 5) = (int)s1;
+
+// Check that casts between pointers and long ints do not affect
+// equivalence of bounds
+
+extern int f10(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
+extern int f10(int a, _Array_ptr<int> b,
+                _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (long) b + a));
+extern int f10(int a, _Array_ptr<int> b,
+               _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (short) b + a)); // expected-error {{function redeclaration has conflicting parameter bounds}} \
+                                                                                 // expected-warning 2 {{cast to '_Array_ptr<int>' from smaller integer type 'short'}}
+
+extern int f11(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
+extern int f11(int a, _Array_ptr<int> b,
+                _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (void *) (long) b + a));

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -1164,7 +1164,9 @@ void check_pointer_arithmetic(void)
    // nt_array_ptr<void> is not allowed, so we don't have to test it.
    int *p_tmp;
    array_ptr<int> r_tmp;
-   nt_array_ptr<int> s_tmp = 0;
+   // By default, s_tmp has bounds of count(0).  We don't want to test checking
+   // of bounds declarations here, so set the bounds to unknown.
+   nt_array_ptr<int> s_tmp : bounds(unknown) = 0;
 
    p_tmp = p + 5;
    p_tmp = 5 + p;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -1165,7 +1165,8 @@ void check_pointer_arithmetic(void)
    int *p_tmp;
    array_ptr<int> r_tmp;
    // By default, s_tmp has bounds of count(0).  We don't want to test checking
-   // of bounds declarations here, so set the bounds to unknown.
+   // of bounds declarations at assignments to s_tmp below, so set the bounds to
+   // unknown.
    nt_array_ptr<int> s_tmp : bounds(unknown) = 0;
 
    p_tmp = p + 5;

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -351,14 +351,14 @@ void f72(int * fn(int *, int *) : itype(ptr<int>));
 
 //---------------------------------------------------------------------------//
 // The bounds declarations must be syntactically identical for now, modulo   //
-// parameter names.                                                          //
+// parameter names and ignoring value-preserving operations                  //
 //---------------------------------------------------------------------------//
 
 void f80(int *p : count(len), int len);
 // Rename parameters
 void f80(int *p : count(mylen), int mylen);
 void f80(int *r : count(i), int i);
-void f80(int *p : count((len)), int len); // expected-error {{conflicting parameter bounds}}
+void f80(int *p : count((len)), int len);
 
 void f81(int *p : count(len), int len);
 void f81(int *p : bounds(p, p + len), int len);  // expected-error {{conflicting parameter bounds}}

--- a/tests/typechecking/type_check_bounds_cast.c
+++ b/tests/typechecking/type_check_bounds_cast.c
@@ -86,10 +86,10 @@ extern void f6() {
         _Assume_bounds_cast<array_ptr<int>>(i, bounds(int_ptr_lb, int_array_ptr_ub));
 }
 
-extern void f7() {
+extern void f7(void *p) {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>>(h4(), count(3));
+  r = _Assume_bounds_cast<array_ptr<int>>(p, count(3));
   q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 


### PR DESCRIPTION
This matches a compiler change that turns on checking of bounds declarations everywhere and teaches the compiler about simple equality facts (PR https://github.com/Microsoft/checkedc-clang/pull/476).

Checking of bounds declarations is a static analysis that checks that declared bounds are valid (follow from existing bounds and other information in the environment). It was only on by default for checked scopes.  It is now on by default for unchecked scopes too.   The checking of bounds declarations is still simple, so it may produce unnecessary warnings.   It can be turned off using  `-Wno-check-bounds-decls` (everywhere), `-Wno-check-bounds-decl-unchecked-scope` (for unchecked scopes), and `-Wno-check-bounds-decls-checked-scope` (for checked scopes), 

  - Added more tests of expression equivalence (lexical_equality.c should be renamed because it now tests for expression equivalence using a few additional facts about C expressions).
  - Updated tests to handle the fact that checking of bounds declaration is on everywhere by default.  Replace a bunch of TODO's with expected warning messages. Also deleted some warnings that are no longer issued because the compiler can prove the bounds are valid.
  - Kept checking of bounds declarations on for most tests and only disabled it for some parsing and typechecking tests.
  - In some cases, made simple changes to avoid warnings about bounds declarations (the original cases will be captured in the new Checked C clang repo file test/CheckedC/static-checking/bounds-decl-challenges.c)
