### PR TITLE
Remove POSIX checks in socket, inet

### DIFF
--- a/include/arpa/inet_checked.h
+++ b/include/arpa/inet_checked.h
@@ -13,11 +13,8 @@
 
 #pragma CHECKED_SCOPE ON
 
-#if _POSIX_VERSION >= 200112L
-
 extern in_addr_t inet_addr (const char *__cp : itype(_Nt_array_ptr<const char>)) __THROW;
 
-#endif // POSIX
 
 #pragma CHECKED_SCOPE OFF
 

--- a/include/sys/socket_checked.h
+++ b/include/sys/socket_checked.h
@@ -12,8 +12,6 @@
 
 #pragma CHECKED_SCOPE ON
 
-#if _POSIX_VERSION >= 200112L
-
 extern int socketpair (int __domain, int __type, int __protocol, 
     int __fds[2] : itype(int _Checked[2])) __THROW;
 
@@ -115,8 +113,6 @@ extern int accept4 (
     socklen_t *__restrict __addr_len : itype(_Ptr<socklen_t> __restrict), 
     int __flags);
 #endif
-
-#endif // POSIX
 
 #pragma CHECKED_SCOPE OFF
 


### PR DESCRIPTION
My example code was not picking up the bounds-safe interfaces in socket_checked and inet_checked. When I remove the checks for POSIX it does pick them up correctly. Passes checkedc tests.