### PR TITLE
Bounds-safe interface for function in errno

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,7 +7,8 @@
 # library just to get the Checked C include wrpaper files.
 # So we place the header files with the compiler.
 
-set(files 
+set(files
+  errno_checked.h
   fenv_checked.h
   inttypes_checked.h
   math_checked.h

--- a/include/errno_checked.h
+++ b/include/errno_checked.h
@@ -3,6 +3,9 @@
 //                                                                    //
 ////////////////////////////////////////////////////////////////////////
 
+#ifndef __ERRNO_CHECKED_H
+#define __ERRNO_CHECKED_H
+
 #include <errno.h>
 
 #pragma CHECKED_SCOPE ON
@@ -10,3 +13,5 @@
 extern int* __errno_location(void) : itype(_Ptr<int>) __THROW __attribute_const__;
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/errno_checked.h
+++ b/include/errno_checked.h
@@ -1,0 +1,12 @@
+//--------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in errno.h                    //
+//                                                                    //
+////////////////////////////////////////////////////////////////////////
+
+#include <errno.h>
+
+#pragma CHECKED_SCOPE ON
+
+extern int* __errno_location(void) : itype(_Ptr<int>) __THROW __attribute_const__;
+
+#pragma CHECKED_SCOPE OFF

--- a/include/errno_checked.h
+++ b/include/errno_checked.h
@@ -16,6 +16,7 @@
 __declspec(dllimport) int* __cdecl _errno(void) : itype(_Ptr<int>);
 #else
 extern int* __errno_location(void) : itype(_Ptr<int>) __THROW __attribute_const__;
+#endif
 
 #pragma CHECKED_SCOPE OFF
 

--- a/include/errno_checked.h
+++ b/include/errno_checked.h
@@ -3,15 +3,21 @@
 //                                                                    //
 ////////////////////////////////////////////////////////////////////////
 
+#include <errno.h>
+
+#ifndef __cplusplus
 #ifndef __ERRNO_CHECKED_H
 #define __ERRNO_CHECKED_H
 
-#include <errno.h>
 
 #pragma CHECKED_SCOPE ON
 
+#if defined(_WIN32) || defined(_WIN64)
+__declspec(dllimport) int* __cdecl _errno(void) : itype(_Ptr<int>);
+#else
 extern int* __errno_location(void) : itype(_Ptr<int>) __THROW __attribute_const__;
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif // guards
+#endif // c++

--- a/tests/typechecking/errno-use.c
+++ b/tests/typechecking/errno-use.c
@@ -1,0 +1,15 @@
+// Quick test for errno bounds safe interface
+// 
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang -fsyntax-only -Werror %s
+
+#include <stdchecked.h>
+#include <errno_checked.h>
+
+#pragma CHECKED_SCOPE ON
+
+void f1(void)
+{
+	errno = 0;
+}

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -9,6 +9,7 @@
 // RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=2 %s
 
 // C Standard
+#include "../../include/errno_checked.h"
 #include "../../include/fenv_checked.h"
 #include "../../include/inttypes_checked.h"
 #include "../../include/math_checked.h"


### PR DESCRIPTION
One of the files I'm converting uses `errno`. This makes CheckedC unhappy because the function that makes errno (inside a layer of macros) returns an `int*`. This PR adds a new `errno_checked.h` header file to provide a bounds-safe interface for that function. It passes the `redeclare_libraries` test and gets rid of the errors in my converted file. `errno.h` is a short header; I believe this is the only function.