### PR TITLE
Enable dynamic_checking tests for ARM

### DIFF
--- a/tests/dynamic_checking/bounds/array-bounds-decls.c
+++ b/tests/dynamic_checking/bounds/array-bounds-decls.c
@@ -3,20 +3,20 @@
 // override bounds based on the size of the 1st 
 // dimension of the array.
 //
-// RUN: %clang %s -o %t1 -Werror -Wno-unused-value
-// RUN:  %t1 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
-// RUN:  %t1 1 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 2 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 3 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 4 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 5 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 6 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 7 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 8 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 9 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 10 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 11 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 12 | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
+// RUN: %checkedc_rununder %t1 1 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 2 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 3 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 4 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 5 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 6 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 7 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 8 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 9 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 10 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 11 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 12 | FileCheck %s --check-prefixes=CHECK
 
 #include <assert.h>
 #include <signal.h>

--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -1,50 +1,50 @@
 // Test bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang %s -o %t1 -Wno-unused-value
-// RUN:  %t1 0 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
-// RUN:  %t1 1 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 2 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 3 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 4 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 5 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 6 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 7 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 8 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 9 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 10 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 11 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 12 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 13 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 14 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 15 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 16 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 17 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 18 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 19 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 20 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 21 0 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 1 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 2 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 3 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 4 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 5 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 6 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 7 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 8 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 9 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 10 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 11 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 12 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 13 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 14 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 15 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 16 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 17 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 18 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 19 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 20 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 0 21 | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang %s -o %t1 -Wno-unused-value %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 0 0 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES
+// RUN: %checkedc_rununder %t1 1 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 2 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 3 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 4 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 5 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 6 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 7 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 8 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 9 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 10 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 11 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 12 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 13 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 14 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 15 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 16 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 17 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 18 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 19 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 20 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 21 0 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 1 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 2 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 3 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 4 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 5 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 6 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 7 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 8 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 9 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 10 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 11 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 12 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 13 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 14 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 15 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 16 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 17 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 18 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 19 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 20 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 0 21 | FileCheck %s --check-prefixes=CHECK
 
 #include <assert.h>
 #include <signal.h>

--- a/tests/dynamic_checking/bounds/deref.c
+++ b/tests/dynamic_checking/bounds/deref.c
@@ -7,41 +7,41 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-memory-accesses
-// RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-memory-accesses %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror -Wno-check-memory-accesses
-// RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror -Wno-check-memory-accesses %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-memory-accesses
-// RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-memory-accesses %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses
-// RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
 #include <assert.h>
 #include <signal.h>

--- a/tests/dynamic_checking/bounds/deref_arith.c
+++ b/tests/dynamic_checking/bounds/deref_arith.c
@@ -15,118 +15,118 @@
 //
 // The following lines are for the clang automated test suite
 //
-// RUN: %clang %S/subscript.c -DTEST_READ -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value
-// RUN: %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t1 3            | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 -1           | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 5          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 9        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 5    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %clang %S/subscript.c -DTEST_READ -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 3            | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 -1           | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 5          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 9        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 5    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_WRITE -DPOINTER_ARITHMETIC -o %t2 -Werror
-// RUN: %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t2 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_WRITE -DPOINTER_ARITHMETIC -o %t2 -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t2 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_INCREMENT -DPOINTER_ARITHMETIC -o %t3 -Werror
-// RUN: %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t3 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_INCREMENT -DPOINTER_ARITHMETIC -o %t3 -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t3 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -DPOINTER_ARITHMETIC -o %t4 -Werror
-// RUN: %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t4 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -DPOINTER_ARITHMETIC -o %t4 -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t4 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 
 #import <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/deref_arith_call_expr.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr.c
@@ -14,31 +14,31 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
-// RUN: %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
 //
-// RUN: %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
-// RUN: %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
 //.
-// RUN: %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
-// RUN: %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
 //
-// RUN: %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
-// RUN: %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -46,25 +46,25 @@
 // The 3rd argument = array length and 4th argument = element to perform operation on.
 //
 //
-// RUN: %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
-// RUN: %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
 //
-// RUN: %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
-// RUN: %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
 //
-// RUN: %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
-// RUN: %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
 //
-// RUN: %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN: %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN  %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
-// RUN  %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to null-terminated array of 5 integers, where the integers are
@@ -72,32 +72,32 @@
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
 //
 // 4th argument = value to write.
-// RUN: %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
 //
 // The next test line tries to increment the null terminator.
-// RUN: %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
-// RUN: %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
 //
 // The next test line tries to do a compound assignment on the null terminator.
-// RUN: %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
-// RUN: %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to a null-terminated array with bounds dependent on the value of an argument n. 
@@ -105,85 +105,85 @@
 // 3rd argument = array length. 4th argument = element to performance operation on.
 //
 //
-// RUN: %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
-// RUN: %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
 // Test reading null-terminator.
-// RUN: %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
 //
 // 5th argument = value to write.
 // Test trying to overwrite null terminator with a non-zero value.
-// RUN: %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
 // Test overwriting the null terminator with 0
-// RUN: %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
 //
-// RUN: %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
 // Try to do a compound assignment on the null terminator.
-// RUN: %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
-// RUN: %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
 //
 // Try to do a compound assignment on the null element.
-// RUN: %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN  %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
-// RUN  %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
-// i.e. with a stride of 2.
+// i .e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
 // element to performanc an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
-// RUN: %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
 // This results in an access outside of the 2d array, so it fails.
-// RUN: %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
-// RUN: %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 // This is still within the entire array, it is allowed.
-// RUN: %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 // The access is still within the entire array, so it is allowed.
-// RUN: %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
 //
 // These fail because the function call returns a null pointer.
-// RUN: %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
 // These fail because of a bounds error.
-// RUN: %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN  %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
@@ -15,31 +15,31 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value -O3
+// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value -O3 %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
-// RUN: %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
 //
-// RUN: %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
-// RUN: %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
 //.
-// RUN: %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
-// RUN: %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
 //
-// RUN: %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
-// RUN: %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -47,25 +47,25 @@
 // The 3rd argument = array length and 4th argument = element to perform operation on.
 //
 //
-// RUN: %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
-// RUN: %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
 //
-// RUN: %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
-// RUN: %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
 //
-// RUN: %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
-// RUN: %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
 //
-// RUN: %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN: %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN  %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
-// RUN  %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to null-terminated array of 5 integers, where the integers are
@@ -73,32 +73,32 @@
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
 //
 // 4th argument = value to write.
-// RUN: %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
 //
 // The next test line tries to increment the null terminator.
-// RUN: %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
-// RUN: %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
 //
 // The next test line tries to do a compound assignment on the null terminator.
-// RUN: %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
-// RUN: %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to a null-terminated array with bounds dependent on the value of an argument n. 
@@ -106,38 +106,38 @@
 // 3rd argument = array length. 4th argument = element to performance operation on.
 //
 //
-// RUN: %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
-// RUN: %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
 // Test reading null-terminator.
-// RUN: %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
 //
 // 5th argument = value to write.
 // Test trying to overwrite null terminator with a non-zero value.
-// RUN: %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
 // Test overwriting the null terminator with 0
-// RUN: %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
 //
-// RUN: %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
 // Try to do a compound assignment on the null terminator.
-// RUN: %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
-// RUN: %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
 //
 // Try to do a compound assignment on the null element.
-// RUN: %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN  %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
-// RUN  %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -147,44 +147,44 @@
 // element to performanc an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
-// RUN: %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
 // This results in an access outside of the 2d array, so it fails.
-// RUN: %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
-// RUN: %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 // This is still within the entire array, it is allowed.
-// RUN: %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 // The access is still within the entire array, so it is allowed.
-// RUN: %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
 //
 // These fail because the function call returns a null pointer.
-// RUN: %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
 // These fail because of a bounds error.
-// RUN: %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN  %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/deref_arith_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arith_opt.c
@@ -13,118 +13,118 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript.c -DTEST_READ -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value -O3
-// RUN: %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t1 3            | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 -1           | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 5          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 9        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 5    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %clang %S/subscript.c -DTEST_READ -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 3            | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 -1           | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 5          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 9        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 5    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_WRITE -DPOINTER_ARITHMETIC -o %t2 -Werror -O3
-// RUN: %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t2 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_WRITE -DPOINTER_ARITHMETIC -o %t2 -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t2 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_INCREMENT -DPOINTER_ARITHMETIC -o %t3 -Werror -O3
-// RUN: %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t3 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_INCREMENT -DPOINTER_ARITHMETIC -o %t3 -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t3 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -DPOINTER_ARITHMETIC -o %t4 -Werror -O3
-// RUN: %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t4 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -DPOINTER_ARITHMETIC -o %t4 -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t4 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 
 
 #import <stdlib.h>

--- a/tests/dynamic_checking/bounds/deref_arrow_member_expr.c
+++ b/tests/dynamic_checking/bounds/deref_arrow_member_expr.c
@@ -11,53 +11,53 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value
-// RUN: %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
-// RUN: %t1 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-READ
-// RUN: %t1 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
+// RUN: %checkedc_rununder %t1 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror
-// RUN: %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
-// RUN: %t2 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-WRITE
-// RUN: %t2 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror
-// RUN: %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
-// RUN: %t3 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror
-// RUN: %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t4 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
 #import <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/deref_arrow_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arrow_member_expr_opt.c
@@ -11,53 +11,53 @@
 // `subscript_dot_member_expr.c`. This is run as a separate test so we know
 // if optimisation is breaking some dynamic checks.
 //
-// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value -O3
-// RUN: %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
-// RUN: %t1 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-READ
-// RUN: %t1 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
+// RUN: %checkedc_rununder %t1 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3
-// RUN: %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
-// RUN: %t2 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-WRITE
-// RUN: %t2 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3
-// RUN: %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
-// RUN: %t3 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3
-// RUN: %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t4 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-5-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
 #import <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/deref_dot_member_expr.c
+++ b/tests/dynamic_checking/bounds/deref_dot_member_expr.c
@@ -19,53 +19,53 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value
-// RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
-// RUN: %t1 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-READ
-// RUN: %t1 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t1 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
+// RUN: %checkedc_rununder %t1 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror
-// RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
-// RUN: %t2 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-WRITE
-// RUN: %t2 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t2 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror
-// RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
-// RUN: %t3 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-INCREMENT
-// RUN: %t3 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t3 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
-// RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t4 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass5 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-5-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 #include <assert.h>
 #include <signal.h>
 #include <stdio.h>

--- a/tests/dynamic_checking/bounds/deref_dot_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_dot_member_expr_opt.c
@@ -14,53 +14,53 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3
-// RUN: %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
-// RUN: %t1 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-READ
-// RUN: %t1 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
+// RUN: %checkedc_rununder %t1 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3
-// RUN: %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
-// RUN: %t2 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-WRITE
-// RUN: %t2 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror -O3
-// RUN: %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
-// RUN: %t3 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
-// RUN: %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t4 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/deref_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-5-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %S/deref_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/deref_opt.c
+++ b/tests/dynamic_checking/bounds/deref_opt.c
@@ -13,41 +13,41 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -O3
-// RUN: %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -O3
-// RUN: %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -O3
-// RUN: %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -O3
-// RUN: %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
 #import <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/nullterm_pointers.c
+++ b/tests/dynamic_checking/bounds/nullterm_pointers.c
@@ -1,26 +1,26 @@
 // Test runtime bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses
-// RUN:  %t1 1 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-1
-// RUN:  %t1 2 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 3 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 4 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 5 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-2
-// RUN:  %t1 6 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 7 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 8 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 9 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-3
-// RUN:  %t1 10 | FileCheck %s --check-prefixes=CHECK
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 1 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-1
+// RUN: %checkedc_rununder %t1 2 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 3 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 4 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 5 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-2
+// RUN: %checkedc_rununder %t1 6 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 7 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 8 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 9 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-3
+// RUN: %checkedc_rununder %t1 10 | FileCheck %s --check-prefixes=CHECK
 //
-// RUN:  %t1 21 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-4
-// RUN:  %t1 22 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 23 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 24 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 25 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-5
-// RUN:  %t1 26 | FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 27| FileCheck %s --check-prefixes=CHECK
-// RUN:  %t1 28 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 21 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-4
+// RUN: %checkedc_rununder %t1 22 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 23 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 24 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 25 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-5
+// RUN: %checkedc_rununder %t1 26 | FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 27| FileCheck %s --check-prefixes=CHECK
+// RUN: %checkedc_rununder %t1 28 | FileCheck %s --check-prefixes=CHECK
 
 #include <assert.h>
 #include <signal.h>

--- a/tests/dynamic_checking/bounds/subscript.c
+++ b/tests/dynamic_checking/bounds/subscript.c
@@ -18,118 +18,118 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %s -DTEST_READ -o %t1 -Werror -Wno-unused-value
-// RUN: %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
-// RUN: %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
-// RUN: %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
-// RUN: %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
-// RUN: %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
-// RUN: %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
-// RUN: %t1 3            | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 -1           | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 5          | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 9        | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 5    | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %clang %s -DTEST_READ -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
+// RUN: %checkedc_rununder %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
+// RUN: %checkedc_rununder %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
+// RUN: %checkedc_rununder %t1 3            | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 -1           | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 5          | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 9        | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 5    | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %s -DTEST_WRITE -o %t2 -Werror
-// RUN: %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
-// RUN: %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
-// RUN: %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
-// RUN: %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
-// RUN: %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
-// RUN: %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
-// RUN: %t2 3          | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 5        | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %clang %s -DTEST_WRITE -o %t2 -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
+// RUN: %checkedc_rununder %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
+// RUN: %checkedc_rununder %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
+// RUN: %checkedc_rununder %t2 3          | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 5        | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t2 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %s -DTEST_INCREMENT -o %t3 -Werror
-// RUN: %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
-// RUN: %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
-// RUN: %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
-// RUN: %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
-// RUN: %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
-// RUN: %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
-// RUN: %t3 3          | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 5        | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %clang %s -DTEST_INCREMENT -o %t3 -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
+// RUN: %checkedc_rununder %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
+// RUN: %checkedc_rununder %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
+// RUN: %checkedc_rununder %t3 3          | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 5        | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t3 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %s -DTEST_COMPOUND_ASSIGN -o %t4 -Werror
-// RUN: %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
-// RUN: %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
-// RUN: %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
-// RUN: %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
-// RUN: %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
-// RUN: %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
-// RUN: %t4 3          | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 5        | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %clang %s -DTEST_COMPOUND_ASSIGN -o %t4 -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %s
+// RUN: %checkedc_rununder %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %s
+// RUN: %checkedc_rununder %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %s
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %s
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %s
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %s
+// RUN: %checkedc_rununder %t4 3          | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 -1         | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 5        | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 -1       | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 9      | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 -1     | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 9    | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 -1   | FileCheck %s --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t4 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 5  | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 -1 | FileCheck %s --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  3 0   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  2 3   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 9   | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %s --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %s --check-prefix=CHECK-FAIL-3
 
 #include <signal.h>
 #include <stdlib.h>

--- a/tests/dynamic_checking/bounds/subscript_arrow_member_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_arrow_member_expr.c
@@ -11,49 +11,49 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror
-// RUN: %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
-// RUN: %t1 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror
-// RUN: %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
-// RUN: %t2 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror
-// RUN: %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror
-// RUN: %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t4 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 #import <stdlib.h>
 
 int main(void) {

--- a/tests/dynamic_checking/bounds/subscript_arrow_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_arrow_member_expr_opt.c
@@ -13,49 +13,49 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror  -Wno-unused-value -O3
-// RUN: %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
-// RUN: %t1 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -DARROW_OPERATOR -Werror  -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 //
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3
-// RUN: %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
-// RUN: %t2 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -DARROW_OPERATOR -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3
-// RUN: %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -DARROW_OPERATOR -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3
-// RUN: %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
-// RUN: %t4 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -DARROW_OPERATOR -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,ARROW,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,ARROW,FAIL-5
 
 
 #import <stdlib.h>

--- a/tests/dynamic_checking/bounds/subscript_call_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr.c
@@ -20,34 +20,34 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %s -o %t1 -Werror -Wno-unused-value
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
 //
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to do operation on.
 //
 //
-// RUN: %t1 constant_bounds read 5 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read  -1 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read 4 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-SUCCESS
-// RUN: %t1 constant_bounds read 0 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 5 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read  -1 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read 4 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-SUCCESS
 // Make sure we aren't accidentally running the bounds-safe interface verison of this test.
-// RUN: %t1 constant_bounds read 0 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-SUCCESS,CHECK-BSI-NOT
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %s --check-prefixes=CB-READ-START,CB-READ-SUCCESS,CHECK-BSI-NOT
 //
-// RUN: %t1 constant_bounds write 5| FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write -1 | FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write 4 | FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
-// RUN: %t1 constant_bounds write 0 | FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 5| FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write -1 | FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write 4 | FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 0 | FileCheck %s --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
 //.
-// RUN: %t1 constant_bounds inc 7| FileCheck %s --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc -2 | FileCheck %s --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc 4 | FileCheck %s --check-prefixes=CB-INC-START,CB-INC-SUCCESS
-// RUN: %t1 constant_bounds inc 0 | FileCheck %s --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 7| FileCheck %s --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc -2 | FileCheck %s --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc 4 | FileCheck %s --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 0 | FileCheck %s --check-prefixes=CB-INC-START,CB-INC-SUCCESS
 //
-// RUN: %t1 constant_bounds compound 1000| FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound -146 | FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound 4 | FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
-// RUN: %t1 constant_bounds compound 0 | FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 1000| FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound -146 | FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound 4 | FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 0 | FileCheck %s --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -55,25 +55,25 @@
 // The 3rd argument = array length and 4th argument = element to do the operation on.
 //
 //
-// RUN: %t1 dependent_bounds read 2 5 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 3 -1 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 5 4 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-SUCCESS
-// RUN: %t1 dependent_bounds read 10 0 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 2 5 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 3 -1 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 5 4 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 10 0 | FileCheck %s --check-prefixes=DB-READ-START,DB-READ-SUCCESS
 //
-// RUN: %t1 dependent_bounds write 6 6 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 11 -1 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 3 2 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
-// RUN: %t1 dependent_bounds write 3 0 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 6 6 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 11 -1 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 2 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 0 | FileCheck %s --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
 //
-// RUN: %t1 dependent_bounds inc 5 -1 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 5 5 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 12 11 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-SUCCESS
-// RUN: %t1 dependent_bounds inc 12 0 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 -1 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 5 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 11 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 0 | FileCheck %s --check-prefixes=DB-INC-START,DB-INC-SUCCESS
 //
-// RUN: %t1 dependent_bounds compound 50 1000| FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN: %t1 dependent_bounds compound 50 -146 | FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN  %t1 dependent_bounds compound 10 9 | FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
-// RUN  %t1 dependent_bounds compound 10 0 | FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 1000| FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 -146 | FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 9 | FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 0 | FileCheck %s --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to null-terminated array of 5 integers, where the integers are
@@ -81,32 +81,32 @@
 // The 3rd argument = element to do the operation on.
 //
 //
-// RUN: %t1 nt_constant_bounds read 6 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read -1 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read 5 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 4 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 0 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 6 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read -1 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 5 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 4 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 0 | FileCheck %s --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
 //
 // 4th argument = value to write.
-// RUN: %t1 nt_constant_bounds write 6 5| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write -1 5 | FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write 5 0| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 4 5| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 0 5| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 6 5| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write -1 5 | FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 5 0| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 4 5| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 0 5| FileCheck %s --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
 //
 // The next test line tries to increment the null terminator.
-// RUN: %t1 nt_constant_bounds inc 5 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 7| FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc -2 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 4 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
-// RUN: %t1 nt_constant_bounds inc 0 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 5 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 7| FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc -2 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 4 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 0 | FileCheck %s --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
 //
 // The next test line tries to do a compound assignment on the null terminator.
-// RUN: %t1 nt_constant_bounds compound 5 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 1000| FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound -146 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 4 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
-// RUN: %t1 nt_constant_bounds compound 0 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 5 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 1000| FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound -146 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 4 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 0 | FileCheck %s --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to a null-terminated array with bounds dependent on the value of an argument n. 
@@ -114,38 +114,38 @@
 // 3rd argument = array length. 4th argument = element to do operation on.
 //
 //
-// RUN: %t1 nt_dependent_bounds read 2 5 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
-// RUN: %t1 nt_dependent_bounds read 3 -1 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 2 5 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 3 -1 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
 // Test reading null-terminator.
-// RUN: %t1 nt_dependent_bounds read 5 5 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 5 4 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 10 0 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 5 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 4 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 10 0 | FileCheck %s --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
 //
 // 5th argument = value to write.
 // Test trying to overwrite null terminator with a non-zero value.
-// RUN: %t1 nt_dependent_bounds write 6 6 100 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 15 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 0  | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 100 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 15 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 0  | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
 // Test overwriting the null terminator with 0
-// RUN: %t1 nt_dependent_bounds write 6 6 0 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 6 5 25 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 3 0 10 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 0 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 5 25 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 3 0 10 | FileCheck %s --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
 //
-// RUN: %t1 nt_dependent_bounds inc 5 -1 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 -1 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
 // Try to do a compound assignment on the null terminator.
-// RUN: %t1 nt_dependent_bounds inc 5 5 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 20 21 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 12 11 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
-// RUN: %t1 nt_dependent_bounds inc 12 0 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 5 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 20 21 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 11 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 0 | FileCheck %s --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
 //
 // Try to do a compound assignment on the null element.
-// RUN: %t1 nt_dependent_bounds compound 50 50 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 1000| FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 -146 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN  %t1 nt_dependent_bounds compound 10 9 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
-// RUN  %t1 nt_dependent_bounds compound 10 0 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 50 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 1000| FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 -146 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 9 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 0 | FileCheck %s --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -155,44 +155,44 @@
 // element to do the operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
-// RUN: %t1 md_dependent_bounds read 2 2 0   | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 3 -1 1  | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 -1 1  | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
 // This results in an access outside of the 2d array, so it fails.
-// RUN: %t1 md_dependent_bounds read 3 1 6   | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 5 4 2  | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
-// RUN: %t1 md_dependent_bounds read 10 0 3 | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 1 6   | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 5 4 2  | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 3 | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 // This is still within the entire array, it is allowed.
-// RUN: %t1 md_dependent_bounds read 10 0 4 | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 4 | FileCheck %s --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds write 6 6 2 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 3 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 11 -1 2 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 2 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 6 5 0 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 6 2 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 3 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 11 -1 2 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 2 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 0 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 // The access is still within the entire array, so it is allowed.
-// RUN: %t1 md_dependent_bounds write 3 0 5 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 3 0 0 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 5 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 0 | FileCheck %s --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 5 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 4 4 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 3| FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 11 2| FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 0 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 5 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 4 4 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 3| FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 2| FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 0 0 | FileCheck %s --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
 //
 // These fail because the function call returns a null pointer.
-// RUN: %t1 md_dependent_bounds compound 50 1000 0| FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 1000 0| FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
 // These fail because of a bounds error.
-// RUN: %t1 md_dependent_bounds compound 50 50 0 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 49 4 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 48 6 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN  %t1 md_dependent_bounds compound 10 9 3 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 10 0 0 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 50 1 1 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 50 0 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 49 4 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 48 6 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 9 3 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 0 0 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 50 1 1 | FileCheck %s --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
 
 #include <assert.h>
 #include <limits.h>

--- a/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
@@ -14,33 +14,33 @@
 // 
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_call_expr.c -o %t1 -DBOUNDS_INTERFACE -Werror -Wno-unused-value
+// RUN: %clang %S/subscript_call_expr.c -o %t1 -DBOUNDS_INTERFACE -Werror -Wno-unused-value %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
-// RUN: %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
 // Check that this is a bounds-safe interface test
-// RUN: %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CHECK-BSI,CB-READ-START
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CHECK-BSI,CB-READ-START
 
-// RUN: %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
-// RUN: %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
 //.
-// RUN: %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
-// RUN: %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
 //
-// RUN: %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
-// RUN: %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -48,25 +48,25 @@
 // The 3rd argument = array length and 4th argument = element to perform operation on.
 //
 //
-// RUN: %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
-// RUN: %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
 //
-// RUN: %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
-// RUN: %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
 //
-// RUN: %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
-// RUN: %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
 //
-// RUN: %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN: %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN  %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
-// RUN  %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to null-terminated array of 5 integers, where the integers are
@@ -74,32 +74,32 @@
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
 //
 // 4th argument = value to write.
-// RUN: %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
 //
 // The next test line tries to increment the null terminator.
-// RUN: %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
-// RUN: %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
 //
 // The next test line tries to do a compound assignment on the null terminator.
-// RUN: %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
-// RUN: %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to a null-terminated array with bounds dependent on the value of an argument n. 
@@ -107,38 +107,38 @@
 // 3rd argument = array length. 4th argument = element to performance operation on.
 //
 //
-// RUN: %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
-// RUN: %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
 // Test reading null-terminator.
-// RUN: %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
 //
 // 5th argument = value to write.
 // Test trying to overwrite null terminator with a non-zero value.
-// RUN: %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
 // Test overwriting the null terminator with 0
-// RUN: %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
 //
-// RUN: %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
 // Try to do a compound assignment on the null terminator.
-// RUN: %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
-// RUN: %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
 //
 // Try to do a compound assignment on the null element.
-// RUN: %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN  %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
-// RUN  %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -148,44 +148,44 @@
 // element to performanc an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
-// RUN: %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
 // This results in an access outside of the 2d array, so it fails.
-// RUN: %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
-// RUN: %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 // This is still within the entire array, it is allowed.
-// RUN: %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 // The access is still within the entire array, so it is allowed.
-// RUN: %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
 //
 // These fail because the function call returns a null pointer.
-// RUN: %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
 // These fail because of a bounds error.
-// RUN: %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN  %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
@@ -14,31 +14,31 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_call_expr.c -o %t1 -Werror -Wno-unused-value -O3
+// RUN: %clang %S/subscript_call_expr.c -o %t1 -Werror -Wno-unused-value -O3 %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
-// RUN: %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
-// RUN: %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read  -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-READ-START,CB-READ-SUCCESS
 //
-// RUN: %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
-// RUN: %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
-// RUN: %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 5| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds write 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds write 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-WRITE-START,CB-WRITE-SUCCESS
 //.
-// RUN: %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
-// RUN: %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
-// RUN: %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-INC-START,CB-INC-SUCCESS
 //
-// RUN: %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
-// RUN: %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
-// RUN: %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=CB-COMPOUND-START,CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -46,25 +46,25 @@
 // The 3rd argument = array length and 4th argument = element to perform operation on.
 //
 //
-// RUN: %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
-// RUN: %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
-// RUN: %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-READ-START,DB-READ-SUCCESS
 //
-// RUN: %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
-// RUN: %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
-// RUN: %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 6 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 11 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds write 3 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-WRITE-START,DB-WRITE-SUCCESS
 //
-// RUN: %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
-// RUN: %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
-// RUN: %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-INC-START,DB-INC-SUCCESS
 //
-// RUN: %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN: %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
-// RUN  %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
-// RUN  %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=DB-COMPOUND-START,DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to null-terminated array of 5 integers, where the integers are
@@ -72,32 +72,32 @@
 // The 3rd argument = element to perform operation on.
 //
 //
-// RUN: %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
-// RUN: %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
-// RUN: %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds read 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-READ-START,NT-CB-READ-SUCCESS
 //
 // 4th argument = value to write.
-// RUN: %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
-// RUN: %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
-// RUN: %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 6 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write -1 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 5 0| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 4 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds write 0 5| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-WRITE-START,NT-CB-WRITE-SUCCESS
 //
 // The next test line tries to increment the null terminator.
-// RUN: %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
-// RUN: %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
-// RUN: %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 7| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc -2 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds inc 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-INC-START,NT-CB-INC-SUCCESS
 //
 // The next test line tries to do a compound assignment on the null terminator.
-// RUN: %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
-// RUN: %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
-// RUN: %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_constant_bounds compound 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-CB-COMPOUND-START,NT-CB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer to a null-terminated array with bounds dependent on the value of an argument n. 
@@ -105,38 +105,38 @@
 // 3rd argument = array length. 4th argument = element to performance operation on.
 //
 //
-// RUN: %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
-// RUN: %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 2 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 3 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-FAIL
 // Test reading null-terminator.
-// RUN: %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
-// RUN: %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 5 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds read 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-READ-START,NT-DB-READ-SUCCESS
 //
 // 5th argument = value to write.
 // Test trying to overwrite null terminator with a non-zero value.
-// RUN: %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
-// RUN: %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 100 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 15 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 10 0  | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 11 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-FAIL
 // Test overwriting the null terminator with 0
-// RUN: %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
-// RUN: %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 6 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 6 5 25 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds write 3 0 10 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-WRITE-START,NT-DB-WRITE-SUCCESS
 //
-// RUN: %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
 // Try to do a compound assignment on the null terminator.
-// RUN: %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
-// RUN: %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
-// RUN: %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 5 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 20 21 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 11 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds inc 12 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-INC-START,NT-DB-INC-SUCCESS
 //
 // Try to do a compound assignment on the null element.
-// RUN: %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN: %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
-// RUN  %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
-// RUN  %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 50 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 1000| FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 nt_dependent_bounds compound 50 -146 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 9 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 nt_dependent_bounds compound 10 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=NT-DB-COMPOUND-START,NT-DB-COMPOUND-SUCCESS
 //
 //
 // Test operations on a pointer with bounds dependent on the value of an argument n. The pointer points
@@ -146,44 +146,44 @@
 // element to performanc an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
-// RUN: %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 -1 1  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
 // This results in an access outside of the 2d array, so it fails.
-// RUN: %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
-// RUN: %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
-// RUN: %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 3 1 6   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 5 4 2  | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 // This is still within the entire array, it is allowed.
-// RUN: %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds read 10 0 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
-// RUN: %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 6 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 11 -1 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 2 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 6 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 // The access is still within the entire array, so it is allowed.
-// RUN: %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
-// RUN: %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds write 3 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-WRITE-START,MD-DB-WRITE-SUCCESS
 //
-// RUN: %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
-// RUN: %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
-// RUN: %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 5 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 0 -1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 5 4 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 3| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 11 2| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds inc 12 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-INC-START,MD-DB-INC-SUCCESS
 //
 // These fail because the function call returns a null pointer.
-// RUN: %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 1000 0| FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -146 5 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
 // These fail because of a bounds error.
-// RUN: %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN: %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
-// RUN  %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
-// RUN  %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 50 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 49 4 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 48 6 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN: %checkedc_rununder %t1 md_dependent_bounds compound 50 -1 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-FAIL
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 9 3 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 10 0 0 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
+// RUN %checkedc_rununder %t1 md_dependent_bounds compound 50 1 1 | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-COMPOUND-START,MD-DB-COMPOUND-SUCCESS
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/subscript_dot_member_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_dot_member_expr.c
@@ -18,49 +18,49 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %s -o %t1 -DTEST_READ -Werror
-// RUN: %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
-// RUN: %t1 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t1 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror
-// RUN: %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
-// RUN: %t2 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t2 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror
-// RUN: %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
-// RUN: %t3 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t3 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror
-// RUN: %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t4 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
 #include <assert.h>
 #include <signal.h>

--- a/tests/dynamic_checking/bounds/subscript_dot_member_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_dot_member_expr_opt.c
@@ -13,49 +13,49 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -Werror  -Wno-unused-value -O3
-// RUN: %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
-// RUN: %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
-// RUN: %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
-// RUN: %t1 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
-// RUN: %t1 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t1 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t1 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t1 -DTEST_READ -Werror  -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
+// RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
+// RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
+// RUN: %checkedc_rununder %t1 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-READ
+// RUN: %checkedc_rununder %t1 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t1 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t1 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 //
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3
-// RUN: %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
-// RUN: %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
-// RUN: %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
-// RUN: %t2 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
-// RUN: %t2 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t2 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t2 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t2 -DTEST_WRITE -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
+// RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
+// RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
+// RUN: %checkedc_rununder %t2 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-WRITE
+// RUN: %checkedc_rununder %t2 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t2 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t2 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror  -O3
-// RUN: %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
-// RUN: %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
-// RUN: %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
-// RUN: %t3 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
-// RUN: %t3 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t3 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t3 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t3 -DTEST_INCREMENT -Werror  -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
+// RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
+// RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
+// RUN: %checkedc_rununder %t3 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-INCREMENT
+// RUN: %checkedc_rununder %t3 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t3 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t3 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
-// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3
-// RUN: %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
-// RUN: %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
-// RUN: %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
-// RUN: %t4 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
-// RUN: %t4 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
-// RUN: %t4 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
-// RUN: %t4 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
-// RUN: %t4 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
-// RUN: %t4 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
+// RUN: %clang %S/subscript_dot_member_expr.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 pass4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-PASS,PASS-4-COMPOUND-ASSIGN
+// RUN: %checkedc_rununder %t4 fail1 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-1
+// RUN: %checkedc_rununder %t4 fail2 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-2
+// RUN: %checkedc_rununder %t4 fail3 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
+// RUN: %checkedc_rununder %t4 fail4 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
+// RUN: %checkedc_rununder %t4 fail5 | FileCheck %S/subscript_dot_member_expr.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-5
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/bounds/subscript_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_opt.c
@@ -13,118 +13,118 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/subscript.c -DTEST_READ -o %t1 -Werror -Wno-unused-value -O3
-// RUN: %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t1 3            | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 -1           | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 5          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 9        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 5    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t1 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %clang %S/subscript.c -DTEST_READ -o %t1 -Werror -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t1 3            | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 -1           | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 5          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 9        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 5    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t1 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_WRITE -o %t2 -Werror -O3
-// RUN: %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t2 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_WRITE -o %t2 -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t2 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t2 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t2 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t2 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror -O3
-// RUN: %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t3 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_INCREMENT -o %t3 -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t3 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t3 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t3 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t3 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 //
-// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror -O3
-// RUN: %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
-// RUN: %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
-// RUN: %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
-// RUN: %t4 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %clang %S/subscript.c -DTEST_COMPOUND_ASSIGN -o %t4 -Werror -O3 %checkedc_target_flags
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0   0 0 0  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 1 2 4 4 2 2  1 2   1 1 1  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 4 4  2 1   2 2 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  0 4   0 3 2  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  1 3   0 1 5  | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 2 4 8 8 3 3  2 -1  2 -1 2 | FileCheck %S/subscript.c
+// RUN: %checkedc_rununder %t4 3          | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 -1         | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 5        | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 -1       | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 9      | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 -1     | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 9    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 -1   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
 // Skip the case for testing string literals.
-// RUN: %t4 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
-// RUN: %t4 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
-// RUN: %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
-// RUN: %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 5  | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-1
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  3 0   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  2 3   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 9   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-2
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  3 0 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 9 0    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  2 2 3    | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  0 0 27   | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
+// RUN: %checkedc_rununder %t4 0 0 0 0 0 0  0 0  -1 -1 -1 | FileCheck %S/subscript.c --check-prefix=CHECK-FAIL-3
 
 #include <stdlib.h>
 

--- a/tests/dynamic_checking/dynamic_check/arith-fail.c
+++ b/tests/dynamic_checking/dynamic_check/arith-fail.c
@@ -2,9 +2,9 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -Xclang -verify -o %t.exe %s
+// RUN: %clang -Xclang -verify -o %t.exe %s %checkedc_target_flags
 // LLVM thinks that exiting via llvm.trap() is a crash.
-// RUN: %t.exe
+// RUN: %checkedc_rununder %t.exe
 
 // The dynamic_check in f1 cannot be statically checked by clang yet
 // expected-no-diagnostics

--- a/tests/dynamic_checking/dynamic_check/arith-pass.c
+++ b/tests/dynamic_checking/dynamic_check/arith-pass.c
@@ -2,8 +2,8 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -Xclang -verify -o %t.exe %s
-// RUN: %t.exe
+// RUN: %clang -Xclang -verify -o %t.exe %s %checkedc_target_flags
+// RUN: %checkedc_rununder %t.exe
 
 // expected-no-diagnostics
 

--- a/tests/dynamic_checking/dynamic_check/simple-fail.c
+++ b/tests/dynamic_checking/dynamic_check/simple-fail.c
@@ -2,8 +2,8 @@
 //
 // The following lines are for the LLVM test harness:
 //
-// RUN: %clang -Xclang -verify -o %t.exe %s
-// RUN: %t.exe
+// RUN: %clang -Xclang -verify -o %t.exe %s %checkedc_target_flags
+// RUN: %checkedc_rununder %t.exe
 
 #include <stdbool.h>
 #include <signal.h>


### PR DESCRIPTION
Added the following to all tests under dynamic_checking:
1.  %checkedc_target_flags to all clang compile RUN lines.
2. %checkedc_rununder to all execution RUN lines.