### PR TITLE
Matching tests to the new logic on handling empty/invalid ranges

### DIFF
--- a/tests/dynamic_checking/bounds/deref.c
+++ b/tests/dynamic_checking/bounds/deref.c
@@ -7,7 +7,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
+// RUN: %clang %s -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
 // RUN: %checkedc_rununder %t1 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %checkedc_rununder %t1 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %checkedc_rununder %t1 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -16,7 +16,7 @@
 // RUN: %checkedc_rununder %t1 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t1 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
+// RUN: %clang %s -o %t2 -DTEST_WRITE -Werror -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
 // RUN: %checkedc_rununder %t2 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %checkedc_rununder %t2 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %checkedc_rununder %t2 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -25,7 +25,7 @@
 // RUN: %checkedc_rununder %t2 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t2 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
+// RUN: %clang %s -o %t3 -DTEST_INCREMENT -Werror -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
 // RUN: %checkedc_rununder %t3 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %checkedc_rununder %t3 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %checkedc_rununder %t3 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -34,7 +34,7 @@
 // RUN: %checkedc_rununder %t3 fail3 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t3 fail4 | FileCheck %s --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
+// RUN: %clang %s -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
 // RUN: %checkedc_rununder %t4 pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %checkedc_rununder %t4 pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %checkedc_rununder %t4 pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN
@@ -72,8 +72,8 @@ void passing_test_1(void);
 void passing_test_2(array_ptr<int> a : count(1));
 void passing_test_3(array_ptr<int> a : count(len), int len);
 
-void failing_test_1(void);
-void failing_test_2(void);
+void failing_test_1(int k);
+void failing_test_2(int k);
 void failing_test_3(array_ptr<int> a : count(g_zero));
 void failing_test_4(array_ptr<int> a : count(len), int len);
 
@@ -148,12 +148,12 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
   else if (strcmp(argv[1], "fail1") == 0) {
     // FAIL-1-NOT: Unreachable
     // FAIL-1-NOT: Unexpected Success
-    failing_test_1();
+    failing_test_1(0);
   }
   else if (strcmp(argv[1], "fail2") == 0) {
     // FAIL-2-NOT: Unreachable
     // FAIL-2-NOT: Unexpected Success
-    failing_test_2();
+    failing_test_2(2);
   }
   else if (strcmp(argv[1], "fail3") == 0) {
     // FAIL-3-NOT: Unreachable
@@ -207,10 +207,9 @@ void passing_test_3(array_ptr<int> a : count(len), int len) {
   puts("Expected Success");
 }
 
-// Bounds describe empty range, no deref
-void failing_test_1(void) {
+// Bounds describe empty range (function is called with k=0), no deref
+void failing_test_1(int k) {
   int a checked[2] = { 0, 0 };
-  int k = 0;
   array_ptr<int> b : bounds(a, a + k) = a;
   
   TEST_OP(*b, 1);
@@ -219,10 +218,9 @@ void failing_test_1(void) {
   puts("Unexpected Success");
 }
 
-// Bounds describe empty range (a + 2 > a), no deref
-void failing_test_2(void) {
+// Bounds describe invalid range (function is called with k=2, a + 2 > a), no deref
+void failing_test_2(int k) {
   int a checked[3] = { 0, 0, 0 };
-  int k = 2;
   array_ptr<int> b : bounds(a + k, a) = a;
 
   TEST_OP(*b, 2);

--- a/tests/dynamic_checking/bounds/deref_opt.c
+++ b/tests/dynamic_checking/bounds/deref_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -22,7 +22,7 @@
 // RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -31,7 +31,7 @@
 // RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -40,7 +40,7 @@
 // RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/deref_opt.c
+++ b/tests/dynamic_checking/bounds/deref_opt.c
@@ -13,7 +13,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t1 -DTEST_READ -Werror -Wno-unused-value  -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t1 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-READ
 // RUN: %checkedc_rununder %t1 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-READ
 // RUN: %checkedc_rununder %t1 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-READ
@@ -22,7 +22,7 @@
 // RUN: %checkedc_rununder %t1 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t1 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 //
-// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t2 -DTEST_WRITE -Werror  -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t2 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-WRITE
 // RUN: %checkedc_rununder %t2 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-WRITE
 // RUN: %checkedc_rununder %t2 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-WRITE
@@ -31,7 +31,7 @@
 // RUN: %checkedc_rununder %t2 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t2 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t3 -DTEST_INCREMENT -Werror  -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t3 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-INCREMENT
 // RUN: %checkedc_rununder %t3 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-INCREMENT
 // RUN: %checkedc_rununder %t3 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-INCREMENT
@@ -40,7 +40,7 @@
 // RUN: %checkedc_rununder %t3 fail3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-3
 // RUN: %checkedc_rununder %t3 fail4 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-FAIL,FAIL-4
 
-// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -O3 %checkedc_target_flags
+// RUN: %clang %S/deref.c -o %t4 -DTEST_COMPOUND_ASSIGN -Werror -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope -O3 %checkedc_target_flags
 // RUN: %checkedc_rununder %t4 pass1 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-1-COMPOUND-ASSIGN
 // RUN: %checkedc_rununder %t4 pass2 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-2-COMPOUND-ASSIGN
 // RUN: %checkedc_rununder %t4 pass3 | FileCheck %S/deref.c --check-prefixes=CHECK,CHECK-PASS,PASS-3-COMPOUND-ASSIGN

--- a/tests/dynamic_checking/bounds/nullterm_pointers.c
+++ b/tests/dynamic_checking/bounds/nullterm_pointers.c
@@ -1,7 +1,7 @@
 // Test runtime bounds checking in checked scopes of uses of pointers
 // and arrays with bounds-safe interfaces.
 //
-// RUN: %clang %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses %checkedc_target_flags
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value -Wno-check-memory-accesses -Wno-check-bounds-decls-unchecked-scope %checkedc_target_flags
 // RUN: %checkedc_rununder %t1 1 | FileCheck %s --check-prefixes=CHECK,NO-BOUNDS-FAILURES-1
 // RUN: %checkedc_rununder %t1 2 | FileCheck %s --check-prefixes=CHECK
 // RUN: %checkedc_rununder %t1 3 | FileCheck %s --check-prefixes=CHECK
@@ -182,9 +182,9 @@ int test1(void) {
 // to cause a runtime fault.
 int test2(void) {
   array_ptr<char> s : count(0) = "hello";
-  int i = 0;
-  while (*s) {
-    i += *s;
+  int i = 0, j = 0;
+  while (*(s+j)) {
+    i += *(s+j);
     s++;
   }
   // CHECK-NOT: expected bounds failure on read
@@ -210,7 +210,8 @@ void test3(void) {
 void test4(void) {
   char data checked[6] = "hello";
   array_ptr<char> s : count(6) = data;
-  *(s + 6) = 'd';
+  int k = 6;
+  *(s + k) = 'd';
   // CHECK-NOT: expected bounds failure on write
   puts("expected bounds failure on write");
   return;
@@ -233,7 +234,8 @@ void test6(void) {
   char data checked[6] = "hello";
   array_ptr<char> s : count(6) = data;
   char result = 0;
-  s[6] = result;
+  int k = 6;
+  s[k] = result;
   // CHECK-NOT: expected bounds failure on write
   puts("expected bounds failure on write");
   return;
@@ -246,7 +248,8 @@ void test7(void) {
   char data nt_checked[6] = "hello";
   array_ptr<char> s : count(5) = data;
   char result = 0;
-  s[5 + 1] = result;
+  int k = 5;
+  s[k + 1] = result;
   // CHECK-NOT: expected bounds failure on write
   puts("expected bounds failure on write");
   return;
@@ -258,7 +261,8 @@ void test8(void) {
   char data checked[6] = "hello";
   array_ptr<char> s : count(6) = data;
   char result = 0;
-  s[6 + 1] = result;
+  int k = 6;
+  s[k + 1] = result;
   // CHECK-NOT: expected bounds failure on write
   puts("expected bounds failure on write");
   return;
@@ -281,7 +285,8 @@ void test9(void) {
 void test10(void) {
   char data nt_checked[6] = "hello";
   nt_array_ptr<char> s : bounds(data + 6, data + 5) = data;
-  s[6] = 0;
+  int k = 6;
+  s[k] = 0;
   // CHECK-NOT: expected bounds failure on write
   puts("expected bounds failure on write");
   return;

--- a/tests/dynamic_checking/bounds/predefined_literals.c
+++ b/tests/dynamic_checking/bounds/predefined_literals.c
@@ -32,10 +32,10 @@ void pass1(_Ptr<const char> s) {
   printf("%c\n", __func__[4]);
 }
 
-void fail1() {
+void fail1(int x) {
 // FAIL1: Error: out-of-bounds access of predefined literal
 #pragma CHECKED_SCOPE ON
-  char c = __func__[100];
+  char c = __func__[x];
 #pragma CHECKED_SCOPE OFF
 }
 
@@ -63,7 +63,7 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
       pass1(__func__);
       break;
     case 100:
-      fail1();
+      fail1(100);
       break;
 
     default:

--- a/tests/dynamic_checking/dynamic-bounds-cast-check.c
+++ b/tests/dynamic_checking/dynamic-bounds-cast-check.c
@@ -273,9 +273,10 @@ void failing_test_3(void) {
 void failing_test_4(void) {
   int r checked[10] = {0,1,2,3,4,5,6,7,8,9};
   array_ptr<int> s : count(3) = _Dynamic_bounds_cast<array_ptr<int>>(r, count(5));
-  
+
+  int k = 5;
   printf("Printable1\n");
-  printf("Unprintable2: %d\n", *(s+5));
+  printf("Unprintable2: %d\n", *(s+k));
   
   puts("Unexpected Success");
 }

--- a/tests/dynamic_checking/dynamic-bounds-cast-check.c
+++ b/tests/dynamic_checking/dynamic-bounds-cast-check.c
@@ -1,6 +1,6 @@
 // The following lines are for the clang automated test suite
 //
-// RUN: %clang %s -o %t -Werror -Wno-check-memory-accesses
+// RUN: %clang %s -o %t -Werror
 // RUN: %t pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-1
 // RUN: %t pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-2
 // RUN: %t pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-3
@@ -27,7 +27,7 @@ void passing_test_3(void);
 void failing_test_1(void);
 void failing_test_2(void);
 void failing_test_3(void);
-void failing_test_4(void);
+void failing_test_4(int k);
 void failing_test_5(array_ptr<char> pc : count(len), unsigned len);
 void failing_test_6(array_ptr<char> pc : count(len), unsigned len);
 void failing_test_7(array_ptr<char> pc : count(len), unsigned len);
@@ -113,7 +113,7 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
     // CHECK-FAIL-4 : Printable1
     // CHECK-FAIL-4-NOT: Unprintable2
     // CHECK-FAIL-4-NOT: Unexpected Success
-    failing_test_4();
+    failing_test_4(5);
   } else if (strcmp(argv[1], "fail5") == 0) {
     array_ptr<char> p : count(12) = "\0\0\0\0\0\0\0\0abcd";
     // CHECK-FAIL-5: Successful pointer conversion
@@ -270,11 +270,11 @@ void failing_test_3(void) {
 
 // bounds_cast insert dynamic_check(r <= r && (r+5) <= r+10) -> OK;
 // dereference insert dynamic_check(s <= s+5 && (s+5) < s+3) -> FAIL
-void failing_test_4(void) {
+// k = 5
+void failing_test_4(int k) {
   int r checked[10] = {0,1,2,3,4,5,6,7,8,9};
   array_ptr<int> s : count(3) = _Dynamic_bounds_cast<array_ptr<int>>(r, count(5));
 
-  int k = 5;
   printf("Printable1\n");
   printf("Unprintable2: %d\n", *(s+k));
   

--- a/tests/runtime_operations/assignments.c
+++ b/tests/runtime_operations/assignments.c
@@ -1,6 +1,6 @@
 // The following lines are for the clang automated test suite
 //
-// RUN: %clang -fcheckedc-extension %s -o %t -Werror -Wno-check-memory-accesses
+// RUN: %clang -fcheckedc-extension %s -o %t -Werror
 // RUN: %t | FileCheck %s --check-prefixes=CHECK
 
 #include <stdchecked.h>

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -333,7 +333,7 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // assignment through pointer
   *t1 = 1;            // expected-error {{expression has unknown bounds}}
-  *t2 = 2;            // expected-warning {{out-of-bounds memory access}}
+  *t2 = 2;
   *t3 = 3;
 
   // read through a pointer
@@ -343,7 +343,7 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // assignment via subcript
   t1[0] = 1;          // expected-error {{expression has unknown bounds}}
-  t2[0] = 3;          // expected-warning {{out-of-bounds memory access}}
+  t2[0] = 3;
   t3[0] = 4;
 
   // read via subscript
@@ -354,19 +354,19 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
 
   // pre-increment/post-increment
   ++(*t1);            // expected-error {{expression has unknown bounds}}
-  ++(*t2);            // expected-warning {{out-of-bounds memory access}}
+  ++(*t2);            // expected-error {{out-of-bounds memory access}}
   ++(*t3);
 
   --(*t1);            // expected-error {{expression has unknown bounds}}
-  --(*t2);            // expected-warning {{out-of-bounds memory access}}
+  --(*t2);            // expected-error {{out-of-bounds memory access}}
   --(*t3);
 
   (*t1)++;            // expected-error {{expression has unknown bounds}}
-  (*t2)++;            // expected-warning {{out-of-bounds memory access}}
+  (*t2)++;            // expected-error {{out-of-bounds memory access}}
   (*t3)++;
 
   --(*t1);            // expected-error {{expression has unknown bounds}}
-  --(*t2);            // expected-warning {{out-of-bounds memory access}}
+  --(*t2);            // expected-error {{out-of-bounds memory access}}
   --(*t3);
 
   // operations involving struct members

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -58,10 +58,10 @@ extern void f3() {
   *(_Assume_bounds_cast<ptr<int>>(r) + 2) = 4; // expected-error{{arithmetic on _Ptr type}}
   // For the statement below, the compiler figures out that r + 2 is out of bounds r : count(1).
   // r : count(1) normals to bounds(r, r + 1), and r + 2 is out of that range.
-  *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} expected-warning {{out-of-bounds memory access}}
+  *(_Dynamic_bounds_cast<array_ptr<int>>(r, count(1)) + 2) = 4; // expected-error {{expression has unknown bounds}} expected-error {{out-of-bounds memory access}}
   // For the statement below, the compiler figures out that t[3] is out of bounds t : count(3).
   // t : count(3) normals to bounds(t, t + 3), and t[3] is out of that range.
-  int n = (_Dynamic_bounds_cast<array_ptr<int>>(t, count(3)))[3]; // expected-warning {{out-of-bounds memory access}}
+  int n = (_Dynamic_bounds_cast<array_ptr<int>>(t, count(3)))[3]; // expected-error {{out-of-bounds memory access}}
   s1 = _Dynamic_bounds_cast<array_ptr<int>>(p, count(5)); // expected-error {{expression has unknown bounds}}
   s2 = _Assume_bounds_cast<array_ptr<int>>(r, count(5));
 }

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -207,21 +207,21 @@ extern void f20(void *p) {
 
 extern void f21(array_ptr<char> buf : count(len), int len) {
   array_ptr<int> intbuf : count(12) = _Dynamic_bounds_cast<array_ptr<int>>(buf, bounds(intbuf, intbuf + 12));
-  int i = intbuf[12]; // expected-warning {{out-of-bounds memory access}} \
+  int i = intbuf[12]; // expected-error {{out-of-bounds memory access}} \
                       // expected-note {{accesses memory at or above the upper bound}} \
                       // expected-note {{(expanded) inferred bounds are 'bounds(intbuf, intbuf + 12)'}}
 }
 
 extern void f22() {
   array_ptr<int> intbuf : count(2) = _Dynamic_bounds_cast<array_ptr<int>>(h8(), count(2));
-  int i = intbuf[2]; // expected-warning {{out-of-bounds memory access}} \
+  int i = intbuf[2]; // expected-error {{out-of-bounds memory access}} \
                      // expected-note {{accesses memory at or above the upper bound}} \
                      // expected-note {{(expanded) inferred bounds are 'bounds(intbuf, intbuf + 2)'}}
 }
 
 extern void f23() {
   array_ptr<char> buf : count(10) = _Assume_bounds_cast<array_ptr<char>>(h7(), count(10));
-  char c = buf[10]; // expected-warning {{out-of-bounds memory access}} \
+  char c = buf[10]; // expected-error {{out-of-bounds memory access}} \
                     // expected-note {{accesses memory at or above the upper bound}} \
                     // expected-note {{(expanded) inferred bounds are 'bounds(buf, buf + 10)'}}
 }
@@ -229,14 +229,14 @@ extern void f23() {
 extern void f24() {
   array_ptr<char> buf : count(3) = "abc";
   buf = _Dynamic_bounds_cast<array_ptr<char>>(h7(), bounds(buf, buf + 3));
-  char c = buf[3]; // expected-warning {{out-of-bounds memory access}} \
+  char c = buf[3]; // expected-error {{out-of-bounds memory access}} \
                    // expected-note {{accesses memory at or above the upper bound}} \
                    // expected-note {{(expanded) inferred bounds are 'bounds(buf, buf + 3)'}}
 }
 
 extern void f25(array_ptr<char> buf : count(len), int len) {
   array_ptr<int> intbuf : count(6) = _Dynamic_bounds_cast<array_ptr<int>>(buf + 5, count(6));
-  int i = intbuf[6]; // expected-warning {{out-of-bounds memory access}} \
+  int i = intbuf[6]; // expected-error {{out-of-bounds memory access}} \
                      // expected-note {{accesses memory at or above the upper bound}} \
                      // expected-note {{(expanded) inferred bounds are 'bounds(intbuf, intbuf + 6)'}}
 }


### PR DESCRIPTION
This is to update the tests to match the new handling of empty and invalid ranges. The corresponding code for the new handling is in this [pull-request](https://github.com/microsoft/checkedc-clang/pull/707).