### PR TITLE
Bounds-safe interface for assert

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,7 +7,7 @@
 # library just to get the Checked C include wrpaper files.
 # So we place the header files with the compiler.
 
-set(files 
+set(files
   assert_checked.h
   errno_checked.h
   fenv_checked.h

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,7 +7,8 @@
 # library just to get the Checked C include wrpaper files.
 # So we place the header files with the compiler.
 
-set(files
+set(files 
+  assert_checked.h
   errno_checked.h
   fenv_checked.h
   inttypes_checked.h

--- a/include/assert_checked.h
+++ b/include/assert_checked.h
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in stdlib.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+/////////////////////////////////////////////////////////////////////////
+
+
+#include <assert.h>
+
+#ifndef __cplusplus
+#ifndef __ASSERT_CHECKED_H
+#define __ASSERT_CHECKED_H
+
+#pragma CHECKED_SCOPE ON
+
+#if defined(_WIN32) || defined(_WIN64)
+_ACRTIMP void __cdecl _wassert(_In_z_ wchar_t const *_Message : itype(_Nt_array_ptr>),
+                               _In_z_ wchar_t const *_File : itype(<_Nt_array_ptr>),
+                               _In_ unsigned _Line);
+#else
+// not sure what to do on Linux
+#endif
+
+#pragma CHECKED_SCOPE OFF
+
+#endif  // guard
+#endif  // no c++

--- a/include/assert_checked.h
+++ b/include/assert_checked.h
@@ -16,11 +16,14 @@
 #pragma CHECKED_SCOPE ON
 
 #if defined(_WIN32) || defined(_WIN64)
-_ACRTIMP void __cdecl _wassert(_In_z_ wchar_t const *_Message : itype(_Nt_array_ptr>),
-                               _In_z_ wchar_t const *_File : itype(<_Nt_array_ptr>),
+_ACRTIMP void __cdecl _wassert(_In_z_ wchar_t const *_Message : itype(_Nt_array_ptr<const wchar_t>),
+                               _In_z_ wchar_t const *_File : itype(_Nt_array_ptr<const wchar_t>),
                                _In_ unsigned _Line);
 #else
-// not sure what to do on Linux
+extern void __assert(const char *msg : itype(_Nt_array_ptr<const char>), 
+					 const char *file : itype(_Nt_array_ptr<const char>), 
+					 int line);
+
 #endif
 
 #pragma CHECKED_SCOPE OFF

--- a/include/assert_checked.h
+++ b/include/assert_checked.h
@@ -1,9 +1,7 @@
 //---------------------------------------------------------------------//
-// Bounds-safe interfaces for functions in stdlib.h that               //
+// Bounds-safe interfaces for some functions in assert.h that          //
 // take pointer arguments.                                             //
 //                                                                     //
-// These are listed in the same order that they occur in the C11       //
-// specification.                                                      //
 /////////////////////////////////////////////////////////////////////////
 
 

--- a/tests/typechecking/redeclare_libraries.c
+++ b/tests/typechecking/redeclare_libraries.c
@@ -9,6 +9,7 @@
 // RUN: %clang -fsyntax-only -D_FORTIFY_SOURCE=2 %s
 
 // C Standard
+#include "../../include/assert_checked.h"
 #include "../../include/errno_checked.h"
 #include "../../include/fenv_checked.h"
 #include "../../include/inttypes_checked.h"


### PR DESCRIPTION
Both Windows and Linux have some interesting things going on with their use of assert. Add a new header with bounds-safe interface for the function eventually called by assert macros in the case of failure.