### PR TITLE
Improve tests for function pointers casts.

### DIFF
--- a/tests/typechecking/function_casts.c
+++ b/tests/typechecking/function_casts.c
@@ -313,7 +313,7 @@ struct myops {
 };
 
 struct mystruct {
-	const struct myops *ops : itype(_Ptr<const struct myops>);
+	const struct myops *ops : itype(ptr<const struct myops>);
 };
 
 void myfunc(struct mystruct *s) {
@@ -325,13 +325,19 @@ void myfunc(struct mystruct *s) {
 #pragma BOUNDS_CHECKED ON
 
 struct myops_checked {
-   void ((*myfptr)(void)) : itype(_Ptr<void (void)>);
+  void ((*myfptr)(void)) : itype(ptr<void (void)>);
 };
 
 struct mystruct_checked {
-	const struct myops_checked *ops : itype(_Ptr<const struct myops_checked>);
+	const struct myops_checked *ops : itype(ptr<const struct myops_checked>);
 };
 
-void myfunc_checked(struct mystruct_checked *s : itype(_Ptr<struct mystruct_checked>)) {
-	s->ops->myfptr();
+void myfunc_checked(struct mystruct_checked *s : itype(ptr<struct mystruct_checked>)) {
+  s->ops->myfptr();
+}
+
+#pragma BOUNDS_CHECKED OFF
+
+void bounds_safe_interface_assign(struct myops_checked s1, ptr<void(void)> p) {
+  s1.myfptr = p;
 }


### PR DESCRIPTION
A programmer reported that a function call involving a const member with checked function pointer type resulted in an unexpected compiler error (https://github.com/Microsoft/checkedc-clang/issues/481).   This is due to a compiler bug.  This change improves the testing of function pointer casts.
- Add tests of assignments to members with function pointer types.
- Add tests of calls via members with function pointer types.
- Add tests of uses of const members with function pointer types.  These
  uses include member reads, member writes, and indirect calls via members.
- Add case from programmer bug report.
- Spot check uses of members with bounds-safe interfaces that are checked
  function pointer types.

The compiler bug will be fixed by PR https://github.com/Microsoft/checkedc-clang/pull/482.   

C provides no way to ensure that function pointer casts are correct.  It allows casts between function pointers with different numbers of arguments, for example, which can result in crashes involving corrupted stack pointers.

Checked C restricts casts to checked function pointer to ensure that values are actually valid function pointers.  For example, casts from a variable with an unchecked function pointer type to a checked function pointer type is not allowed.  The variable with unchecked type could have been
corrupted via an incorrect function pointer cast.  Checked C allows casts from declared functions, null pointers, and values with checked pointer types. It also allows casts via value-preserving casts and cast-like operations applied to these expressions.  (address-of and dereference of function pointer types are value-preserving operations).
