### PR TITLE
Adding support for polymorphic bounds safe interface functions.

### DIFF
--- a/tests/typechecking/itype_generic_functions.c
+++ b/tests/typechecking/itype_generic_functions.c
@@ -44,7 +44,7 @@ void CallItypeGenericFunctions(void) {
   checked {
     p = validItypeGenericFunction<float>(5, p2, p2);
     //Checked scope expects type arguments
-    validItypeGenericFunction(5, 0, 0); //expected-error {{expected a list of type arguments for an itype generic function}}
+    validItypeGenericFunction(5, 0, 0); //expected-error {{expected a list of type arguments for a generic function}}
   }
   unchecked{
     void * p3 = (void *) p2;

--- a/tests/typechecking/itype_generic_functions.c
+++ b/tests/typechecking/itype_generic_functions.c
@@ -1,0 +1,56 @@
+#include <stdchecked.h>
+// Test type checking of itype generic function calls.
+//
+// RUN: %clang_cc1 -verify -verify-ignore-unexpected=note %s
+
+//
+// Test mismatches between the number of type variables and type arguments.
+//
+_Itype_for_any(T) void* oneTypeVariable(void* a : itype(_Ptr<T>), void* b : itype(_Ptr<T>)) : itype(_Ptr<T>) {
+  return a;
+}
+
+_Itype_for_any(T, Q) void* manyTypeVariables(void* a : itype(_Ptr<T>), void* b : itype(_Ptr<Q>)) : itype(_Ptr<Q>) {
+  return b;
+}
+
+
+_Itype_for_any(T)
+void* validItypeGenericFunction(int a, void* b : itype(_Ptr<T>), void* c : itype(_Ptr<T>)) : itype(_Ptr<T>);
+
+_Itype_for_any(T)
+void* validItypeGenericFunction(int a, void* b : itype(_Ptr<T>) , void* c : itype(_Ptr<T>) ) : itype(_Ptr<T>) {
+  _Ptr<T> m = b;
+  return m;
+}
+
+
+
+void CallItypeGenericFunctions(void) {
+  int a = 0, b = 0, c = 0, d = 0;
+  _Ptr<int> ap = &a;
+  _Ptr<int> bp = &b;
+  _Ptr<int> cp = &c;
+  _Ptr<int> dp = &d;
+
+  oneTypeVariable<int, int>(ap, bp);  //expected-error {{mismatch between the number of types listed and number of type variables}}
+  oneTypeVariable<>(ap, bp);          //expected-error {{mismatch between the number of types listed and number of type variables}}
+  manyTypeVariables<int, int>(ap, bp);
+  manyTypeVariables<>(ap, bp); //expected-error {{mismatch between the number of types listed and number of type variables}}
+
+  float y = 5.5, z = 0.0;
+  _Ptr<float> p2 = &y;
+  _Ptr<float> p = &z;
+  checked {
+    p = validItypeGenericFunction<float>(5, p2, p2);
+    //Checked scope expects type arguments
+    validItypeGenericFunction(5, 0, 0); //expected-error {{expected a list of type arguments for an itype generic function}}
+  }
+  unchecked{
+    void * p3 = (void *) p2;
+    //Unchecked scope. Type arguments are not mandated.
+    float *p4 = validItypeGenericFunction(5, p3, p3);
+    _Ptr<float> p5 = validItypeGenericFunction<float>(5,p2,p2);
+  }
+}
+

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -673,3 +673,14 @@ void f108(void) {
   extern int buf3_count;
   extern array_ptr<int> buf3 : count(buf3_count); // expected-error {{added bounds}}
 }
+
+//Checked C: redeclaration with conflicting function specifiers must throw error
+_Itype_for_any(T) void* f109(void *a);
+_For_any(T) void* f109(void *a) { // expected-error {{conflicting function specifiers for 'f109'. _Itype_for_any and _For_any are incompatible function specifiers}}
+}
+
+//Checked C: redeclaration of _Itype_for_any function with a normal declaration for backward compatibility
+void* f110(void *a);
+_Itype_for_any(T) void* f110(void *a : itype(_Ptr<T>)) : itype(_Ptr<T>) {
+  return a;
+}


### PR DESCRIPTION
Parsing logic of _For_any and _Itype_for_any seems to fail in linux.
Merging this PR must wait until the root cause is found and fixed.