### PR TITLE
Add unistd_checked.h to CMakeLists.txt

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -18,6 +18,7 @@ set(files
   string_checked.h
   threads_checked.h
   time_checked.h
+  unistd_checked.h
   _builtin_stdio_checked.h
   _builtin_string_checked.h
   _builtin_common.h


### PR DESCRIPTION
unistd_checked.h was missing from CMakeLists and couldn't be found by Clang. This change adds it.