### PR TITLE
Fixing a typo in the snprintf_array_ptr definition.

### DIFF
--- a/include/checkedc_extensions.h
+++ b/include/checkedc_extensions.h
@@ -19,9 +19,9 @@ extern inline int strncmp_array_ptr(const char *src : count(n), const char *s2 :
 // default snprintf assumes nt_array_ptr for bounds-safe interface
 // this option is for array_ptr
 _Unchecked
-int snprintf_array_ptr(char * restrict s : _Array_ptr<char>) restrict count(n),
+int snprintf_array_ptr(char * restrict s : itype(restrict _Array_ptr<char>) count(n),
                        size_t n, 
-                       const char * restrict format : itype(restrict _Nt_array_ptr<const char>), 
+                       const char * restrict format : itype(restrict _Nt_array_ptr<const char>),
                        ...);
 
 #endif /* __CHECKED_C_EXTENSIONS_H */


### PR DESCRIPTION
Typo was not caught before because my checkedc tests build got corrupted and I had to rebuild clang and the checkedc tests from scratch this afternoon. The tests caught the typo.