### PR TITLE
Update tests after revamping implementation of generic functions

### DIFF
--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -29,8 +29,8 @@ extern void f4() {
   array_ptr<int> a : count(2) = 0;
   array_ptr<char> b : count(2) = 0;
 
-  a = _Asume_bounds_cast<array_ptr<int>>(b, count(2)); // expected-error{{use of undeclared identifier}} expected-error {{expected expression}}
-  a = _Dssume_bounds_cast<int>(b); // expected-error{{use of undeclared identifier}} expected-error {{expected expression}}
+  a = _Asume_bounds_cast<array_ptr<int>>(b, count(2)); // expected-error{{use of undeclared identifier}}
+  a = _Dssume_bounds_cast<int>(b); // expected-error{{use of undeclared identifier}}
 }
 
 struct S1 {
@@ -86,12 +86,12 @@ extern void f10() {
   s = _Assume_bounds_cast<ptr<int *>>(q);
   t = _Assume_bounds_cast<ptr<ptr<int>>>(q);
 
-  s = ynamic_bounds_cast<ptr<int *>>(q); // expected-error {{use of undeclared identifier}} expected-error {{expected expression}}
+  s = ynamic_bounds_cast<ptr<int *>>(q); // expected-error {{use of undeclared identifier}}
   t = _Dynamic_bounds_cast<ptr<ptr<int>>>(q);
 
   r = _Assume_bounds_cast<ptr<int>>(q);
   p = _Assume_bounds_cast<int *>(q);
-  p = _Dssume_bounds_cast<int *>(h5); // expected-error {{expected expression}} expected-error {{use of undeclared identifier}}
+  p = _Dssume_bounds_cast<int *>(h5); // expected-error {{use of undeclared identifier}}
 }
 
 extern void f11() {

--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -29,7 +29,7 @@ extern void f4() {
   array_ptr<int> a : count(2) = 0;
   array_ptr<char> b : count(2) = 0;
 
-  a = _Asume_bounds_cast<array_ptr<int>>(b, count(2)); // expected-error{{use of undeclared identifier}}
+  a = _Asume_bounds_cast<array_ptr<int>>(b, count(2)); // expected-error{{use of undeclared identifier}} expected-warning {{implicit declaration of function 'count' is invalid in C99}}
   a = _Dssume_bounds_cast<int>(b); // expected-error{{use of undeclared identifier}}
 }
 
@@ -91,7 +91,7 @@ extern void f10() {
 
   r = _Assume_bounds_cast<ptr<int>>(q);
   p = _Assume_bounds_cast<int *>(q);
-  p = _Dssume_bounds_cast<int *>(h5); // expected-error {{use of undeclared identifier}}
+  p = _Dssume_bounds_cast<int *>(h5); // expected-error 2 {{use of undeclared identifier}}
 }
 
 extern void f11() {

--- a/tests/parsing/typevariable/generic_func_parsing_error.c
+++ b/tests/parsing/typevariable/generic_func_parsing_error.c
@@ -12,5 +12,5 @@ void CallGenericFunction() {
   _Ptr<int> x = &num;
   Foo<int int>(x, x); //expected-error{{cannot combine with previous 'int' declaration specifier}}
   Foo<int, >(x, x);   //expected-error{{expected a type}}
-  Foo(x, x);          //expected-error{{ expected a type argument list for a generic function call}}
+  Foo(x, x);          //expected-error{{expected a type argument list for a generic function call}}
 }

--- a/tests/parsing/typevariable/generic_func_parsing_error.c
+++ b/tests/parsing/typevariable/generic_func_parsing_error.c
@@ -11,7 +11,6 @@ void CallGenericFunction() {
   int num = 0;
   _Ptr<int> x = &num;
   Foo<int int>(x, x); //expected-error{{cannot combine with previous 'int' declaration specifier}}
-  Foo<int, >(x, x); //expected-error{{expected a type}}
-  Foo<, , >(x, x); //expected-error{{expected a type}}
-  Foo(x, x); //expected-error{{expected a list of type arguments for a generic function}}
+  Foo<int, >(x, x);   //expected-error{{expected a type}}
+  Foo(x, x);          //expected-error{{ expected a type argument list for a generic function call}}
 }

--- a/tests/typechecking/itype_generic_functions.c
+++ b/tests/typechecking/itype_generic_functions.c
@@ -44,7 +44,7 @@ void CallItypeGenericFunctions(void) {
   checked {
     p = validItypeGenericFunction<float>(5, p2, p2);
     //Checked scope expects type arguments
-    validItypeGenericFunction(5, 0, 0); //expected-error {{expected a list of type arguments for a generic function}}
+    validItypeGenericFunction(5, 0, 0); //expected-error {{expected a type argument list for a bounds-safe interface call in a checked scope}}
   }
   unchecked{
     void * p3 = (void *) p2;

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -690,18 +690,37 @@ void f107(void) {
   extern array_ptr<int> buf3;
 }
 
-void f108(void) {
+void f10(void) {
   extern int buf3_count;
   extern array_ptr<int> buf3 : count(buf3_count); // expected-error {{added bounds}}
 }
 
-//Checked C: redeclaration with conflicting function specifiers must throw error
+// Redeclaration with conflicting _For_any and _Itype_for_any specifiers
 _Itype_for_any(T) void* f109(void *a);
 _For_any(T) void* f109(void *a) { // expected-error {{conflicting function specifiers for 'f109'. _Itype_for_any and _For_any are incompatible function specifiers}}
 }
 
-//Checked C: redeclaration of _Itype_for_any function with a normal declaration for backward compatibility
+// Redeclaration of a non-generic function with _For_any is not allowed.
 void* f110(void *a);
-_Itype_for_any(T) void* f110(void *a : itype(_Ptr<T>)) : itype(_Ptr<T>) {
+_For_any(T) void f110(void* a); //expected-error {{conflicting non-generic and generic declarations of 'f110'}}
+
+// Redeclaration of a non-generic function with _Itype_for_any is OK
+void* f111(void *a);
+_Itype_for_any(T) void* f111(void *a : itype(_Ptr<T>)) : itype(_Ptr<T>) {
   return a;
 }
+
+// Conflicting numbers of type variables.
+_For_any(T, S) void f112(void *a);
+_For_any(T) void f112(void* a);  // expected-error {{conflicting numbers of type variables for declarations of 'f112'}}
+
+// Conflicting numbers of type variables.
+_Itype_for_any(T, S) void f113(void *a);
+_Itype_for_any(T) void f113(void *a);  // expected-error {{conflicting numbers of type variables for declarations of 'f113'}}
+
+// Try out multiple function declarators in one declaration.
+_For_any(T, S) void f114(void *a), f115(void *b);
+_For_any(T, S) void f114(void *a), f115(void *b);
+_Itype_for_any(T, S) void f114(void *a), f115(void *b); // expected-error {{conflicting function specifiers for 'f114'}} \
+                                                        // expected-error {{conflicting function specifiers for 'f115'}}
+

--- a/tests/typechecking/redeclarations.c
+++ b/tests/typechecking/redeclarations.c
@@ -690,7 +690,7 @@ void f107(void) {
   extern array_ptr<int> buf3;
 }
 
-void f10(void) {
+void f108(void) {
   extern int buf3_count;
   extern array_ptr<int> buf3 : count(buf3_count); // expected-error {{added bounds}}
 }


### PR DESCRIPTION
We've revamped the implementation of generic functions in the compiler:
- Add tests of ways functions with generic types and non-generic types can be incompatible.
- We are now parsing type argument lists based on mostly syntactic information.  This causes misnamed bounds cast operations to be treated as applications of functions to generic type arguments.
- A few error messages changed.

