### PR TITLE
Propose change to snprintf bounds-safe interface

### DIFF
--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -21,7 +21,7 @@ extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 :
 _Unchecked
 int snprintf_array_ptr(char * restrict s : _Array_ptr<char>) restrict count(n),
                        size_t n, 
-                       const char * restrict format : itype(restrict    _Nt_array_ptr<const char>), 
+                       const char * restrict format : itype(restrict _Nt_array_ptr<const char>), 
                        ...);
 
 #endif /* __CHECKED_C_EXTENSIONS_H */

--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -16,4 +16,11 @@ extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 :
   _Unchecked { return strncmp(src, s2, n); }
 }
 
+// default snprintf assumes nt_array_ptr for bounds-safe interface
+// this option is for array_ptr
+_Unchecked
+int snprintf_array_ptr(char * restrict s : _Array_ptr<char>) restrict count(n),
+             size_t n,
+             const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+
 #endif /* __CHECKED_C_EXTENSIONS_H */

--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -20,7 +20,8 @@ extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 :
 // this option is for array_ptr
 _Unchecked
 int snprintf_array_ptr(char * restrict s : _Array_ptr<char>) restrict count(n),
-             size_t n,
-             const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
+                       size_t n, 
+                       const char * restrict format : itype(restrict    _Nt_array_ptr<const char>), 
+                       ...);
 
 #endif /* __CHECKED_C_EXTENSIONS_H */

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -101,9 +101,10 @@ int sscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
 
 // Since snprintf automatically adds the null terminator
 // and counts that number in n, s only needs count(n-1) per the 
-// definition of _Nt types.
+// definition of _Nt types. Additional declaration for arrays 
+// available in checkedc_extensions.h
 _Unchecked
-int snprintf(char * restrict s : itype(restrict _Nt_array_ptr<char>) count(n-1),
+int snprintf(char * restrict s : itype(restrict _Nt_array_ptr<char>) count(n == 0 ? 0 : n-1),
              size_t n,
              const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 #endif

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -98,8 +98,13 @@ int sscanf(const char * restrict s : itype(restrict _Nt_array_ptr<const char>),
 
 #if _FORTIFY_SOURCE == 0 || !defined(snprintf)
 #undef snprintf
+
+// Since snprintf automatically adds the null terminator
+// and counts that number in n, s only needs count(n-1) per the 
+// definition of _Nt types.
 _Unchecked
-int snprintf(char * restrict s : count(n), size_t n,
+int snprintf(char * restrict s : itype(restrict _Nt_array_ptr<char>) count(n-1),
+             size_t n,
              const char * restrict format : itype(restrict _Nt_array_ptr<const char>), ...);
 #endif
 


### PR DESCRIPTION
Since `snprintf` always puts a null-terminator for `n > 0`, I propose that we adjust the bounds-safe interface for `snprintf` slightly to reflect that the destination buffer will be null-terminated and can be 1 unit shorter than `n`. This allows for the fairly common idiom of 
```
char foo _Nt_checked[##];
snprintf(foo, sizeof(foo), formatStr, ...)
```
without any code changes beyond changing the type of foo to be checked.