### PR TITLE
In declarations, treat _Checked as a declaration specifier

### DIFF
--- a/tests/parsing/return_bounds.c
+++ b/tests/parsing/return_bounds.c
@@ -227,12 +227,12 @@ extern array_ptr<int> f28(int len) : coount(len) { // expected-error {{expected 
 }
 
 // Omit an argument to bounds to cause a parsing error
-extern array_ptr<int> f29(int len, array_ptr<int> arr : count(len)) : bounds(arr)) { // expected-error {{expected ','}}
+extern array_ptr<int> f29(int len, array_ptr<int> arr : count(len)) : bounds(arr) { // expected-error {{expected ','}}
   return 0;
 }
 
 // Omit both arguments to bounds to cause a parsing error
-extern array_ptr<int> f30(int len, array_ptr<int> arr : count(len)) : bounds()) { // expected-error {{expected expression}}
+extern array_ptr<int> f30(int len, array_ptr<int> arr : count(len)) : bounds() { // expected-error {{expected expression}}
   return 0;
 }
 

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -400,8 +400,9 @@ void func30(void) {
   int a = 5;
   int len = 10;
   array_ptr<int> pa : count(len) = 0;
-  checked(len);     // expected-error {{expected compound statement after checked scope keyword}}
-  checked [5][5];   // expected-error {{expected compound statement after checked scope keyword}}
+  /// checked is a declaration specifier unless followed by '{' or '['
+  checked(len2);    // expected-warning {{type specifier missing}}
+  checked [5][5];   // expected-error {{expected identifier}}
 }
 
 // Test for unchecked scope.

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -400,9 +400,9 @@ void func30(void) {
   int a = 5;
   int len = 10;
   array_ptr<int> pa : count(len) = 0;
-  /// checked is a declaration specifier unless followed by '{' or '['
-  checked(len2);    // expected-warning {{type specifier missing}}
-  checked [5][5];   // expected-error {{expected identifier}}
+  /// checked is a function declaration specifier unless followed by '{' or '['
+  checked int len2;   // expected-error {{'_Checked' can only appear on functions}}
+  checked [5][5];     // expected-error {{expected identifier}}
 }
 
 // Test for unchecked scope.


### PR DESCRIPTION
We've updated the compiler to treat _Checked as a function declaration specifier, unless it is followed by a `{` or a `[`.  Update a few tests involving incorrect declarations using _Checked/
