### PR TITLE
New header with additional bounds-safe interfaces

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -22,6 +22,7 @@ set(files
   _builtin_stdio_checked.h
   _builtin_string_checked.h
   _builtin_common.h
+  checkedc_extensions.h
   )
 
 # Hack - compute the CLANG version from the LLVM version.  The

--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -10,7 +10,8 @@
 #include <stdlib_checked.h>
 #include <string_checked.h>
 
-// default strncmp assumes nt_array_ptr; this option is for array_ptr
+// default strncmp has a bounds-safe interface nt_array_ptr;
+// this option is for array_ptr
 extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 : count(n), size_t n) {
   _Unchecked { return strncmp(src, s2, n); }
 }

--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -1,0 +1,24 @@
+//--------------------------------------------------------------------------//
+// Additional bounds-safe interface options for functions that have         //
+// different interfaces for array_ptr and nt_array_ptr args. Programmer can //
+// choose to use these over the default bounds-safe interfaces.             //
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef __CHECKED_C_EXTENSIONS_H
+#define __CHECKED_C_EXTENSIONS_H
+
+#include <stdlib_checked.h>
+#include <string_checked.h>
+
+// default strncmp assumes nt_array_ptr; this option is for array_ptr
+extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 : count(n), size_t n) {
+  _Unchecked { return strncmp(src, s2, n); }
+}
+
+// default free assumes at least one byte of memory, not always true for nt_arrays
+// TODO: Will be able to do nt_array_ptr<void> after polymorphism implemented
+extern inline void free_nt_array_ptr(void *pointer : count(0)) {
+  _Unchecked { free(pointer); }
+}
+
+#endif /* __CHECKED_C_EXTENSIONS_H */

--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -17,7 +17,7 @@ extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 :
 
 // default free assumes at least one byte of memory, not always true for nt_arrays
 // TODO: Will be able to do nt_array_ptr<void> after polymorphism implemented
-extern inline void free_nt_array_ptr(void *pointer : count(0)) {
+extern inline void free_nt_array_ptr(void *pointer : byte_count(0)) {
   _Unchecked { free(pointer); }
 }
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -56,7 +56,7 @@ unsigned long long int strtoull(const char * restrict nptr :
 // TODO: express alignment constraints once where clauses have been added.
 void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
-void free(void *pointer : byte_count(1));
+void free(void *pointer : byte_count(1)); // for _Array_ptr
 void *malloc(size_t size) : byte_count(size);
 void *realloc(void *pointer : byte_count(1), size_t size) : byte_count(size);
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -56,7 +56,12 @@ unsigned long long int strtoull(const char * restrict nptr :
 // TODO: express alignment constraints once where clauses have been added.
 void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
-void free(void *pointer : byte_count(1)); // for _Array_ptr
+void free(void *pointer : byte_count(1)); // for _Ptr and _Array_ptr
+// Note: there's a separate bounds-safe interface for freeing _Nt_array_ptr-
+// typed arguments (which by default have a byte_count of 0) in the
+// checkedc_extensions.h header file.
+
+
 void *malloc(size_t size) : byte_count(size);
 void *realloc(void *pointer : byte_count(1), size_t size) : byte_count(size);
 

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -109,7 +109,9 @@ int strcoll(const char *src1 : itype(_Nt_array_ptr<const char>),
             const char *src2 : itype(_Nt_array_ptr<const  char>));
 
 
-int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
+int strncmp(const char *src : itype(_Nt_array_ptr<const char>),
+            const char *s2 : itype(_Nt_array_ptr<const char>),
+            size_t n);
 
 size_t strxfrm(char * restrict dest : count(n),
                const char * restrict src :
@@ -135,8 +137,6 @@ size_t strspn(const char *s1 : itype(_Nt_array_ptr<const char>),
 char *strstr(const char *s1 : itype(_Nt_array_ptr<const char>),
              const char *s2 : itype(_Nt_array_ptr<const char>)) :
   itype(_Nt_array_ptr<char>);
-// TODO: remove count(0) on return value after
-// https://github.com/Microsoft/checkedc-clang/issues/424 is addressed
 char *strtok(char * restrict s1 : itype(restrict _Nt_array_ptr<char>),
              const char * restrict s2 : itype(restrict _Nt_array_ptr<const char>)) :
   itype(_Nt_array_ptr<char>);

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -108,7 +108,13 @@ int strcmp(const char *src1 : itype(_Nt_array_ptr<const char>),
 int strcoll(const char *src1 : itype(_Nt_array_ptr<const char>),
             const char *src2 : itype(_Nt_array_ptr<const  char>));
 
-
+// strncmp takes possibly null-terminated strings as arguments and checks
+// up to n characters. For a bounds-safe interface, this means each string
+// needs to be EITHER null-terminated OR have bounds greater than or equal to
+// n. We cannot express them both in a single interface, so this is the
+// interface for null-terminated strings (assumed to be the most common case).
+// In the checkedc_extensions.h header there is a bounds-safe interface for
+// use of _Array_ptr rather than _Nt_array_ptr.
 int strncmp(const char *src : itype(_Nt_array_ptr<const char>),
             const char *s2 : itype(_Nt_array_ptr<const char>),
             size_t n);

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -19,6 +19,7 @@
 #define _CHECKEDC_MOCKUP_THREADS 1
 #include "../../include/threads_checked.h"
 #include "../../include/time_checked.h"
+#include "../../include/checkedc_extensions.h"
 
 // Posix Headers
 //


### PR DESCRIPTION
Added a new header `checkedc_extensions.h` which specifies extra bounds-safe interfaces that can be chosen by the programmer when functions have different interfaces for `array_ptr` and `nt_array_ptr`. Added it to the `CMakeLists.txt` in the include folder and added it to the header inclusion test `tests/typechecking/redeclare_libraries.c`. Passes this test and functions properly when compiling example third-party code.

Addresses #291 and #290 