### PR TITLE
Require byte_count(0) of the arg to free

### DIFF
--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -16,10 +16,4 @@ extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 :
   _Unchecked { return strncmp(src, s2, n); }
 }
 
-// default free assumes at least one byte of memory, not always true for nt_arrays
-// TODO: Will be able to do nt_array_ptr<void> after polymorphism implemented
-extern inline void free_nt_array_ptr(void *pointer : byte_count(0)) {
-  _Unchecked { free(pointer); }
-}
-
 #endif /* __CHECKED_C_EXTENSIONS_H */

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -63,12 +63,7 @@ unsigned long long int strtoull(const char * restrict nptr :
 // TODO: express alignment constraints once where clauses have been added.
 void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
-void free(void *pointer : byte_count(1)); // for _Ptr and _Array_ptr
-// Note: there's a separate bounds-safe interface for freeing _Nt_array_ptr-
-// typed arguments (which by default have a byte_count of 0) in the
-// checkedc_extensions.h header file.
-
-
+void free(void *pointer : byte_count(0));
 void *malloc(size_t size) : byte_count(size);
 void *realloc(void *pointer : byte_count(1), size_t size) : byte_count(size);
 


### PR DESCRIPTION
We decided to change the bounds-safe interface requirement of the argument passed to free to be byte_count(0) rather than byte_count(1). This means we no longer need the extra version of free in checkedc_extensions, or several lines of commentary.

Addresses #290 