### PR TITLE
Add new lit variables to support ARM testing in lit

### DIFF
--- a/tests/dynamic_checking/dynamic_check/simple-pass.c
+++ b/tests/dynamic_checking/dynamic_check/simple-pass.c
@@ -2,8 +2,8 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -Xclang -verify -o %t.exe %s
-// RUN: %t.exe
+// RUN: %clang -Xclang -verify -o %t.exe %s %checkedc_target_flags
+// RUN: %checkedc_rununder %t.exe
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
Added two lit variables:
  1. %checkedc_target_flags: target-specific triple and sysroot flags.
  2. %checkedc_rununder: target-specific run host, like qemu.