### PR TITLE
Making Memcpy, bsearch, realloc  polymorphic generic functions

### DIFF
--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -78,12 +78,12 @@ int system(const char *s : itype(_Nt_array_ptr<const char>));
 // on parameters based on size.  Currently we are requiring that
 // bounds in parameters lists be closed with respect to variables
 // in the parameter list.
-_Itype_for_any(T) void *bsearch(const void *key : itype(_Array_ptr<const T>) byte_count(size),
-              const void *base : itype(_Array_ptr<const T>) byte_count(nmemb * size),
-              size_t nmemb, size_t size,
-              int ((*compar)(const void *, const void *)) :
-                itype(_Ptr<int(_Ptr<const T>, _Ptr<const T>)>)) :
-                byte_count(size);
+_Itype_for_any(T) void *bsearch(const void *key : itype(_Ptr<const T>),
+                                const void *base : itype(_Array_ptr<const T>) byte_count(nmemb * size),
+                                size_t nmemb, size_t size,
+                                int ((*compar)(const void *, const void *)) :
+                                  itype(_Ptr<int(_Ptr<const T>, _Ptr<const T>)>)
+                                ) : itype(_Ptr<T>);
 
 // TODO: compar needs to have an itype that has bounds
 // on parameters based on size.  Currently we are requiring that

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -65,7 +65,7 @@ void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
 _Itype_for_any(T) void *calloc(size_t nmemb, size_t size) : itype(_Array_ptr<T>) byte_count(nmemb * size);
 _Itype_for_any(T) void free(void *pointer : itype(_Array_ptr<T>) byte_count(0));
 _Itype_for_any(T) void *malloc(size_t size) : itype(_Array_ptr<T>) byte_count(size);
-void *realloc(void *pointer : byte_count(1), size_t size) : byte_count(size);
+_Itype_for_any(T) void *realloc(void *pointer : itype(_Array_ptr<T>) byte_count(1), size_t size) : itype(_Array_ptr<T>) byte_count(size);
 
 char *getenv(const char *n : itype(_Nt_array_ptr<const char>)) : itype(_Nt_array_ptr<char>);
 

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -78,11 +78,11 @@ int system(const char *s : itype(_Nt_array_ptr<const char>));
 // on parameters based on size.  Currently we are requiring that
 // bounds in parameters lists be closed with respect to variables
 // in the parameter list.
-void *bsearch(const void *key : byte_count(size),
-              const void *base : byte_count(nmemb * size),
+_Itype_for_any(T) void *bsearch(const void *key : itype(_Array_ptr<const T>) byte_count(size),
+              const void *base : itype(_Array_ptr<const T>) byte_count(nmemb * size),
               size_t nmemb, size_t size,
               int ((*compar)(const void *, const void *)) :
-                itype(_Ptr<int(_Ptr<const void>, _Ptr<const void>)>)) :
+                itype(_Ptr<int(_Ptr<const T>, _Ptr<const T>)>)) :
                 byte_count(size);
 
 // TODO: compar needs to have an itype that has bounds

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -52,9 +52,9 @@
 
 #if _FORTIFY_SOURCE == 0 || !defined(memcpy)
 #undef memcpy
-void *memcpy(void * restrict dest : byte_count(n),
-             const void * restrict src : byte_count(n),
-             size_t n) : bounds(dest, (_Array_ptr<char>) dest + n);
+_Itype_for_any(T) void *memcpy(void * dest : itype(_Array_ptr<T>) byte_count(n),
+             const void * src : itype(_Array_ptr<T>) byte_count(n),
+             size_t n) : itype(_Array_ptr<T>) byte_count(n);
 #endif
 
 #if _FORTIFY_SOURCE == 0 || !defined(memmove)

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -52,8 +52,8 @@
 
 #if _FORTIFY_SOURCE == 0 || !defined(memcpy)
 #undef memcpy
-_Itype_for_any(T) void *memcpy(void * dest : itype(_Array_ptr<T>) byte_count(n),
-             const void * src : itype(_Array_ptr<T>) byte_count(n),
+_Itype_for_any(T) void *memcpy(void * restrict dest : itype(restrict _Array_ptr<T>) byte_count(n),
+             const void * restrict src : itype(restrict _Array_ptr<const T>) byte_count(n),
              size_t n) : itype(_Array_ptr<T>) byte_count(n);
 #endif
 

--- a/tests/typechecking/malloc_free.c
+++ b/tests/typechecking/malloc_free.c
@@ -50,7 +50,7 @@ void f12(void) {
 // Test you can always `free` a `realloc`d ptr
 void f13(void) {
     ptr<int> x = malloc<int>(sizeof(int));
-    ptr<int> y = realloc(x, 2 * sizeof(int));
+    ptr<int> y = realloc<int>(x, 2 * sizeof(int));
     free<int>(y);
 }
 
@@ -75,7 +75,7 @@ void f22(void) {
 // Test you can always `free` a `realloc`d array_ptr
 void f23(void) {
     array_ptr<int> x : count(4) = malloc<int>(4 * sizeof(int));
-    array_ptr<int> y : count(8) = realloc(x, 8 * sizeof(int));
+    array_ptr<int> y : count(8) = realloc<int>(x, 8 * sizeof(int));
     free<int>(y);
 }
 


### PR DESCRIPTION
Signatures of memcpy, bsearch and realloc are modified to make them polymorphic bounds safe interface functions