### PR TITLE
Add tests of _Bounds_only modifier for checked scopes.

### DIFF
--- a/include/stdchecked.h
+++ b/include/stdchecked.h
@@ -7,6 +7,7 @@
 #define checked _Checked
 #define nt_checked _Nt_checked
 #define unchecked _Unchecked
+#define bounds_only _Bounds_only
 #define where _Where
 #define dynamic_check _Dynamic_check
 #define dynamic_bounds_cast _Dynamic_bounds_cast

--- a/tests/typechecking/checked_scope_bounds_only.c
+++ b/tests/typechecking/checked_scope_bounds_only.c
@@ -1,0 +1,15 @@
+// Feature tests of typechecking of uses of checked scopes with the
+// _Bounds_only modifier.
+//
+// This builds the file checked_scope_basic.c, #defining BOUNDS_ONLY to 1.
+//
+// The following line is for the LLVM test harness:
+//
+// RUN: %clang_cc1 -Wno-unused-value -Wno-pointer-bool-conversion -verify -verify-ignore-unexpected=note -DBOUNDS_ONLY=1 %S/checked_scope_basic.c
+//
+
+#import <stdlib.h>
+
+int main(void) {
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
By default, checked scopes will include compile-time checks to prevent type
confusion.  The checks will restrict pointer casts, for example. If a
programmer wants only checks for bounds safety, a programmer can modify a
checked scope using the _Bounds_only modifier:

checked bounds_only { ... }

This change adds tests of checked scopes with the new bounds_only modifier.
We haven't implemented the restrictions on pointer casts yet, so the tests
check only that checked scopes with bounds_only modifiers implement the same
restrictions that regular checked scopes currently do.

The change parameterizes checked_scope_basic.c by a #define that adds
a scope modifier optionally..  We create a dummy file to compile the alternate
version of the file.