### PR TITLE
Add tests for bounds cast expression temporary bindings

### DIFF
--- a/tests/static_checking/lexical_equality.c
+++ b/tests/static_checking/lexical_equality.c
@@ -1076,3 +1076,35 @@ extern int f211_1(_Array_ptr<int> b : bounds(*(&arr), arr + 5));
 extern int f211_2(_Array_ptr<int> b : bounds(&arr, &arr));
 extern int f211_2(_Array_ptr<int> b : bounds((int (*) _Checked[10]) arr, (int (*) _Checked[10]) arr));
 extern int f211_2(_Array_ptr<int> b : bounds(&arr, (int (*) _Checked[10]) arr));
+
+//-----------------------------------------------------//
+// Checked C bounds cast expressions.                  //
+//-----------------------------------------------------// 
+
+// _Dynamic_bounds_cast and _Assume_bounds_cast should not be treated as value-preserving casts for unevaluated expressions.
+
+_Array_ptr<char> ga;
+
+extern void f212_1(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Dynamic_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3));
+extern void f212_1(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Dynamic_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3));
+
+extern void f212_2(_Array_ptr<char> a : bounds(_Assume_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(ga, count(2)) + 3));
+extern void f212_2(_Array_ptr<char> a : bounds(_Assume_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(ga, count(2)) + 3));
+
+extern void f212_3(_Array_ptr<char> a : bounds(_Assume_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3));
+extern void f212_3(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3)); // expected-error {{conflicting parameter bounds}}
+
+extern void f212_4(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3));
+extern void f212_4(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Dynamic_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3)); // expected-error {{conflicting parameter bounds}}
+
+extern void f212_5(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3));
+extern void f212_5(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(5)), _Assume_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3)); // expected-error {{conflicting parameter bounds}}
+
+extern void f212_6(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(a, count(2)) + 3));
+extern void f212_6(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(a, count(1)), _Assume_bounds_cast<_Array_ptr<int>>(a, bounds(a, a + 2)) + 3)); // expected-error {{conflicting parameter bounds}}
+
+extern void f212_7(_Array_ptr<char> a : bounds(_Dynamic_bounds_cast<_Array_ptr<int>>(b, count(1)), b + 3), _Array_ptr<int> b : count(1));
+extern void f212_7(_Array_ptr<char> a : bounds(b, b + 3), _Array_ptr<int> b : count(1)); // expected-error {{conflicting parameter bounds}}
+
+extern void f212_8(_Array_ptr<char> a : bounds(b, _Assume_bounds_cast<_Array_ptr<int>>(b, count(1)) + 3), _Array_ptr<int> b : count(1));
+extern void f212_8(_Array_ptr<char> a : bounds(b, b + 3), _Array_ptr<int> b : count(1)); // expected-error {{conflicting parameter bounds}}

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -58,7 +58,8 @@ extern void f3() {
   // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
   *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} \
-                                                         // TODO: GitHub checkedc-clang issue #695. Re-enable this expected warning. expected warning {{out-of-bounds memory access}}
+                                                         // TODO: GitHub checkedc-clang issue #695. Re-enable the expected warning. \
+                                                         // expected warning {{out-of-bounds memory access}}
   s1 = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
   s2 = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
 }

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -58,7 +58,7 @@ extern void f3() {
   // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
   *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} \
-                                                         // expected-warning {{out-of-bounds memory access}}
+                                                         // TODO: GitHub checkedc-clang issue #695. Re-enable this expected warning. expected warning {{out-of-bounds memory access}}
   s1 = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
   s2 = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
 }

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -186,3 +186,55 @@ extern void f19(){
   x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(p, p + 1)); // expected-error {{declared bounds for x are invalid after assignment}}
 }
 
+extern array_ptr<int> h7(void) : count(3) {
+  array_ptr<int> p : bounds(p, p + 3) = 0;
+  return p;
+}
+
+extern array_ptr<char> h8(void) : count(8) {
+  array_ptr<char> buf : count(8) = 0;
+  return buf;
+}
+
+extern void f20(void *p) {
+  array_ptr<int> intbuf : count(3) = 0;
+  intbuf = _Assume_bounds_cast<array_ptr<int>>(h7(), count(3));
+  int i = intbuf[2];
+}
+
+extern void f21(array_ptr<char> buf : count(len), int len) {
+  array_ptr<int> intbuf : count(12) = _Dynamic_bounds_cast<array_ptr<int>>(buf, bounds(intbuf, intbuf + 12));
+  int i = intbuf[12]; // expected-warning {{out-of-bounds memory access}} \
+                      // expected-note {{accesses memory at or above the upper bound}} \
+                      // expected-note {{(expanded) inferred bounds are 'bounds(intbuf, intbuf + 12)'}}
+}
+
+extern void f22() {
+  array_ptr<int> intbuf : count(2) = _Dynamic_bounds_cast<array_ptr<int>>(h8(), count(2));
+  int i = intbuf[2]; // expected-warning {{out-of-bounds memory access}} \
+                     // expected-note {{accesses memory at or above the upper bound}} \
+                     // expected-note {{(expanded) inferred bounds are 'bounds(intbuf, intbuf + 2)'}}
+}
+
+extern void f23() {
+  array_ptr<char> buf : count(10) = _Assume_bounds_cast<array_ptr<char>>(h7(), count(10));
+  char c = buf[10]; // expected-warning {{out-of-bounds memory access}} \
+                    // expected-note {{accesses memory at or above the upper bound}} \
+                    // expected-note {{(expanded) inferred bounds are 'bounds(buf, buf + 10)'}}
+}
+
+extern void f24() {
+  array_ptr<char> buf : count(3) = "abc";
+  buf = _Dynamic_bounds_cast<array_ptr<char>>(h7(), bounds(buf, buf + 3));
+  char c = buf[3]; // expected-warning {{out-of-bounds memory access}} \
+                   // expected-note {{accesses memory at or above the upper bound}} \
+                   // expected-note {{(expanded) inferred bounds are 'bounds(buf, buf + 3)'}}
+}
+
+extern void f25(array_ptr<char> buf : count(len), int len) {
+  array_ptr<int> intbuf : count(6) = _Dynamic_bounds_cast<array_ptr<int>>(buf + 5, count(6));
+  int i = intbuf[6]; // expected-warning {{out-of-bounds memory access}} \
+                     // expected-note {{accesses memory at or above the upper bound}} \
+                     // expected-note {{(expanded) inferred bounds are 'bounds(intbuf, intbuf + 6)'}}
+}
+


### PR DESCRIPTION
This PR adds tests for microsoft/checkedc-clang#694:
* Lexical equality tests to ensure that _Dynamic_bounds_cast and _Assume_bounds_cast expressions are not treated as value-preserving in function redeclarations.
* Memory access checks involving _Dynamic_bounds_cast and _Assume_bounds_cast expressions have the correct inferred bounds.

The expected out-of-bounds memory access warning has also been disabled in static_check_bounds_check.c. microsoft/checkedc-clang#695 tracks the work necessary to re-enable this warning.