### PR TITLE
Remove comment about issue that has been fixed.

### DIFF
--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -1158,6 +1158,4 @@ array_ptr<int> f301(void) : bounds(return_value, return_value + 10);
 array_ptr<int> f302(void) : bounds(return_value - 5, return_value + 5);
 array_ptr<int> f303(void) : count(return_value); // expected-error {{invalid argument type}}
 array_ptr<int> f304(void) : bounds(arr, arr + (return_value << 5)); // expected-error {{invalid operands to binary expression}}
-// TODO: Github issue #543.  Duplicate error mesages issued for type checking
-// error in bounds expression.
 array_ptr<void> f305(void) : bounds(return_value, return_value + 5); // expected-error {{arithmetic on a pointer to void}}


### PR DESCRIPTION
The compiler no longer emits a duplicate error message for a test. We can remove the comment about needing to fix this.
