### PR TITLE
Add typechecking tests for static declarations involving free type variables

### DIFF
--- a/tests/typechecking/static_variables_free_type_variables.c
+++ b/tests/typechecking/static_variables_free_type_variables.c
@@ -13,36 +13,36 @@ static _Exists(T, struct S<T, T, T>) gs;
 //
 
 _For_any(T, U, V) void f1(_Ptr<T> pt, struct S<T, U, V> s) {
-  static T t; // expected-error {{static variable 't' cannot have type variable 'T' that is bound by an enclosing scope}} \
+  static T t; // expected-error {{type 'T' for static variable 't' cannot use type variable 'T' that is bound by an enclosing scope}} \
               // expected-note@15 {{type variable 'T' declared here}}
 
-  static _Ptr<U> p; // expected-error {{static variable 'p' cannot have type variable 'U' that is bound by an enclosing scope}} \
+  static _Ptr<U> p; // expected-error {{type '_Ptr<U>' for static variable 'p' cannot use type variable 'U' that is bound by an enclosing scope}} \
                     // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Array_ptr<V> a1; // expected-error {{static variable 'a1' cannot have type variable 'V' that is bound by an enclosing scope}} \
+  static _Array_ptr<V> a1; // expected-error {{type '_Array_ptr<V>' for static variable 'a1' cannot use type variable 'V' that is bound by an enclosing scope}} \
                            // expected-note@15 {{type variable 'V' declared here}}
 
-  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{static variable 'a2' cannot have type variable 'T' that is bound by an enclosing scope}} \
+  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{type '_Array_ptr<_Array_ptr<T>>' for static variable 'a2' cannot use type variable 'T' that is bound by an enclosing scope}} \
                                        // expected-note@15 {{type variable 'T' declared here}}
 
-  static struct S<T, U, T> s1; // expected-error {{static variable 's1' cannot have type variable 'T' that is bound by an enclosing scope}} \
+  static struct S<T, U, T> s1; // expected-error {{type 'struct S<T, U, T>' for static variable 's1' cannot use type variable 'T' that is bound by an enclosing scope}} \
                                // expected-note@15 {{type variable 'T' declared here}} \
-                               // expected-error {{static variable 's1' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                               // expected-error {{type 'struct S<T, U, T>' for static variable 's1' cannot use type variable 'U' that is bound by an enclosing scope}} \
                                // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Exists(T, _Ptr<U>) e1; // expected-error {{static variable 'e1' cannot have type variable 'U' that is bound by an enclosing scope}} \
+  static _Exists(T, _Ptr<U>) e1; // expected-error {{type 'Exists(T, _Ptr<U>)' for static variable 'e1' cannot use type variable 'U' that is bound by an enclosing scope}} \
                                  // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{static variable 'e2' cannot have type variable 'U' that is bound by an enclosing scope}} \
+  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{type 'Exists(T, struct S<T, U, V>)' for static variable 'e2' cannot use type variable 'U' that is bound by an enclosing scope}} \
                                            // expected-note@15 {{type variable 'U' declared here}} \
-                                           // expected-error {{static variable 'e2' cannot have type variable 'V' that is bound by an enclosing scope}} \
+                                           // expected-error {{type 'Exists(T, struct S<T, U, V>)' for static variable 'e2' cannot use type variable 'V' that is bound by an enclosing scope}} \
                                            // expected-note@15 {{type variable 'V' declared here}}
 
-  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{static variable 'e3' cannot have type variable 'T' that is bound by an enclosing scope}} \
+  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{type 'Exists(A, struct S<T, U, V>)' for static variable 'e3' cannot use type variable 'T' that is bound by an enclosing scope}} \
                                            // expected-note@15 {{type variable 'T' declared here}} \
-                                           // expected-error {{static variable 'e3' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                                           // expected-error {{type 'Exists(A, struct S<T, U, V>)' for static variable 'e3' cannot use type variable 'U' that is bound by an enclosing scope}} \
                                            // expected-note@15 {{type variable 'U' declared here}} \
-                                           // expected-error {{static variable 'e3' cannot have type variable 'V' that is bound by an enclosing scope}} \
+                                           // expected-error {{type 'Exists(A, struct S<T, U, V>)' for static variable 'e3' cannot use type variable 'V' that is bound by an enclosing scope}} \
                                            // expected-note@15 {{type variable 'V' declared here}}
 
   // Static variable declarations can use integral and pointer types and bound type variables.

--- a/tests/typechecking/static_variables_free_type_variables.c
+++ b/tests/typechecking/static_variables_free_type_variables.c
@@ -13,36 +13,36 @@ static _Exists(T, struct S<T, T, T>) gs;
 //
 
 _For_any(T, U, V) void f1(_Ptr<T> pt, struct S<T, U, V> s) {
-  static T t; // expected-error {{type 'T' for static variable 't' cannot use type variable 'T' that is bound by an enclosing scope}} \
+  static T t; // expected-error {{static variable 't' has a type that uses a type variable bound in an enclosing scope (type is 'T' and type variable is 'T')}} \
               // expected-note@15 {{type variable 'T' declared here}}
 
-  static _Ptr<U> p; // expected-error {{type '_Ptr<U>' for static variable 'p' cannot use type variable 'U' that is bound by an enclosing scope}} \
+  static _Ptr<U> p; // expected-error {{static variable 'p' has a type that uses a type variable bound in an enclosing scope (type is '_Ptr<U>' and type variable is 'U')}} \
                     // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Array_ptr<V> a1; // expected-error {{type '_Array_ptr<V>' for static variable 'a1' cannot use type variable 'V' that is bound by an enclosing scope}} \
+  static _Array_ptr<V> a1; // expected-error {{static variable 'a1' has a type that uses a type variable bound in an enclosing scope (type is '_Array_ptr<V>' and type variable is 'V')}} \
                            // expected-note@15 {{type variable 'V' declared here}}
 
-  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{type '_Array_ptr<_Array_ptr<T>>' for static variable 'a2' cannot use type variable 'T' that is bound by an enclosing scope}} \
+  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{static variable 'a2' has a type that uses a type variable bound in an enclosing scope (type is '_Array_ptr<_Array_ptr<T>>' and type variable is 'T')}} \
                                        // expected-note@15 {{type variable 'T' declared here}}
 
-  static struct S<T, U, T> s1; // expected-error {{type 'struct S<T, U, T>' for static variable 's1' cannot use type variable 'T' that is bound by an enclosing scope}} \
+  static struct S<T, U, T> s1; // expected-error {{static variable 's1' has a type that uses a type variable bound in an enclosing scope (type is 'struct S<T, U, T>' and type variable is 'T')}} \
                                // expected-note@15 {{type variable 'T' declared here}} \
-                               // expected-error {{type 'struct S<T, U, T>' for static variable 's1' cannot use type variable 'U' that is bound by an enclosing scope}} \
+                               // expected-error {{static variable 's1' has a type that uses a type variable bound in an enclosing scope (type is 'struct S<T, U, T>' and type variable is 'U')}} \
                                // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Exists(T, _Ptr<U>) e1; // expected-error {{type 'Exists(T, _Ptr<U>)' for static variable 'e1' cannot use type variable 'U' that is bound by an enclosing scope}} \
+  static _Exists(T, _Ptr<U>) e1; // expected-error {{static variable 'e1' has a type that uses a type variable bound in an enclosing scope (type is 'Exists(T, _Ptr<U>)' and type variable is 'U')}} \
                                  // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{type 'Exists(T, struct S<T, U, V>)' for static variable 'e2' cannot use type variable 'U' that is bound by an enclosing scope}} \
+  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{static variable 'e2' has a type that uses a type variable bound in an enclosing scope (type is 'Exists(T, struct S<T, U, V>)' and type variable is 'U')}} \
                                            // expected-note@15 {{type variable 'U' declared here}} \
-                                           // expected-error {{type 'Exists(T, struct S<T, U, V>)' for static variable 'e2' cannot use type variable 'V' that is bound by an enclosing scope}} \
+                                           // expected-error {{static variable 'e2' has a type that uses a type variable bound in an enclosing scope (type is 'Exists(T, struct S<T, U, V>)' and type variable is 'V')}} \
                                            // expected-note@15 {{type variable 'V' declared here}}
 
-  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{type 'Exists(A, struct S<T, U, V>)' for static variable 'e3' cannot use type variable 'T' that is bound by an enclosing scope}} \
+  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{static variable 'e3' has a type that uses a type variable bound in an enclosing scope (type is 'Exists(A, struct S<T, U, V>)' and type variable is 'T')}} \
                                            // expected-note@15 {{type variable 'T' declared here}} \
-                                           // expected-error {{type 'Exists(A, struct S<T, U, V>)' for static variable 'e3' cannot use type variable 'U' that is bound by an enclosing scope}} \
+                                           // expected-error {{static variable 'e3' has a type that uses a type variable bound in an enclosing scope (type is 'Exists(A, struct S<T, U, V>)' and type variable is 'U')}} \
                                            // expected-note@15 {{type variable 'U' declared here}} \
-                                           // expected-error {{type 'Exists(A, struct S<T, U, V>)' for static variable 'e3' cannot use type variable 'V' that is bound by an enclosing scope}} \
+                                           // expected-error {{static variable 'e3' has a type that uses a type variable bound in an enclosing scope (type is 'Exists(A, struct S<T, U, V>)' and type variable is 'V')}} \
                                            // expected-note@15 {{type variable 'V' declared here}}
 
   // Static variable declarations can use integral and pointer types and bound type variables.

--- a/tests/typechecking/static_variables_free_type_variables.c
+++ b/tests/typechecking/static_variables_free_type_variables.c
@@ -1,0 +1,59 @@
+// Test type checking of static variables.
+// Static variable declarations should not use free type variables.
+//
+// RUN: %clang_cc1 -verify %s
+
+struct S _For_any(X, Y, Z) { };
+
+// Global static variable declarations can use bound type variables.
+static _Exists(T, struct S<T, T, T>) gs;
+
+//
+// Test that declarations of static variables cannot use free type variables.
+//
+
+_For_any(T, U, V) void f1(_Ptr<T> pt, struct S<T, U, V> s) {
+  static T t; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 't'}} \
+              // expected-note@15 {{free type variable 'T' declared here}}
+
+  static _Ptr<U> p; // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'p'}} \
+                    // expected-note@15 {{free type variable 'U' declared here}}
+
+  static _Array_ptr<V> a1; // expected-error {{illegal use of free type variable 'V' in declaration of static variable 'a1'}} \
+                           // expected-note@15 {{free type variable 'V' declared here}}
+
+  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 'a2'}} \
+                                       // expected-note@15 {{free type variable 'T' declared here}}
+
+  static struct S<T, U, T> s1; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 's1'}} \
+                               // expected-note@15 {{free type variable 'T' declared here}} \
+                               // expected-error {{illegal use of free type variable 'U' in declaration of static variable 's1'}} \
+                               // expected-note@15 {{free type variable 'U' declared here}}
+
+  static _Exists(T, _Ptr<U>) e1; // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'e1'}} \
+                                 // expected-note@15 {{free type variable 'U' declared here}}
+
+  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'e2'}} \
+                                           // expected-note@15 {{free type variable 'U' declared here}} \
+                                           // expected-error {{illegal use of free type variable 'V' in declaration of static variable 'e2'}} \
+                                           // expected-note@15 {{free type variable 'V' declared here}}
+
+  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 'e3'}} \
+                                           // expected-note@15 {{free type variable 'T' declared here}} \
+                                           // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'e3'}} \
+                                           // expected-note@15 {{free type variable 'U' declared here}} \
+                                           // expected-error {{illegal use of free type variable 'V' in declaration of static variable 'e3'}} \
+                                           // expected-note@15 {{free type variable 'V' declared here}}
+
+  // Static variable declarations can use integral and pointer types and bound type variables.
+  static int i;
+  static struct S<char, _Ptr<int>, double> s2;
+  static _Exists(T, _Ptr<T>) e4;
+  static _Exists(A, struct S<A, _Ptr<A>, _Array_ptr<A>>) e5;
+
+  // Non-static variable declarations can use free type variables.
+  _Ptr<T> q = 0;
+  _Array_ptr<_Array_ptr<U>> a3;
+  struct S<T, U, V> s3;
+  _Exists(U, _Ptr<T>) e6;
+}

--- a/tests/typechecking/static_variables_free_type_variables.c
+++ b/tests/typechecking/static_variables_free_type_variables.c
@@ -13,37 +13,37 @@ static _Exists(T, struct S<T, T, T>) gs;
 //
 
 _For_any(T, U, V) void f1(_Ptr<T> pt, struct S<T, U, V> s) {
-  static T t; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 't'}} \
-              // expected-note@15 {{free type variable 'T' declared here}}
+  static T t; // expected-error {{static variable 't' cannot have type variable 'T' that is bound by an enclosing scope}} \
+              // expected-note@15 {{type variable 'T' declared here}}
 
-  static _Ptr<U> p; // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'p'}} \
-                    // expected-note@15 {{free type variable 'U' declared here}}
+  static _Ptr<U> p; // expected-error {{static variable 'p' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                    // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Array_ptr<V> a1; // expected-error {{illegal use of free type variable 'V' in declaration of static variable 'a1'}} \
-                           // expected-note@15 {{free type variable 'V' declared here}}
+  static _Array_ptr<V> a1; // expected-error {{static variable 'a1' cannot have type variable 'V' that is bound by an enclosing scope}} \
+                           // expected-note@15 {{type variable 'V' declared here}}
 
-  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 'a2'}} \
-                                       // expected-note@15 {{free type variable 'T' declared here}}
+  static _Array_ptr<_Array_ptr<T>> a2; // expected-error {{static variable 'a2' cannot have type variable 'T' that is bound by an enclosing scope}} \
+                                       // expected-note@15 {{type variable 'T' declared here}}
 
-  static struct S<T, U, T> s1; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 's1'}} \
-                               // expected-note@15 {{free type variable 'T' declared here}} \
-                               // expected-error {{illegal use of free type variable 'U' in declaration of static variable 's1'}} \
-                               // expected-note@15 {{free type variable 'U' declared here}}
+  static struct S<T, U, T> s1; // expected-error {{static variable 's1' cannot have type variable 'T' that is bound by an enclosing scope}} \
+                               // expected-note@15 {{type variable 'T' declared here}} \
+                               // expected-error {{static variable 's1' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                               // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Exists(T, _Ptr<U>) e1; // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'e1'}} \
-                                 // expected-note@15 {{free type variable 'U' declared here}}
+  static _Exists(T, _Ptr<U>) e1; // expected-error {{static variable 'e1' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                                 // expected-note@15 {{type variable 'U' declared here}}
 
-  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'e2'}} \
-                                           // expected-note@15 {{free type variable 'U' declared here}} \
-                                           // expected-error {{illegal use of free type variable 'V' in declaration of static variable 'e2'}} \
-                                           // expected-note@15 {{free type variable 'V' declared here}}
+  static _Exists(T, struct S<T, U, V>) e2; // expected-error {{static variable 'e2' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                                           // expected-note@15 {{type variable 'U' declared here}} \
+                                           // expected-error {{static variable 'e2' cannot have type variable 'V' that is bound by an enclosing scope}} \
+                                           // expected-note@15 {{type variable 'V' declared here}}
 
-  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{illegal use of free type variable 'T' in declaration of static variable 'e3'}} \
-                                           // expected-note@15 {{free type variable 'T' declared here}} \
-                                           // expected-error {{illegal use of free type variable 'U' in declaration of static variable 'e3'}} \
-                                           // expected-note@15 {{free type variable 'U' declared here}} \
-                                           // expected-error {{illegal use of free type variable 'V' in declaration of static variable 'e3'}} \
-                                           // expected-note@15 {{free type variable 'V' declared here}}
+  static _Exists(A, struct S<T, U, V>) e3; // expected-error {{static variable 'e3' cannot have type variable 'T' that is bound by an enclosing scope}} \
+                                           // expected-note@15 {{type variable 'T' declared here}} \
+                                           // expected-error {{static variable 'e3' cannot have type variable 'U' that is bound by an enclosing scope}} \
+                                           // expected-note@15 {{type variable 'U' declared here}} \
+                                           // expected-error {{static variable 'e3' cannot have type variable 'V' that is bound by an enclosing scope}} \
+                                           // expected-note@15 {{type variable 'V' declared here}}
 
   // Static variable declarations can use integral and pointer types and bound type variables.
   static int i;


### PR DESCRIPTION
(See microsoft/checkedc-clang#684)
Add typechecking tests to verify that declarations of static variables cannot use free type variables.