### PR TITLE
Tests for parsing and type checking return_value expressions.

### DIFF
--- a/include/stdchecked.h
+++ b/include/stdchecked.h
@@ -11,5 +11,6 @@
 #define dynamic_check _Dynamic_check
 #define dynamic_bounds_cast _Dynamic_bounds_cast
 #define assume_bounds_cast _Assume_bounds_cast
+#define return_value _Return_value
 
 #endif /* __STDCHECKED_H */

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -4,9 +4,6 @@
 //
 // RUN: %clang_cc1 -Wno-check-bounds-decls -verify -verify-ignore-unexpected=note %s
 
-// Test expressions with standard signed and unsigned integers types as
-// arguments to count and byte_count.
-
 #include <stdchecked.h>
 
 static int A = 8;
@@ -28,6 +25,9 @@ enum E1 {
   EnumVal1,
   EnumVal2
 };
+
+// Test expressions with standard signed and unsigned integers types as
+// arguments to count and byte_count.
 
 extern void count_exprs(void) {
   char c1 = 8;
@@ -1066,7 +1066,7 @@ void fn263(array_ptr<void> (*fnptr)(void) : count(5)); // expected-error {{count
 // Test bounds declarations for function pointers
 //
 
-void function_pointers() {
+void function_pointers(void) {
   // Assignments to function pointers with return bounds on array_ptr types
   array_ptr<int>(*t1)(void) : count(5) = fn1;
   nt_array_ptr<int>(*t1a)(void) : count(0) = fn1a;
@@ -1143,9 +1143,21 @@ void function_pointers() {
   fn231(fn111);
 }
 
-void invalid_function_pointers() {
+void invalid_function_pointers(void) {
   array_ptr<int>(*t1)(void) : count(4) = fn1;  // expected-error {{incompatible type}}
   ptr<array_ptr<int>(void) : count(4)> t1a = fn1;  // expected-error {{incompatible type}}
   array_ptr<int>(*t4)(void) : byte_count(6 * sizeof(int)) = fn4; // expected-error {{incompatible type}}
   array_ptr<int>(*t10)(void) : bounds(s1, s1 + 4) = fn10; // expected-error {{incompatible type}}
 }
+
+// Test type checking of return_value
+
+extern int arr[10];
+int f300(void) : bounds(arr, arr + return_value);
+array_ptr<int> f301(void) : bounds(return_value, return_value + 10);
+array_ptr<int> f302(void) : bounds(return_value - 5, return_value + 5);
+array_ptr<int> f303(void) : count(return_value); // expected-error {{invalid argument type}}
+array_ptr<int> f304(void) : bounds(arr, arr + (return_value << 5)); // expected-error {{invalid operands to binary expression}}
+// TODO: Github issue #543.  Duplicate error mesages issued for type checking
+// error in bounds expression.
+array_ptr<void> f305(void) : bounds(return_value, return_value + 5); // expected-error 2 {{arithmetic on a pointer to void}}

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -122,7 +122,7 @@ scope must have a pointer, array or function type that uses only checked types o
 //   entity.
 
 //
-// Test types that are allowed for parameters in checked scopes.
+// Test types that are allowed for parameters and returns in checked scopes.
 //
 
 checked int func4(int p[]) {  // expected-error {{parameter in a checked scope must have a checked type or a bounds-safe interface}}

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -273,6 +273,17 @@ checked int *f21b(int *b : count(4)) : byte_count(4 * sizeof(int)) {
   return b;
 }
 
+checked int *f21c(int *b : count(4)) : bounds(return_value, return_value + 4) {
+  return b;
+}
+
+checked int *f21d(int *b : count(4)) :
+   bounds((array_ptr<char>)return_value,
+          (array_ptr<char>)return_value + (4 * sizeof(int))) {
+  return b;
+}
+
+
 // Test checked return types implied by a bounds-safe interface
 checked void test_checked_returns(void) {
   int arr1 checked[5][5];
@@ -284,6 +295,8 @@ checked void test_checked_returns(void) {
   array_ptr<int> t3 = 0;
   t3 = f21a(arr2);
   t3 = f21b(arr2);
+  t3 = f21c(arr2);
+  t3 = f21d(arr2);
 }
 
 // No-prototype functions with a bounds-safe interface on the return type

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -50,6 +50,9 @@ void f8a(char *, int len);
 int *f20(int len);
 int *f20(int len) : count(len);
 
+int *f20a(int len);
+int *f20a(int len) : bounds(return_value, return_value + len);
+
 int *f21(int len);
 int *f21(int len) : byte_count(len * sizeof(int));
 
@@ -63,6 +66,9 @@ char *f22a(int len) : itype(nt_array_ptr<char>);
 int *f23(int len) : count(len);
 int *f23(int len);
 
+int *f23a(int len) : bounds(return_value, return_value + len);;
+int *f23a(int len);
+
 int *f24(int len) : byte_count(len * sizeof(int));
 int *f24(int len);
 
@@ -71,6 +77,8 @@ int *f25(int len);
 
 char *f25a(int len) : itype(nt_array_ptr<char>);
 char *f25a(int len);
+
+
 
 //---------------------------------------------------------------------------//
 // Redeclarations of functions that have parameters with unchecked types     //
@@ -238,6 +246,10 @@ int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
 int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
 int *f52(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // expected-error {{conflicting return bounds}}
 
+int *f52a(int *p : bounds(p, p + len), int len) : bounds(return_value, return_value + len);
+int *f52a(int *p : bounds(p, p + len), int len) : bounds(return_value, return_value + len);
+int *f52a(int *p : bounds(p, p + len), int len) : bounds(return_value, return_value + len + 1);  // expected-error {{conflicting return bounds}}
+
 int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len);
 int *f53(int *p, int len);
 // A redeclaration without a bounds-safe interface is compatible with the
@@ -247,6 +259,11 @@ int *f53(int *p : bounds(p, p + len), int len) : bounds(p, p + len + 1);  // exp
 
 int *f54(int len) : itype(ptr<int>);
 int *f54(int len) : count(len);  // expected-error {{added return bounds}}
+
+// Require syntactic identity for return bounds, even when an expanded
+// form is used.
+int *f54a(int *p : bounds(p, p + len), int len) : count(len);
+int *f54a(int *p : bounds(p, p + len), int len) : bounds(return_value, return_value + len);  // expected-error {{conflicting return bounds}}
 
 //
 // Bounds declarations plus interface types
@@ -306,6 +323,10 @@ char *f50l(int len) : itype(nt_array_ptr<char>) count(1);  // expected-error {{c
 array_ptr<int> f60(int len) : count(len);
 array_ptr<int> f60(int len) : count(len);
 array_ptr<int> f60(int len) : count(len + 1); // expected-error {{conflicting return bounds}}
+
+array_ptr<int> f60a(int len) : bounds(return_value, return_value + len);
+array_ptr<int> f60a(int len) : bounds(return_value, return_value + len);
+array_ptr<int> f60a(int len) : bounds(return_value, return_value + (len + 1)); // expected-error {{conflicting return bounds}}
 
 array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);
 array_ptr<int> f61(array_ptr<int> p : count(len), int len) : bounds(p, p + len);


### PR DESCRIPTION
This changes add tests for parsing and type checking of return_value expressions.  This matches the compiler pull request at https://github.com/Microsoft/checkedc-clang/pull/544.