### PR TITLE
Fix failing tests on Windows x64.

### DIFF
--- a/tests/typechecking/pointer-sized-long-long/lit.local.cfg
+++ b/tests/typechecking/pointer-sized-long-long/lit.local.cfg
@@ -1,7 +1,7 @@
 import re
 
 # On 64-bit windows a pointer is the same size as long long
-if re.match(r'^x86_64.*-(win32|mingw32|windows-gnu)$', config.target_triple):
+if re.match(r'^x86_64.*-(windows-msvc|windows-gnu)$', config.target_triple):
     config.available_features.add('pointer-sized-long-long')
 
 if not 'pointer-sized-long-long' in config.available_features:

--- a/tests/typechecking/pointer-sized-long/lit.local.cfg
+++ b/tests/typechecking/pointer-sized-long/lit.local.cfg
@@ -2,7 +2,7 @@ import re
 
 
 # On 64-bit windows a pointer is not the same size as long
-if not re.match(r'^x86_64.*-(win32|mingw32|windows-gnu)$', config.target_triple):
+if not re.match(r'^x86_64.*-(windows-msvc|windows-gnu)$', config.target_triple):
     config.available_features.add('pointer-sized-long')
 
 if not 'pointer-sized-long' in config.available_features:


### PR DESCRIPTION
Some automated tests are failing on Windows x64 after updating the LLVM/clang sources.   The tests are platform-specific and aren't supposed to be run on 64-bit Windows targets.    The target platform name for Windows changed in the LLVM test infrastructure, which caused this failure.
