### PR TITLE
Add header guards

### DIFF
--- a/include/fenv_checked.h
+++ b/include/fenv_checked.h
@@ -6,6 +6,9 @@
 // specification.                                                     //
 ////////////////////////////////////////////////////////////////////////
 
+#ifndef __FENV_CHECKED_H
+#define __FENV_CHECKED_H
+
 #include <fenv.h>
 
 #pragma CHECKED_SCOPE ON
@@ -18,3 +21,5 @@ int fesetenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
 int feupdateenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/fenv_checked.h
+++ b/include/fenv_checked.h
@@ -6,10 +6,11 @@
 // specification.                                                     //
 ////////////////////////////////////////////////////////////////////////
 
+#include <fenv.h>
+
+#ifndef __cplusplus
 #ifndef __FENV_CHECKED_H
 #define __FENV_CHECKED_H
-
-#include <fenv.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -22,4 +23,5 @@ int feupdateenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
 
 #pragma CHECKED_SCOPE OFF
 
+#endif
 #endif

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -6,6 +6,9 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __INTTYPES_CHECKED_H
+#define __INTTYPES_CHECKED_H
+
 #include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
 #include <inttypes.h>
 
@@ -39,3 +42,5 @@ uintmax_t wcstoumax(const wchar_t * restrict nptr :
                     int base);
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -6,11 +6,12 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __INTTYPES_CHECKED_H
-#define __INTTYPES_CHECKED_H
-
 #include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
 #include <inttypes.h>
+
+#ifndef __cplusplus
+#ifndef __INTTYPES_CHECKED_H
+#define __INTTYPES_CHECKED_H
 
 #pragma CHECKED_SCOPE ON
 
@@ -43,4 +44,5 @@ uintmax_t wcstoumax(const wchar_t * restrict nptr :
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif // guard
+#endif // no c++

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -6,10 +6,11 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#include <math.h>
+
+#ifndef __cplusplus
 #ifndef __MATH_CHECKED_H
 #define __MATH_CHECKED_H
-
-#include <math.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -32,4 +33,5 @@ long double nanl(const char *t : itype(_Nt_array_ptr<const char>));
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif //guard
+#endif // no c++

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -6,6 +6,9 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __MATH_CHECKED_H
+#define __MATH_CHECKED_H
+
 #include <math.h>
 
 #pragma CHECKED_SCOPE ON
@@ -28,3 +31,5 @@ float nanf(const char *t : itype(_Nt_array_ptr<const char>));
 long double nanl(const char *t : itype(_Nt_array_ptr<const char>));
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -3,6 +3,9 @@
 // take pointer arguments.                                             //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __SIGNAL_CHECKED_H
+#define __SIGNAL_CHECKED_H
+
 #include <signal.h>
 
 #pragma CHECKED_SCOPE ON
@@ -15,3 +18,5 @@ void (*signal(int sig,
      )(int);
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -3,10 +3,11 @@
 // take pointer arguments.                                             //
 /////////////////////////////////////////////////////////////////////////
 
+#include <signal.h>
+
+#ifndef __cplusplus
 #ifndef __SIGNAL_CHECKED_H
 #define __SIGNAL_CHECKED_H
-
-#include <signal.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -19,4 +20,5 @@ void (*signal(int sig,
 
 #pragma CHECKED_SCOPE OFF
 
+#endif
 #endif

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -8,6 +8,9 @@
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __STDIO_CHECKED_H
+#define __STDIO_CHECKED_H
+
 #include <stdio.h>
 
 #pragma CHECKED_SCOPE ON
@@ -183,3 +186,5 @@ void perror(const char *s : itype(_Nt_array_ptr<const char>));
 #include "_builtin_stdio_checked.h"
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -8,10 +8,11 @@
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
+#include <stdio.h>
+
+#ifndef __cplusplus
 #ifndef __STDIO_CHECKED_H
 #define __STDIO_CHECKED_H
-
-#include <stdio.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -187,4 +188,5 @@ void perror(const char *s : itype(_Nt_array_ptr<const char>));
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif // guard
+#endif // no C++

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -5,6 +5,10 @@
 // These are listed in the same order that they occur in the C11       //
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
+
+#ifndef __STDLIB_CHECKED_H
+#define __STDLIB_CHECKED_H
+
 #include <stdlib.h>
 
 #pragma CHECKED_SCOPE ON
@@ -113,3 +117,5 @@ size_t wcstombs(char * restrict output : count(n),
                 size_t n);
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -6,10 +6,13 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+
+#include <stdlib.h>
+
+#ifndef __cplusplus
 #ifndef __STDLIB_CHECKED_H
 #define __STDLIB_CHECKED_H
 
-#include <stdlib.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -118,4 +121,5 @@ size_t wcstombs(char * restrict output : count(n),
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif  // guard
+#endif  // no c++

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -11,6 +11,9 @@
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __STRING_CHECKED_H
+#define __STRING_CHECKED_H
+
 #include <string.h>
 
 #pragma CHECKED_SCOPE ON
@@ -153,3 +156,5 @@ size_t strlen(const char *s : itype(_Nt_array_ptr<const char>));
 #include "_builtin_string_checked.h"
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -11,10 +11,13 @@
 // TODO: Better Support for _FORTIFY_SOURCE > 0                        //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __STRING_CHECKED_H
-#define __STRING_CHECKED_H
 
 #include <string.h>
+
+#ifndef __cplusplus
+
+#ifndef __STRING_CHECKED_H
+#define __STRING_CHECKED_H
 
 #pragma CHECKED_SCOPE ON
 
@@ -157,4 +160,5 @@ size_t strlen(const char *s : itype(_Nt_array_ptr<const char>));
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif // guard
+#endif // no C++

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -6,8 +6,7 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __THREADS_CHECKED_H
-#define __THREADS_CHECKED_H
+
 
 #ifdef _CHECKEDC_MOCKUP_THREADS
 // C implementations may not support the C11 threads package or even the
@@ -25,6 +24,10 @@ struct timespec;
 #else
 #include <threads.h>
 #endif
+
+#ifndef __cplusplus
+#ifndef __THREADS_CHECKED_H
+#define __THREADS_CHECKED_H
 
 #pragma CHECKED_SCOPE ON
 
@@ -68,4 +71,5 @@ int tss_set(tss_t key, void *value : itype(_Ptr<void>));
 
 #pragma CHECKED_SCOPE OFF
 
-#endif
+#endif // guard
+#endif // no C++

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -6,6 +6,9 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __THREADS_CHECKED_H
+#define __THREADS_CHECKED_H
+
 #ifdef _CHECKEDC_MOCKUP_THREADS
 // C implementations may not support the C11 threads package or even the
 // macro that says C11 threads are not supported.  This mocks up
@@ -64,3 +67,5 @@ void *tss_get(tss_t key) : itype(_Ptr<void>);
 int tss_set(tss_t key, void *value : itype(_Ptr<void>));
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -6,10 +6,11 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#include <time.h>
+
+#ifndef __cplusplus
 #ifndef __TIME_CHECKED_H
 #define __TIME_CHECKED_H
-
-#include <time.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -38,4 +39,5 @@ size_t strftime(char * restrict output : count(maxsize),
 
 #pragma CHECKED_SCOPE OFF
 
+#endif
 #endif

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -6,6 +6,9 @@
 // specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __TIME_CHECKED_H
+#define __TIME_CHECKED_H
+
 #include <time.h>
 
 #pragma CHECKED_SCOPE ON
@@ -34,3 +37,5 @@ size_t strftime(char * restrict output : count(maxsize),
                    itype(restrict _Ptr<const struct tm>));
 
 #pragma CHECKED_SCOPE OFF
+
+#endif

--- a/include/unistd_checked.h
+++ b/include/unistd_checked.h
@@ -5,10 +5,11 @@
 // These are POSIX-only                                                //
 /////////////////////////////////////////////////////////////////////////
 
+#include <unistd.h>
+
+#ifndef __cplusplus
 #ifndef __UNISTD_CHECKED_H
 #define __UNISTD_CHECKED_H
-
-#include <unistd.h>
 
 #pragma CHECKED_SCOPE ON
 
@@ -20,4 +21,5 @@ extern char ** environ : itype(_Nt_array_ptr<_Nt_array_ptr<char>>);
 
 #pragma CHECKED_SCOPE OFF
 
+#endif
 #endif

--- a/include/unistd_checked.h
+++ b/include/unistd_checked.h
@@ -5,6 +5,9 @@
 // These are POSIX-only                                                //
 /////////////////////////////////////////////////////////////////////////
 
+#ifndef __UNISTD_CHECKED_H
+#define __UNISTD_CHECKED_H
+
 #include <unistd.h>
 
 #pragma CHECKED_SCOPE ON
@@ -16,3 +19,5 @@ extern char ** environ : itype(_Nt_array_ptr<_Nt_array_ptr<char>>);
 #endif
 
 #pragma CHECKED_SCOPE OFF
+
+#endif


### PR DESCRIPTION
Our standard library bounds safe interface headers didn't have guards. This fixes that.
(Completed entirely while code was compiling...)