### PR TITLE
Re-enable out-of-bounds memory access warning

### DIFF
--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -57,9 +57,6 @@ extern void f3() {
   *(_Assume_bounds_cast<ptr<int>>(r) + 2) = 4; // expected-error{{arithmetic on _Ptr type}}
   // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
-  *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} \
-                                                         // TODO: GitHub checkedc-clang issue #695. Re-enable the expected warning. \
-                                                         // expected warning {{out-of-bounds memory access}}
   s1 = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
   s2 = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
 }

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -47,6 +47,7 @@ extern void f3() {
   array_ptr<int> r = 0;
   array_ptr<int> s1 = 0;
   array_ptr<int> s2 : bounds(r, r + 5) = 0;
+  array_ptr<int> t : count(5) = 0;
   p = _Assume_bounds_cast<int *>(r);
   p = _Dynamic_bounds_cast<int *>(r); // expected-error {{expression has unknown bounds}}  
   q = _Assume_bounds_cast<ptr<int>>(p);
@@ -57,6 +58,10 @@ extern void f3() {
   *(_Assume_bounds_cast<ptr<int>>(r) + 2) = 4; // expected-error{{arithmetic on _Ptr type}}
   // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
+  *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} expected-warning {{out-of-bounds memory access}}
+  // For the statement below, the compiler figures out that t[3] is out of bounds t : count(3).
+  // t : count(3) normals to bounds(t, t + 3), and t[3] is out of that range.
+  int n = (_Dynamic_bounds_cast<array_ptr<int>>(t, count(3)))[3]; // expected-warning {{out-of-bounds memory access}}
   s1 = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
   s2 = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
 }


### PR DESCRIPTION
Re-enable the expected out-of-bounds memory access warning for a bounds cast expression, and add additional out-of-bounds memory access testing for a bounds cast expression involving an array access.