### PR TITLE
Introduce read/write sets for bounds declaration checking description.

### DIFF
--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1194,7 +1194,7 @@ Let $B = bounds(v, v + n)$ and $G =\{ v \}$.
 \item Let $RB = $ \boundsunknown (Checked C does not allow bounds for values stored in arrays).
 \end{enumerate}
 \end{enumerate}
-\item If $e$ has the form $*e1$,  let $(B, \mathit{UC}, EQ, \_) = Check(e1, C, EQ, No)$.  Let $G =\emptyset$ and $RB = $ \boundsunknown (Checked C does not allow bounds for values pointed to by pointers).
+\item If $e$ has the form $*e1$,  let $(B, \mathit{UC}, EQ, \_, R, W) = Check(e1, C, EQ, No)$.  Let $G =\emptyset$ and $RB = $ \boundsunknown (Checked C does not allow bounds for values pointed to by pointers).
 \item If $e$ has the form $e1[e2]$,
 \label{list:check-unordered-subscript-operands}
 \begin{enumerate}
@@ -1368,7 +1368,7 @@ $CheckFullExpr(e=$~\code{x = alloc(5)}\code{, len = 5}$)$\\
    \>\>\>$CheckLValue($\code{len}$, C = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, UEQ= \{\{tmp, x\}\})$\\
    \>\>\>\>\>$(B = $ \code{bounds(&len, &len + 1)}$, RB = $\code{bounds(unknown)}$,$
                             $\mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},$\\
-   \>\>\>\>\>~$UEQ = \{\{tmp, x\}\},  PV = \emptyset, R = \emptyset, W = \emptyset)$\\
+   \>\>\>\>\>~$UEQ = \{\{tmp, x\}\},  R = \emptyset, W = \emptyset)$\\
    \>\>\>$Check(e = $\code{5}, $\mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, EQ = \{\{tmp, x\}\},
           Form = No, FB = None)$\\
    \>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
@@ -1406,32 +1406,32 @@ x = (len = getlen()) ? alloc(len) : 0;
 $CheckFullExpr(e=$~\code{x = (len = getlen()) ? alloc(len) : 0}$)$\\
 \>$DC = \{x \mapsto$\code{bounds(x, x + len)}$\}$\\
 \>$Check(e=$~\code{x = (len = getlen()) ? alloc(len) : 0}$,$\\
-\>\>\>\>~$C=\{x \mapsto$\code{bounds(x, x + len)}$\},EQ=\emptyset,PV=\emptyset,
+\>\>\>\>~$C=\{x \mapsto$\code{bounds(x, x + len)}$\},EQ=\emptyset,
            Form = No, FB = None)$\\ \\
 
-\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset)$ \\
+\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset)$ \\
 \>\>\>\>\>$(B = $ \code{bounds(&x, &x + 1)}, $RB = $\code{bounds(x, x + len)}$,
-                    \mathit{UC} = \{x \mapsto$\code{bounds(x, x + len)}$\},$\\
+                    \mathit{UC} = \{x \mapsto$\code{bounds(x, x + len)}$\}, R = \emptyset, W = \emptyset)$\\
 \>\>$Check(e=$~\code{(len = getlen()) ? alloc(len) : 0}$,$\\
-\>\>\>\>~$C=\{x \mapsto$\code{bounds(x, x + len)}$\},EQ=\emptyset,PV=\emptyset,
+\>\>\>\>~$C=\{x \mapsto$\code{bounds(x, x + len)}$\},EQ=\emptyset,
            Form = No, FB = None)$\\ \\
 
 % The condition expression
 \>\>\>{\tt Process the condition:}\\
 \>\>\>$Check(e=$~\code{(len = getlen())}$, C=\{x \mapsto$\code{bounds(x, x + len)}$\},
-       EQ=\emptyset,PV=\emptyset, Form = No,$\\
+       EQ=\emptyset, Form = No,$\\
 \>\>\>\>\>\>$FB = None)$\\
 \>\>\>\>$Check(e=$~\code{len = getlen()}$, C=\{x \mapsto$\code{bounds(x, x + len)}$\},
-         EQ=\emptyset,PV=\emptyset, Form = No,$\\
+         EQ=\emptyset, Form = No,$\\
 \>\>\>\>\>\>\>$FB = None)$\\
-\>\>\>\>\>$CheckLValue($\code{len}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset)$ \\
+\>\>\>\>\>$CheckLValue($\code{len}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset)$ \\
 \>\>\>\>\>\>$(B = $ \code{bounds(&len, &len + 1)}, $RB = $\code{bounds(unknown)}$,
                      \mathit{UC} = \{x \mapsto$\code{bounds(x, x + len)}$\},$\\
-\>\>\>\>\>\>~$UEQ = \emptyset, G = \{$\code{&len}\}$)$ \\
-\>\>\>\>\>\>$Check($\code{getlen()}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset,
+\>\>\>\>\>\>~$UEQ = \emptyset, G = \{$\code{&len}\}$, R = \emptyset, W = \emptyset)$ \\
+\>\>\>\>\>\>$Check($\code{getlen()}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset,
                          Form = No, FB = None)$\\
 \>\>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(x, x + len)}$ , UEQ = \emptyset,
-               G = \emptyset)$\\
+               G = \emptyset, R = \emptyset, G = \emptyset)$\\
 \>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$ , UEQ = \emptyset,
                G = \emptyset)$\\
 \>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$ , UEQ = \emptyset,
@@ -1439,7 +1439,7 @@ $CheckFullExpr(e=$~\code{x = (len = getlen()) ? alloc(len) : 0}$)$\\
 % first arm
 \>\>\>{\tt Process the first arm:}\\
 \>\>\>$Check(e=$~\code{alloc(len)}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-         EQ=\emptyset,PV=\emptyset, Form = No, FB = None)$\\
+         EQ=\emptyset, Form = No, FB = None)$\\
 \>\>\>\>$(B_1 = $ \code{bounds(tmp1, tmp1 + len)}$, \mathit{UC}_1 = \{x\mapsto$\code{bounds(unknown)}$,
                 {UEQ}_1 = \emptyset, G_1 = \{tmp1\})$\\
 
@@ -1447,7 +1447,7 @@ $CheckFullExpr(e=$~\code{x = (len = getlen()) ? alloc(len) : 0}$)$\\
 \\
 \>\>\>{\tt Process the second arm:}\\
 \>\>\>$Check(e=$~\code{0}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-         EQ=\emptyset,PV=\emptyset, Form = No, FB = None)$\\
+         EQ=\emptyset, Form = No, FB = None)$\\
 \>\>\>\>$(B_2 = $ \code{bounds(any)}$, \mathit{UC}_2 = \{x\mapsto$\code{bounds(unknown)}$,
                {UEQ}_2 = \emptyset, G_2 = \{ 0 \}$\\ \\
 
@@ -1490,39 +1490,39 @@ array_ptr<int> x : count(len) = 0;
 $CheckFullExpr(e=$~\code{(len = getlen()) ? (x = alloc(len)) : (x = alloc(1), len = 1)}$)$\\
 \>$DC = \{x \mapsto$\code{bounds(x, x + len)}$\}$\\
 \>$Check(e=$~\code{(len = getlen()) ? (x = alloc(len)) : (x = alloc(1), len = 1)}$,$\\
-\>\>\>\>~$C=\{x \mapsto$\code{bounds(x, x + len)}$\},EQ=\emptyset,PV=\emptyset,
+\>\>\>\>~$C=\{x \mapsto$\code{bounds(x, x + len)}$\},EQ=\emptyset,
            Form = No, FB = None)$\\ \\
 % The condition expression
 \>\>{\tt Process the condition:}\\
 \>\>$Check(e=$~\code{(len = getlen())}$, C=\{x \mapsto$\code{bounds(x, x + len)}$\},
-       EQ=\emptyset,PV=\emptyset, Form = No,$\\
+       EQ=\emptyset, Form = No,$\\
 \>\>\>\>\>$FB = None)$\\
 \>\>\>$Check(e=$~\code{len = getlen()}$, C=\{x \mapsto$\code{bounds(x, x + len)}$\},
-         EQ=\emptyset,PV=\emptyset, Form = No,$\\
+         EQ=\emptyset, Form = No,$\\
 \>\>\>\>\>\>$FB = None)$\\
-\>\>\>\>$CheckLValue($\code{len}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset)$ \\
+\>\>\>\>$CheckLValue($\code{len}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset)$ \\
 \>\>\>\>\>$(B = $ \code{bounds(&len, &len + 1)}, $RB = $\code{bounds(unknown)}$,
                      \mathit{UC} = \{x \mapsto$\code{bounds(x, x + len)}$\},$\\
-\>\>\>\>\>~$UEQ = \emptyset, G = \{$\code{&len}\}$)$ \\
-\>\>\>\>$Check($\code{getlen()}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset,
+\>\>\>\>\>~$UEQ = \emptyset, G = \{$\code{&len}\}$, R = \emptyset, W = \emptyset)$ \\
+\>\>\>\>$Check($\code{getlen()}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset,
                          Form = No, FB = None)$\\
 \>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(x, x + len)}$ , UEQ = \emptyset,
-               G = \emptyset)$\\
+               G = \emptyset, R = \emptyset, G = \emptyset)$\\
 \>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$ , UEQ = \emptyset,
-               G = \emptyset)$\\
+               G = \emptyset, R = \emptyset, W = \{$\code{len}$\})$\\
 \>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$ , UEQ = \emptyset,
-          G = \emptyset)$\\  \\
+          G = \emptyset, R = \emptyset, W = \{$\code{len}$\})$\\  \\
 % first arm
 \>\>{\tt Process the first arm:}\\
 \>\>$Check(e=$~\code{(x = alloc(len))}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-         EQ=\emptyset,PV=\emptyset, Form = No, FB = None)$\\
+         EQ=\emptyset, Form = No, FB = None)$\\
 \>\>\>$Check(e=$~\code{x = alloc(len)}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-          EQ=\emptyset,PV=\emptyset, Form = No, FB = None)$\\
-\>\>\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(unknown)}$\}, EQ = \emptyset, PV = \emptyset)$ \\
+          EQ=\emptyset, Form = No, FB = None)$\\
+\>\>\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(unknown)}$\}, EQ = \emptyset)$ \\
 \>\>\>\>\>$(B = $ \code{bounds(&x, &x + 1)}, $RB = $\code{bounds(unknown)}$,
                      \mathit{UC} = \{x \mapsto$\code{bounds(x, x + len)}$\},$\\
 \>\>\>\>\>~$UEQ = \emptyset, G = \{$\code{&x}\}$)$ \\
-\>\>\>$Check($\code{alloc(len)}$,C  =\{x\mapsto$\code{bounds(unknown)}$\}, EQ = \emptyset, PV = \emptyset,
+\>\>\>$Check($\code{alloc(len)}$,C  =\{x\mapsto$\code{bounds(unknown)}$\}, EQ = \emptyset,
                        Form = No, FB = None)$\\
 \>\>\>\>$(B = $ \code{bounds(tmp1, tmp1 + len)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$,
                 UEQ = \emptyset G = \{tmp1\})$\\
@@ -1532,33 +1532,32 @@ $CheckFullExpr(e=$~\code{(len = getlen()) ? (x = alloc(len)) : (x = alloc(1), le
 % process the second arm
 \>\>{\tt Process the second arm:}\\
 \>\>$Check(e=$~\code{((len = 1, x = alloc(1))}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-         EQ=\emptyset,PV=\emptyset, Form = No,$\\
+         EQ=\emptyset, Form = No,$\\
 \>\>\>\>\>$FB = None)$\\
 \>\>\>$Check(e=$~\code{len = 1, x = alloc(1)}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-          EQ=\emptyset,PV=\emptyset, Form = No,$\\
+          EQ=\emptyset, Form = No,$\\
 \>\>\>\>\>\>$FB = None)$\\
 \>\>\>\>$Check(e=$~\code{len = 1}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-          EQ=\emptyset,PV=\emptyset, Form = No, FB = None)$\\
-\>\>\>\>\>$CheckLValue($\code{len}$, C = \{x \mapsto$\code{bounds(unknown)}$\}, EQ =  \emptyset,
-                   PV = \emptyset)$ \\
+          EQ=\emptyset, Form = No, FB = None)$\\
+\>\>\>\>\>$CheckLValue($\code{len}$, C = \{x \mapsto$\code{bounds(unknown)}$\}, EQ =  \emptyset)$ \\
 \>\>\>\>\>\>$(B = $ \code{bounds(&len, &len + 1)}, $RB = $\code{bounds(unknown)}$,
                      \mathit{UC} = \{x \mapsto$\code{bounds(unknown)}$\},$\\
 \>\>\>\>\>\>~$UEQ =  \emptyset, G = \{$\code{&len}\}$)$ \\
-\>\>\>\>\>$Check($\code{1}$,C  =\{x\mapsto$\code{bounds(unknown)}$\}, EQ = \emptyset, PV = \emptyset,
+\>\>\>\>\>$Check($\code{1}$,C  =\{x\mapsto$\code{bounds(unknown)}$\}, EQ = \emptyset,
                        Form = No, FB = None)$\\
 \>\>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$,
                   UEQ = \emptyset, G = \{1\})$\\
 \>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$,
                   UEQ = \{\{len, 1\}\}, G = \{len, 1\})$\\
 \>\>\>\>$Check(e=$~\code{x = alloc(1)}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
-          EQ=\{\{len, 1\}\},PV=\emptyset, Form = No,$\\
+          EQ=\{\{len, 1\}\}, Form = No,$\\
 \>\>\>\>~$FB = None)$\\
 \>\>\>\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(unknown)}$\}, 
-                                      EQ = \{\{len, 1\}\}, PV = \emptyset)$ \\
+                                      EQ = \{\{len, 1\}\})$ \\
 \>\>\>\>\>\>$(B = $ \code{bounds(&x, &x + 1)}, $RB = $\code{bounds(unknown)}$,
                      \mathit{UC} = \{x \mapsto$\code{bounds(unknown)}$\},$\\
 \>\>\>\>\>\>~$UEQ = \{\{len, 1\}\}, G = \{$\code{&x}\}$)$ \\
-\>\>\>\>\>$Check($\code{alloc(1)}$,C  =\{x\mapsto$\code{bounds(unknown)}$\}, EQ = \{\{len, 1\}\}, PV = \emptyset,
+\>\>\>\>\>$Check($\code{alloc(1)}$,C  =\{x\mapsto$\code{bounds(unknown)}$\}, EQ = \{\{len, 1\}\},
                        Form = No, FB = None)$\\
 \>\>\>\>\>\>$(B = $ \code{bounds(tmp2, tmp2 + 1)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$,
                       UEQ = \{\{len, 1\}\},G = \{tmp2\})$\\

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1201,7 +1201,7 @@ Let $B = bounds(v, v + n)$ and $G =\{ v \}$.
 \item Let $RB = $ \boundsunknown (Checked C does not allow bounds for values stored in arrays).
 \end{enumerate}
 \end{enumerate}
-\item If $e$ has the form $*e1$,  let $(B, \mathit{UC}, EQ, \_, R, W) = Check(e1, C, EQ, No)$.  Let $G =\emptyset$ and $RB = $ \boundsunknown (Checked C does not allow bounds for values pointed to by pointers).
+\item If $e$ has the form $*e1$,  let $(B, \mathit{UC}, UEQ, \_, R, W) = Check(e1, C, EQ, No)$.  Let $G =\emptyset$ and $RB = $ \boundsunknown (Checked C does not allow bounds for values pointed to by pointers).
 \item If $e$ has the form $e1[e2]$,
 \label{list:check-unordered-subscript-operands}
 \begin{enumerate}
@@ -1323,7 +1323,7 @@ to produce the set of sets.  Empty or singleton sets are removed.
 temporary was introduced for the value of $e$,  also add the temporary to $G$.
 \item Let $R = RC \cup R_1 \cup R_2$.  Let $W = WC \cup W_1 \cup W_2$.
 \item Make sure that all assignments to variables used in $DC^\prime$ have been seen before
-validating $DC^prime$ (otherwise the validation may be incorrect).
+validating $DC^\prime$ (otherwise the validation may be incorrect).
 For each bounds expression $B$ in $DC^\prime$, let $Q$ by the variables read by $B$.
 Let $R = R \cup Q$ (if an unordered assignment to a variable used in $Q$ is 
 subsequently processed, this will cause a checking failure).
@@ -1384,7 +1384,9 @@ $CheckFullExpr(e=$~\code{x = alloc(5)}\code{, len = 5}$)$\\
    \>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
              EQ = \{\{tmp, x\},\{5, len\}\},  G = \{5\},$\\
    \>\>\>~$R = \emptyset, W = \{ len \})$\\
-  \>\>$CheckOverlap(\emptyset, \{x\}, \emptyset, \{ len \})$\\
+   \>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
+             EQ = \{\{tmp, x\},\{5, len\}\},  G = \{5\},$\\
+   \>\>~$R = \emptyset, W = \{ x, len \})$\\
   \>$Validate(DC = \{x \mapsto$\code{bounds(x, x + len)}$\},
                    \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
                    EQ = \{\{tmp, x\},\{5, len\}\})$\\

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1070,9 +1070,7 @@ The definition of $Check(e, C, EQ, Form, FB)$ is:
 \item If $e$ does not have array type, there will an implicit read of the lvalue produced by $e$
 at runtime. 
 \begin{enumerate}
-\item Let $R = R_{lv}$.
-\item Let $W = W_{lv}$.
-\item Let $B = RB$. 
+\item Let $R = R_{lv}$,  $W = W_{lv}$, and $B = RB$. 
 \item If $e$ is a (possibly-parenthesized) variable $v$, let $R = R \cup \{ v \}$.
 \item Otherwise, if $NeedsBoundsCheck(e)$ returns true,
 a compiler will insert a bounds check  to ensure $e$ is a valid memory location to access. 
@@ -1105,6 +1103,7 @@ Check that the bound check does not use any variables written by either $lhs$ or
 calling $CheckOverlap(Q, W)$.   Let $R = R \cup Q$.
 \item  If $lhs$ is a variable $v$ (that is, $GetLValueVariable(lhs) = { v }$),
 \begin{enumerate}
+\item Let $W = W \cup \{ v \}$.
 \item Determine whether there is an expression that computes the old value of $v$:
 \begin{enumerate}
 \item If $rhs$ can be inverted with respect to $v$, let $iv = inverse(v, rhs)$. 
@@ -1351,31 +1350,34 @@ Here is a list of checking steps:
 $CheckFullExpr(e=$~\code{x = alloc(5)}\code{, len = 5}$)$\\
 \>$DC = \{x \mapsto$\code{bounds(x, x + len)}$\}$\\
 \>$Check(e=$~\code{x = alloc(5)}\code{, len = 5}$, C=\{x \mapsto$\code{bounds(x, x + len)}$\},  EQ=\emptyset,
-           PV=\emptyset, Form = No, FB = None)$\\
+           Form = No, FB = None)$\\
 \>\>$Check(e=$~\code{x = alloc(5)}$,C=\{x\mapsto$\code{bounds(x,x + len)}$\},
-                EQ=\emptyset, PV=\emptyset, Form=No, FB=None)$ \\
-  \>\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset)$ \\
+                EQ=\emptyset, Form=No, FB=None)$ \\
+  \>\>\>$CheckLValue($\code{x}$, C = \{x \mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset)$ \\
   \>\>\>\>$(B = $ \code{bounds(&x, &x + 1)}, $RB = $\code{bounds(x, x + len)}$,
                            \mathit{UC} = \{x \mapsto$\code{bounds(x, x + len)}$\},$\\
-  \>\>\>\>~$UEQ = \emptyset, G = \{$\code{&x}\}$)$ \\
-  \>\>\>$Check($\code{alloc(5)}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, PV = \emptyset, Form = No, FB = None)$\\
-  \>\>\>\>$(B = $ \code{bounds(tmp, tmp + 5)}$, \mathit{UC} = \{x\mapsto$\code{bounds(x, x + len)}$ , UEQ = \emptyset,
-              G = \{$\code{tmp}$\})$\\
+  \>\>\>\>~$UEQ = \emptyset, G = \{$\code{&x}\}$, R = \emptyset, W = \emptyset)$ \\
+  \>\>\>$Check($\code{alloc(5)}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset, Form = No, FB = None)$\\
+  \>\>\>\>$(B = $ \code{bounds(tmp, tmp + 5)}$, \mathit{UC} = \{x\mapsto$\code{bounds(x, x + len)}$ , 
+              G = \{$\code{tmp}$\}, R = \emptyset, W = \emptyset)$\\
  \>\>\>$(B = $\code{bounds(tmp, tmp + 5)}$, \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, UEQ= \{\{tmp, x\}\},
-          G = \{tmp, x\})$ \\
+          G = \{tmp, x\},$\\
+  \>\>\>~$R = \emptyset, W = \{x\})$ \\
   \>\>$Check(e=$~\code{len = 5}$, C = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, UEQ= \{\{tmp, x\}\},
-        PV=\emptyset, Form = No, FB = None)$\\
-   \>\>\>$CheckLValue($\code{len}$, C = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, UEQ= \{\{tmp, x\}\},
-                              PV = \emptyset)$\\
+        Form = No, FB = None)$\\
+   \>\>\>$CheckLValue($\code{len}$, C = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, UEQ= \{\{tmp, x\}\})$\\
    \>\>\>\>\>$(B = $ \code{bounds(&len, &len + 1)}$, RB = $\code{bounds(unknown)}$,$
                             $\mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},$\\
-   \>\>\>\>\>~$UEQ = \{\{tmp, x\}\},  PV = \emptyset)$\\
-   \>\>\>$Check(e = $\code{5}, $\mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, EQ = \{\{tmp, x\}\}, PV = \emptyset,
+   \>\>\>\>\>~$UEQ = \{\{tmp, x\}\},  PV = \emptyset, R = \emptyset, W = \emptyset)$\\
+   \>\>\>$Check(e = $\code{5}, $\mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\}, EQ = \{\{tmp, x\}\},
           Form = No, FB = None)$\\
    \>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
-            EQ = \{\{tmp, x\},\{5\}\},  G = \{5\})$\\
+            EQ = \{\{tmp, x\},\{5\}\},  G = \{5\},$\\
+  \>\>\>\>~$R = \emptyset, W = \emptyset)$\\
    \>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
-             EQ = \{\{tmp, x\},\{5, len\}\},  G = \{5\})$\\
+             EQ = \{\{tmp, x\},\{5, len\}\},  G = \{5\},$\\
+   \>\>\>~$R = \emptyset, W = \{ len \})$\\
+  \>\>$CheckOverlap(\emptyset, \{x\}, \emptyset, \{ len \})$\\
   \>$Validate(DC = \{x \mapsto$\code{bounds(x, x + len)}$\},
                    \mathit{UC} = \{x\mapsto $\code{bounds(tmp, tmp + 5)}$\},
                    EQ = \{\{tmp, x\},\{5, len\}\})$\\

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -891,7 +891,7 @@ behavior according to the C Standard.
 
 When two expressions have no order of evaluation specifed, an assignment in one expression
 may or may not completed the other expression (or its subexpressions) are evaluated.
-This means that the variable beign assigned to has an {\em indeterminate} value when the
+This means that the variable being assigned to has an {\em indeterminate} value when the
 other expression is evaluated. The checking detects to detect:
 \begin{enumerate}
 \item Uses of variables whose values are indeterminate.
@@ -912,8 +912,7 @@ Given an assignment of the form $e1 = e2$,
 the value computations of $e1$ and $e2$ are sequenced before the
 assignment. The checking takes into account both forms of sequencing.
 For side-effects that must be completed before the evaluation of another
-expression $e$, those side-effects do not cause variables to
-be added to the pending set for $e$.
+expression $e$, we do not check that those side-effect conflicts with $e$.
 
 We introduce the following notation:
 \begin{enumerate}
@@ -1237,7 +1236,7 @@ that is valid when $\mathit{UC}$ is valid.  It checks that $\mathit{UC}$ and $EQ
 $CheckFullExpr(e)$ is defined as follows:
 \begin{enumerate}
 \item Let $DC$ be the context formed from declared bounds.
-\item Let $(\_, \mathit{UC}, UEQ, \_) = Check(e, DC, \emptyset, \emptyset, No, None)$.
+\item Let $(\_, \mathit{UC}, UEQ, \_, \_, \_) = Check(e, DC, \emptyset, No, None)$.
 \item Call $Validate(DC, \mathit{UC}, UEQ)$.
 \end{enumerate}
 
@@ -1247,10 +1246,11 @@ This section covers how to check bounds declarations for expressions
 with control flow: comma expressions, conditional expressions, and
 logical boolean expressions.
 
-For a comma expression $e1$~\lstinline|,|~$e2$, $Check(e, C, EQ, PV, Form, FB)$ is defined as follows:
+For a comma expression $e1$~\lstinline|,|~$e2$, $Check(e, C, EQ, Form, FB)$ is defined as follows:
 \begin{enumerate}
-\item Let $(B_{e1}, \mathit{UC}_{e1}, {UEQ}_{e1}, \_)$ = $Check(e1, C, EQ, PV, No, None)$
-\item Let $(B, \mathit{UC}, UEQ, UG) = Check(e2, \mathit{UC}_{e1}, {UEQ}_{e1}, PV, No, None)$
+\item Let $(B_{e1}, \mathit{UC}_{e1}, {UEQ}_{e1}, \_, R_1, W_1)$ = $Check(e1, C, EQ, No, None)$
+\item Let $(B, \mathit{UC}, UEQ, UG, R_2, W_2) = Check(e2, \mathit{UC}_{e1}, {UEQ}_{e1}, No, None)$
+\item Let $R = R_1 \cup R_2$ and $W = W_1 \cup W_2$.
 \end{enumerate}
 
 For a conditional expression $e1$~\lstinline+?+~$e2$~\lstinline+:+~$e3$, we must
@@ -1279,9 +1279,9 @@ one for each arm. This turn require that $Check$ take a set of contexts as
 To keep checking from becoming too expensive, we disallow such expressions.
 
 \begin{enumerate}
-\item Let $(\_, \mathit{UC}_{e1}, {UEQ}_{e1}, \_)= Check(e1, C, EQ, PV, No, None)$
+\item Let $(\_, \mathit{UC}_{e1}, {UEQ}_{e1}, \_, RC, WC)= Check(e1, C, EQ, No, None)$
 \item For each arm $e_i$ of the conditional branch,
-        let $(B_i, \mathit{UC}_i, {UEQ}_i, _) = Check(e_i, \mathit{UC}_{e1}, EQ, PV, No, None)$.
+        let $(B_i, \mathit{UC}_i, {UEQ}_i, G_i, R_i, W_i) = Check(e_i, \mathit{UC}_{e1}, EQ, No, None)$.
 \item Handle uses of temporaries bound in only one branch.  These temporaries
 will be uninitialized when the other branch of the conditional arm is evaluated.
 If some $B_i$, $\mathit{UC}_i$ or ${UEQ}_i$ uses a temporary bound in $e_i$,
@@ -1302,11 +1302,9 @@ and $G_i$.
 \item Otherwise,
 \begin{enumerate}
 \item Let $DC$ be the context formed from declared bounds.
-Let $DC^\prime$ be $DC$ restricted to variables in $Pending(e1) \cup Pending(e2)$:
-for each variable $v \in dom(DC)$, keep the entry if $v \in Pending(e1) \cup Pending(e2)$
-or $DC[v]$ uses the value of a variable in $Pending(e1) \cup Pending(e2)$.
-\item If there is a bounds expression in $DC^\prime$ that uses variables in $PV$,
-report an error.   Not all side-effects may have been seen.
+Let $DC^\prime$ be $DC$ restricted to variables in $W_1 \cup W_2$:
+for each variable $v \in dom(DC)$, keep the entry if $v \in W_1 \cup W_2$
+or $DC[v]$ uses the value of a variable in $W_1 \cup W_2$.
 \item For each arm $e_i$, call $Validate(DC^\prime, \mathit{UC}_i, {UEQ}_i)$.
 \item Let $\mathit{UC} = C$.  Update $\mathit{UC}$ so that any variables modified by the conditional expression
 have the top-level declared bounds (which were just validated after each arm).
@@ -1317,13 +1315,19 @@ For any variable $v$ in $DC^\prime$, let $\mathit{UC}[v] = DC^\prime[v]$.
 to produce the set of sets.  Empty or singleton sets are removed.
 \item Let $G = G_1 \cap G_2$.  If $e$ has no side-effects,add $\{ e \}$ to $G$.  If a
 temporary was introduced for the value of $e$,  also add the temporary to $G$.
+\item Let $R = RC \cup R_1 \ cup R_2$.  Let $W = WC \cup W_1 \cup W_2$.
+\item Make sure that all assignments to variables used in $DC^\prime$ have been seen before
+validating $DC^prime$ (otherwise the validation may be incorrect).
+For each bounds expression $B$ in $DC^\prime$, let $Q$ by the variables read by $B$.
+Let $R = R \cup Q$ (if an unordered assignment to a variable used in $Q$ is 
+subsequently processed, this will cause a checking failure).
 \end{enumerate}
 
 Logical boolean expressions are treated as forms of conditional expressions.
-For  $Check(e1$ \code{&&} $ e2, C, PV, Form, FB)$, use
-$Check(e1$ \code{ ?  } $e2$ \code{: 0}$, C, EQ, PV, Form, None)$.
-For $Check(e1$ \code{ \|\| } $ e2, C, EQ, PV, Form, FB)$,  use
-$Check(e1 $ \code{ ? 1 : } $e2, C, EQ, PV, No, None)$.
+For  $Check(e1$ \code{&&} $ e2, C, Form, FB)$, use
+$Check(e1$ \code{ ?  } $e2$ \code{: 0}$, C, EQ, Form, None)$.
+For $Check(e1$ \code{ \|\| } $ e2, C, EQ, Form, FB)$,  use
+$Check(e1 $ \code{ ? 1 : } $e2, C, EQ, No, None)$.
 
 \subsection{Examples}
 

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -882,11 +882,17 @@ of variables by calculating an updated context.
 The updated context and equivalence information are used to prove that bounds
 declarations remain valid. 
 
-To detect undefined behavior, the checking tracks
-sets of variables with pending assignments.  Pending
-assignments may or may not have been completed yet, which means
-that the variables being assigned to have {\em indeterminate}
-values.  The sets are used to detect:
+To detect undefined behavior, the checking tracks the set of variables that
+may be read (used) or written (assigned to) by an expression.   When checking an expression with
+subexpressions that have an undefined order of evaluation with respect to each
+other, there is a check that the variables read or assigned to by one subexpression
+do not overlap with the variables assigned to by another subexpression.  This is undefined
+behavior according to the C Standard.
+
+When two expressions have no order of evaluation specifed, an assignment in one expression
+may or may not completed the other expression (or its subexpressions) are evaluated.
+This means that the variable beign assigned to has an {\em indeterminate} value when the
+other expression is evaluated. The checking detects to detect:
 \begin{enumerate}
 \item Uses of variables whose values are indeterminate.
 \item Accessing memory with pointers whose bounds expressions
@@ -922,11 +928,8 @@ of variables in $S$.
 
 The checking is done by the following functions:
 \begin{enumerate}
-\item $Pending$: calculates the set of pending variables for
-an expression.  These are the set of variables that are assigned
-to by the expression.  If the evaluation of the expression is indeterminately
-ordered with respect to another expression, these variables are
-pending during the evaluation of the other expression.
+\item $CheckOverlap$: given the read and write sets for two expressions, check if
+the variables read or written by one expression are written by other expression.
 \item $Update$: updates the context, the sets of equivalent expressions,
 and other information to be valid for the program state after
 a side-effect is completed.
@@ -944,39 +947,6 @@ and sets of equivalent expressions imply that the declared bounds for
 variables are valid.
 \item $CheckFullExpr$: checks that declared bounds are valid after
 evaluating a full expression.  
-\end{enumerate}
-
-\subsection{Computing pending variables}
-
-The function $Pending(e)$ uses the helper functions,
-$GetLValueVariable(e)$ and $GetRValueVariable(e)$.  Those functions
-return a singleton set containing a variable name or the empty set.
-
-The definition of $Pending(e)$ is as follows. If $e$ has the form:
-\begin{enumerate}
-\item $e1 = e2$, let $V = GetLValueVariable(e1)$.
-$P = Pending(e1) \cup Pending(e2) \cup V$.
-\item$e1~op= e2$, let $V = GetLValueVariable(e1)$.
-$P = Pending(e1) \cup Pending(e2) \cup V$.
-\item \code{++}$e1$, \code{--}$e1$, $e1$\code{++}, or $e1$\code{--}.
-let $V =  GetLValueVariable(e1)$.  $P = Pending(e1) \cup V$.
-\item Otherwise, $e$ has $n$ subexpressions, let $S_i$ be
-the $i^{th}$ subexpression.  Let $P = \cup_{i=1}^{n} Pending(S_i)$.
-\end{enumerate}
-
-The definition of $GetLValueVariable(e)$ is as follows. If $e$ has the form:
-\begin{enumerate}
-\item A variable $v$, $\{ v \}$.
-\item $(e1)$, $GetLValueVariable(e1)$.
-\item $*e1$, $GetRValueVariable(e1)$.
-\item Otherwise, $\emptyset$.
-\end{enumerate}
-
-The definition of $GetRValueVariable(e)$ is as follows. If $e$ has the form:
-\begin{enumerate}
-\item \code{&}$e1$, $GetLValueVariable(e1)$.
-\item$(e1)$, $GetRValueVariable(e1)$.
-\item Otherwise, $\emptyset$
 \end{enumerate}
 
 \subsection{Checking expressions with unordered evaluation of operands}
@@ -1040,13 +1010,11 @@ produced by the expression being checked.  $Check$ is parameterized so
 that the same logic can  be re-used across assignments, compound assignments,
 and pre/post-increment expressions.
 
-The function $Check(e, C, EQ, PV, Form, FB)$ takes as inputs:
+The function $Check(e, C, EQ, Form, FB)$ takes as inputs:
 \begin{enumerate}
 \item An expression $e$ that evaluates to a value.
 \item A context $C$.
 \item Sets of equivalent expressions $EQ$.
-\item A set $PV$ of indeterminate variables.  The variables 
-may be modified by other expressions whose  evaluation is unordered with respect to $e$'s evaluation.
 \item Whether $e$ is special instruction form.  This can have 3 values: $No$, $PostIncDec$,
 and $Compound$.
 \item An optional bounds $FB$ for the first operand of $e$.  
@@ -1060,16 +1028,15 @@ $Check$ returns:
 \item An updated context $\mathit{UC}$.
 \item Updated sets of equivalent expressions $UEQ$.
 \item A set of equivalent expressions $G$ that will produce the same value as $e$. 
+\item A set $R$ of variables that may be read during evaluation of $e$.
+\item A set $W$ of variables that may be written during evaluation of $e$.
 \item It may also report an error.
 \end{enumerate}
 The results produced by $Check$ are valid in the program state
-{\em after} the assignments in $e$ have been completed.   When $B$ or entries in 
-$\mathit{UC}$ depend on pending variables, it is important not to use them during runtime bounds checking.
-Similarly, during checking, it is important not to use equality information
-from $UEQ$ or $G$ that depends on pending variables.
+{\em after} the assignments in $e$ have been completed.
 
-The function $CheckLValue(e, C, EQ, PV)$ is similar to $Check$.  It takes the
-same first 4 arguments as $Check$, except that $e$ evaluates to an lvalue.
+The function $CheckLValue(e, C, EQ)$ is similar to $Check$.  It takes the
+same first 3 arguments as $Check$, except that $e$ evaluates to an lvalue.
 It returns:
 \begin{enumerate}
 \item A bounds expression $B$ for the lvalues produced by $e$.
@@ -1077,31 +1044,54 @@ It returns:
 \item An updated context $\mathit{UC}$.
 \item Updated sets of equivalent expressions $UEQ$.
 \item A set of equivalent expressions $G$ that produce the same lvalue as $e$.
+\item A set $R$ of variables that may be read during evaluation of $e$.
+\item A set $W$ of variables that may be written during evaluation of $e$.
 \item It may also report an error.
 \end{enumerate}
+
+The function $CheckOverlap(R_1, W_1, R_2, W_2)$ takes the set of variables read and written
+by expressions $e_1$ and $e_2$:
+\begin{enumerate}
+\item  $R_1$ and $W_1$ are the variables read and written by $e_1$, respectively.
+\item  $R_2$ and $W_2$ are the variables read and written by $e_2$, respecitively.
+\end{enumerate}
+It reports an error if $(R_1 \cup W_1) \cap W_2$ is not empty, or 
+$(R_2 \cup W_2) \cap W_1$ is not empty.
 
 The function $NeedsBoundsCheck(e)$ takes
 an expression that evaluates to an lvalue and determines if an 
 assignment to $e$ requires a bounds check.
 
-Before $Check$ calls itself recursively on a subexpression of $e$, it calculates 
-additional variables that are pending due to other subexpressions of $e$.
 The definition of $Check(e, C, EQ, PV, Form, FB)$ is:
 \begin{enumerate}
 \item If $e$ is an lvalue expression
 \begin{enumerate}
-\item Let $(B_{lv}, RB, \mathit{UC}, UEQ, G_{lv}) = CheckLValue(e, C, EQ,PV)$.
-\item If $e$ has array type, let $B = B_{lv}$ and $G = G_{lv}$.
+\item Let $(B_{lv}, RB, \mathit{UC}, UEQ, G_{lv}, R_{lv}, W_{lv}) = CheckLValue(e, C, EQ)$.
+\item If $e$ has array type, let $B = B_{lv}$, $G = G_{lv}$, $R = R_{lv}$, and $W = W_{lv}$.
 \item If $e$ does not have array type, there will an implicit read of the lvalue produced by $e$
-at runtime:
+at runtime.  There are 3 cases.  The first case is that $e$ is a (possibly-parenthesized) variable $v$:
+\begin{enumerate} 
+\item Let $R = R_{lv} \cup \{ v \}$.
+\item Let $W= W_{lv}$ (note that $W_{lv}$ should be empty in this case).
+\end{enumerate}
+The second case is that $e$ is not a variable and $NeedsBoundsCheck(e)$ returns true.  In this case,
+a compiler will insert a bounds check  to ensure $e$ is a valid memory location to access. 
 \begin{enumerate}
-\item If $NeedsBoundsCheck(e)$ returns true, a compiler will insert a bounds check 
-to ensure $e$ is a valid memory location to access.  Check that $B_{lv}$ does not use any variables in 
-$PV$.  If it does, report an error.
-\item If $e$ is a variable $v$ and $v \in PV$, report an error.  There is an unsequenced use and
-assignment of $v$.
+\item Let $BR$ be the variables that may be read by $B_{lv}$.
+\item Check that $B_{lv}$ does not use any variables written by $e$ by calling $CheckOverlap(BR, W_lv)$.
+\item Let $R = R_{lv} \cup BR$.
+\item Let $W = W_{lv}$.
+\end{enumerate}
+The third case is that $e$ is not a variable and that $NeedBoundsCheck(e)$ return false.
+\begin{enumerate}
+\item Let $R = R_{lv}$.
+\item Let $W= W_{lv}$.
+\end{enumerate}
+For all 3 cases:
+\begin{enumerate}
 \item Let $B = RB$. 
-\item If $e$ is an element of a set of equivalent expressions $F$ in $EQ - PV$, let $G = F$. 
+% TODO - come back to the next point.  Should this be $EQ$ or $UEQ$?
+\item If $e$ is an element of a set of equivalent expressions $F$ in $UEQ$, let $G = F$. 
 \item Otherwise, if evaluating $e$ does not read memory via a pointer or have a side-effect, let $G = \{ e \}$.  
 \item Otherwise, let $G = \emptyset$ (we address aliasing of memory accesses in another section).
 \end{enumerate}

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -968,7 +968,7 @@ or the special value {\it None}.
 \end{itemize}
 It returns updated bounds $\mathit{UB}$, context $\mathit{UC}$, and 
 sets of equivalent expression ($\mathit{UEQ}$, and $\mathit{UG}$)
-that are valid in the program state after the assignment
+that are valid in the program state after the assignment.
 
 Its definition is:
 \begin{enumerate}
@@ -1062,37 +1062,30 @@ The function $NeedsBoundsCheck(e)$ takes
 an expression that evaluates to an lvalue and determines if an 
 assignment to $e$ requires a bounds check.
 
-The definition of $Check(e, C, EQ, PV, Form, FB)$ is:
+The definition of $Check(e, C, EQ, Form, FB)$ is:
 \begin{enumerate}
 \item If $e$ is an lvalue expression
 \begin{enumerate}
 \item Let $(B_{lv}, RB, \mathit{UC}, UEQ, G_{lv}, R_{lv}, W_{lv}) = CheckLValue(e, C, EQ)$.
 \item If $e$ has array type, let $B = B_{lv}$, $G = G_{lv}$, $R = R_{lv}$, and $W = W_{lv}$.
 \item If $e$ does not have array type, there will an implicit read of the lvalue produced by $e$
-at runtime.  There are 3 cases.  The first case is that $e$ is a (possibly-parenthesized) variable $v$:
-\begin{enumerate} 
-\item Let $R = R_{lv} \cup \{ v \}$.
-\item Let $W= W_{lv}$ (note that $W_{lv}$ should be empty in this case).
-\end{enumerate}
-The second case is that $e$ is not a variable and $NeedsBoundsCheck(e)$ returns true.  In this case,
-a compiler will insert a bounds check  to ensure $e$ is a valid memory location to access. 
-\begin{enumerate}
-\item Let $BR$ be the variables that may be read by $B_{lv}$.
-\item Check that $B_{lv}$ does not use any variables written by $e$ by calling $CheckOverlap(BR, W_lv)$.
-\item Let $R = R_{lv} \cup BR$.
-\item Let $W = W_{lv}$.
-\end{enumerate}
-The third case is that $e$ is not a variable and that $NeedBoundsCheck(e)$ return false.
+at runtime. 
 \begin{enumerate}
 \item Let $R = R_{lv}$.
-\item Let $W= W_{lv}$.
-\end{enumerate}
-For all 3 cases:
-\begin{enumerate}
+\item Let $W = W_{lv}$.
 \item Let $B = RB$. 
-% TODO - come back to the next point.  Should this be $EQ$ or $UEQ$?
-\item If $e$ is an element of a set of equivalent expressions $F$ in $UEQ$, let $G = F$. 
-\item Otherwise, if evaluating $e$ does not read memory via a pointer or have a side-effect, let $G = \{ e \}$.  
+\item If $e$ is a (possibly-parenthesized) variable $v$, let $R = R \cup \{ v \}$.
+\item Otherwise, if $NeedsBoundsCheck(e)$ returns true,
+a compiler will insert a bounds check  to ensure $e$ is a valid memory location to access. 
+\begin{enumerate}
+\item Let $Q$ be the variables that may be read by $B_{lv}$.
+\item Check that $B_{lv}$ does not use any variables written by $e$ by calling $CheckOverlap(Q, W_lv)$.
+\item Let $R = R \cup Q$.
+\end{enumerate}
+\item If $e$ is an element of a set of equivalent expressions $F$ in $UEQ$ , let $G = F$ (note that
+in this case, $e$ must be a non-modifying expression.  This implies that the sets of equivalent
+expressions do not change during $CheckLValue(e, C, EQ)$ and $EQ = UEQ$).
+\item Otherwise, if $e$ is non-modifying expression and $e$ does not read memory via a pointer, let $G = \{ e \}$.  
 \item Otherwise, let $G = \emptyset$ (we address aliasing of memory accesses in another section).
 \end{enumerate}
 \end{enumerate}
@@ -1102,22 +1095,23 @@ For all 3 cases:
 \item If $e$ has the form $lhs = rhs$,
 \label{list:check-assignment}
 \begin{enumerate}
-\item Let $P_{lhs} = PV \cup Pending(rhs)$ and $P_{rhs} = PV \cup Pending(lhs).$   $P_{lhs}$
-        and $P_{rhs}$ describe variables that are pending during the evaluations of $lhs$ and $rhs$.
-\item Let $(B_{lhs}, RB, \mathit{UC}_{lhs}, {UEQ}_{lhs}, \_) = CheckLValue(lhs, C, EQ, P_{lhs})$.  
-\item Let $(B_{rhs},  \mathit{UC}_{rhs}, {UEQ}_{rhs}, G_{rhs}) = 
-Check(rhs, \mathit{UC}_{lhs}, {UEQ}_{lhs},P_{rhs}, Form, RB)$.
-\item If $NeedsBoundsCheck(lhs)$ returns true, check that $B_{lhs}$ does not use any variables in 
-$PV \cup Pending(lhs) \cup Pending(rhs)$.  If it does, report an error.
+\item Let $(B_{lhs}, RB, \mathit{UC}_{lhs}, {UEQ}_{lhs}, \_, R_{lhs}, W_{lhs}) = CheckLValue(lhs, C, EQ)$.  
+\item Let $(B_{rhs},  \mathit{UC}_{rhs}, {UEQ}_{rhs}, G_{rhs}, R_{rhs}, W_{rhs}) = 
+Check(rhs, \mathit{UC}_{lhs}, {UEQ}_{lhs}, Form, RB)$.
+\item $lhs$ and $rhs$ do not have a specified order of evaluation with respect to each other,
+so call $CheckOverlap(R_{lhs}, W_{lhs}, R_{rhs}, W_{rhs})$.
+\item Let $R = R_{lhs} \cup R_{rhs}$ and $W = W_{lhs} \cup W_{rhs}$.
+\item If $NeedsBoundsCheck(lhs)$ returns true, let $Q$ be the variable that may be read by $B_lhs$.
+Check that the bound check does not use any variables written by either $lhs$ or $rhs$ by
+calling $CheckOverlap(Q, W)$.   Let $R = R \cup Q$.
 \item  If $lhs$ is a variable $v$ (that is, $GetLValueVariable(lhs) = { v }$),
 \begin{enumerate}
-\item Check that $v \notin PV \cup Pending(lhs) \cup Pending(rhs)$.  If it is, report an error.  
-There are multiple unsequenced assignments to $v$.
-\item Choose an expression that computes the old value of $v$:
+\item Determine whether there is an expression that computes the old value of $v$:
 \begin{enumerate}
 \item If $rhs$ can be inverted with respect to $v$, let $iv = inverse(v, rhs)$. 
-\item Otherwise, if $EQ - (PV \cup Pending(lhs) \cup Pending(rhs))$ contains a set of equivalent expressions $F$ that contains $v$ as 
-an element, and $F$ contains a variable $w \neq v$, set $iv$ to $w$.
+\item Otherwise, if $UEQ$ contains a set of equivalent expressions $F$ that contains $v$ as 
+an element, and $F$ contains a variable $w \neq v$, set $iv$ to $w$ (Note that $w$ is a representative
+from $F$.  If during later processing  an assignment to $w$ is seen, another variable from $F$ will be chosen).
 \item Otherwise, let $iv = $ {\it None}.
 \end{enumerate}
 \item Let $(B, \mathit{UC}, UEQ, G) = Update(v, iv, B_{rhs}, \mathit{UC}_{rhs}, UEQ_{rhs}, G_{rhs})$.
@@ -1128,36 +1122,43 @@ an element, and $F$ contains a variable $w \neq v$, set $iv$ to $w$.
 % lhs op= rhs
 
 \item If $e$ has the form $lhs~op= rhs$, the result is 
-$Check (lhs = lhs~op~rhs, C, EQ, PV, Compound, None)$.
+$Check (lhs = lhs~op~rhs, C, EQ, Compound, None)$.
 
 \item For pre- and post-increment/decrement forms, if $e$ has the form:
 \begin{enumerate}
-\item \code{++}$e1$, the result is  $Check(e1$ \code{ = } $e1$ \code{ + 1}$,C, EQ, PV, 
+\item \code{++}$e1$, the result is  $Check(e1$ \code{ = } $e1$ \code{ + 1}$,C, EQ, 
 Compound, None)$.
-\item \code{--}$e1$, the result is $Check(e1$ \code{ = } $e1$ \code { - 1}$, C, EQ, PV,
+\item \code{--}$e1$, the result is $Check(e1$ \code{ = } $e1$ \code { - 1}$, C, EQ,
 Compound, None)$.
 \item $e1$\code{++}, the result is  $Check(e1$ \code{ = } $ e1$ \code { + 1}$,
-C, EQ, PV, PostIncDec, None)$.
-\item $e1$\code{--}, the result is $Check(e1$ \code{ = } $ e1$ \code{ - 1}$, C, EQ, PV, PostIncDec, None)$.
+C, EQ, PostIncDec, None)$.
+\item $e1$\code{--}, the result is $Check(e1$ \code{ = } $ e1$ \code{ - 1}$, C, EQ, PostIncDec, None)$.
 \end{enumerate}
-\item If $e$ has the form \code{&}$e1$, let $(B, \_, \mathit{UC}, UEQ, G) = CheckLValue(e1, C, EQ, PV)$.
+\item If $e$ has the form \code{&}$e1$, let $(B, \_, \mathit{UC}, UEQ, G) = CheckLValue(e1, C, EQ)$.
       
 \item Otherwise, $e$ is some expression with $n$ subexpressions (n may be 0).  The
 result is 
 \label{list:check-unordered-operands}
 \begin{enumerate}
 \item Let $\mathit{UC} = C$ and $UEQ = EQ$.  Let $S_k$ designate the $k^{th}$ subexpression.
-\item Visit the $n$ subexpressions in some order, accumulating results into $\mathit{UC}$ and $UEQ$.  If the current subexpression being visited is $S_i$,
+\item Visit the $n$ subexpressions in an order where the subexpression whose bounds is used to compute the bounds
+of this expression is visited last, accumulating results into $\mathit{UC}$ and $UEQ$.  If the current subexpression being visited is $S_i$,
 \begin{enumerate}
 \item If $i = 1$ and $Form = PostIncDec$ or $Form = Compound$, $S_1$ has already
-been checked, so use the results from that.  Let $B_1 = FB$.  If $S_1$ appears in some set $F$ in $UEQ$,
- let $G_1 = F$. Otherwise, let $G_1 = \emptyset$.
-\item Otherwise, let $PV_i = PV \cup \bigcup_{j= 1, j <> i}^{n} Pending(S_j)$.
-Let $(B_i, \mathit{UC}, UEQ, G_i) =$  $Check(S_i, \mathit{UC}, UEQ, PV_i, No, None)$.
+been checked, so use the results from that.  Let $B_1 = FB, R_1 = \emptyset, W_1 = \emptyset$.  
+If $S_1$ appears in some set $F$ in $UEQ$,  let $G_1 = F$. Otherwise, let $G_1 = \emptyset$.
+\item Otherwise, let $(B_i, \mathit{UC}, UEQ, G_i, R_i, W_i) =$  $Check(S_i, \mathit{UC}, UEQ, No, None)$.
+\item For any subexpression $k$ whose bounds $B_k$ has already been computed,
+\begin{enumerate}
+\item Let $Q$ be the variables read by $B_k$.  If $Q \cup W_i$, let $B_i = $ \boundsunknown.  
+\item  Also let $G_k = G_k - W_i$.
 \end{enumerate}
+\end{enumerate}
+\item Check that no subexpression writes variables that are read or written by another subexpression. 
+For each pair of subexpressions $(i, k)$, $CheckOverlap(R_i, W_i, R_k, W_k)$.
 \item Determine the set of equivalent expressions for $e$.  Recall that the equivalent expressions must be non-modifying expressions.
 \begin{enumerate}
-\item  If $Form = PostIncDec$, let $Val = S_1$.  Otherwise, let $Val = e$.
+\item If $Form = PostIncDec$, let $Val = S_1$.  Otherwise, let $Val = e$.
 \item If $Val$ is a non-modifying expression, let $G  = \{ Val \}$.
 \item If $Val$ is a call expression, let $G = \emptyset$.
 \item Otherwise, try to construct a version $Val^\prime$ of $Val$ that computes the same value 
@@ -1166,9 +1167,6 @@ Let $(B_i, \mathit{UC}, UEQ, G_i) =$  $Check(S_i, \mathit{UC}, UEQ, PV_i, No, No
       For any subexpression $S_i$ that is a modifying expression, 
       use an expression from $G_i$ (or $G_1$ when $Form = PostIncDec$). If $G_i$ is empty, $Val^\prime$ cannot
       be constructed.
-      
-      Note that an invariant about each $G_i$ is that it will not contain any uses of variables in $PV_i$.
-      This means that side-effects in other subexpressions do not affect the value of expressions in $G_i$.
 \item If $Val^\prime$ can be constructed, let $G = \{ Val^\prime \}$.  Otherwise, let $G = \emptyset$.	
 \end{enumerate}
 \item Use the rules in Section~\ref{section:inferring-expression-bounds} to compute B using the $B_i$. 
@@ -1176,7 +1174,7 @@ Let $(B_i, \mathit{UC}, UEQ, G_i) =$  $Check(S_i, \mathit{UC}, UEQ, PV_i, No, No
 \end{enumerate}
 \end{enumerate}
 
-The definition of $CheckLValue(e, C, EQ, PV)$ is:
+The definition of $CheckLValue(e, C, EQ)$ is:
 \begin{enumerate}
 \item If $e$ is a variable $v$, let $\mathit{UC} = C$, $UEQ=EQ$,
 \begin{enumerate}
@@ -1198,18 +1196,21 @@ Let $B = bounds(v, v + n)$ and $G =\{ v \}$.
 \item Let $RB = $ \boundsunknown (Checked C does not allow bounds for values stored in arrays).
 \end{enumerate}
 \end{enumerate}
-\item If $e$ has the form $*e1$,  let $(B, \mathit{UC}, EQ, \_) = Check(e1, C, EQ, PV, No)$.  Let $G =\emptyset$ and $RB = $ \boundsunknown (Checked C does not allow bounds for values pointed to by pointers).
+\item If $e$ has the form $*e1$,  let $(B, \mathit{UC}, EQ, \_) = Check(e1, C, EQ, No)$.  Let $G =\emptyset$ and $RB = $ \boundsunknown (Checked C does not allow bounds for values pointed to by pointers).
 \item If $e$ has the form $e1[e2]$,
 \label{list:check-unordered-subscript-operands}
 \begin{enumerate}
-\item Let $(B_{e1}, \mathit{UC}_{e1}, {UEQ}_{e1}, \_) = Check(e1, C, EQ, PV \cup Pending(e2), No, 
+\item Let $(B_{e1}, \mathit{UC}_{e1}, {UEQ}_{e1}, \_, R_{e1}, W_{e1}) = Check(e1, C, EQ,  No,
          None)$.
-\item Let $(B_{e2}, \mathit{UC}_{e2}, {UEQ}_{e2}, \_) = Check(e2, \mathit{UC}_{e1}, {EQ}_{e1},
-         PV \cup Pending(e1), No, None)$
+\item Let $(B_{e2}, \mathit{UC}_{e2}, {UEQ}_{e2}, \_, R_{e2}, W_{e2}) = Check(e2, \mathit{UC}_{e1}, {EQ}_{e1},
+         No, None)$
+\item The order of evaluation of $e1$ and $e2$ is unspecified, so 
+         call $CheckOverlap(R_{e1}, W_{e1}, R_{e2}, W_{e2})$.
 \item Choose the $e_i$ that has pointer type.   Let $B = B_{e_i}$, $\mathit{UC} = \mathit{UC}_{e2}$, 
-$UEQ  = {UEQ}_2$,  $G=\emptyset$, and $RB = $ \boundsunknown.
+$UEQ  = {UEQ}_2$,  $G=\emptyset$, $RB = $ \boundsunknown, $R = R_{e1} \cup R_{e2}$, and
+$W = W_{e1} \cup W_{e2}$.
 \end{enumerate}
-\item If $e$ has the form $(e1)$, the result is $CheckLValue(e1, C, EQ, PV)$
+\item If $e$ has the form $(e1)$, the result is $CheckLValue(e1, C, EQ)$
 \end{enumerate}
 
 The definition of $NeedsBoundsCheck(e)$ is:

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1076,7 +1076,7 @@ at runtime.
 a compiler will insert a bounds check  to ensure $e$ is a valid memory location to access. 
 \begin{enumerate}
 \item Let $Q$ be the variables that may be read by $B_{lv}$.
-\item Check that $B_{lv}$ does not use any variables written by $e$ by calling $CheckOverlap(Q, W_lv)$.
+\item Check that $B_{lv}$ does not use any variables written by $e$ by calling $CheckOverlap(Q, W_{lv})$.
 \item Let $R = R \cup Q$.
 \end{enumerate}
 \item If $e$ is an element of a set of equivalent expressions $F$ in $UEQ$ , let $G = F$ (note that
@@ -1098,8 +1098,8 @@ Check(rhs, \mathit{UC}_{lhs}, {UEQ}_{lhs}, Form, RB)$.
 \item $lhs$ and $rhs$ do not have a specified order of evaluation with respect to each other,
 so call $CheckOverlap(R_{lhs}, W_{lhs}, R_{rhs}, W_{rhs})$.
 \item Let $R = R_{lhs} \cup R_{rhs}$ and $W = W_{lhs} \cup W_{rhs}$.
-\item If $NeedsBoundsCheck(lhs)$ returns true, let $Q$ be the variable that may be read by $B_lhs$.
-Check that the bound check does not use any variables written by either $lhs$ or $rhs$ by
+\item If $NeedsBoundsCheck(lhs)$ returns true, let $Q$ be the variable that may be read by $B_{lhs}$.
+Check that the bounds check does not use any variables written by either $lhs$ or $rhs$ by
 calling $CheckOverlap(Q, W)$.   Let $R = R \cup Q$.
 \item  If $lhs$ is a variable $v$ (that is, $GetLValueVariable(lhs) = { v }$),
 \begin{enumerate}
@@ -1115,6 +1115,7 @@ from $F$.  If during later processing  an assignment to $w$ is seen, another var
 \item Let $(B, \mathit{UC}, UEQ, G) = Update(v, iv, B_{rhs}, \mathit{UC}_{rhs}, UEQ_{rhs}, G_{rhs})$.
 \end{enumerate}
 \item If $lhs$ is not a variable, let $(B, \mathit{UC}, UEQ, G) = (B_{rhs}, \mathit{UC}_{rhs}, UEQ_{rhs}, G_{rhs})$
+(we address aliasing of memory accesses in another section).
 \end{enumerate}
 
 % lhs op= rhs
@@ -1132,15 +1133,20 @@ Compound, None)$.
 C, EQ, PostIncDec, None)$.
 \item $e1$\code{--}, the result is $Check(e1$ \code{ = } $ e1$ \code{ - 1}$, C, EQ, PostIncDec, None)$.
 \end{enumerate}
-\item If $e$ has the form \code{&}$e1$, let $(B, \_, \mathit{UC}, UEQ, G) = CheckLValue(e1, C, EQ)$.
+\item If $e$ has the form \code{&}$e1$, let $(B, \_, \mathit{UC}, UEQ, G, R, W) = CheckLValue(e1, C, EQ)$.
       
 \item Otherwise, $e$ is some expression with $n$ subexpressions (n may be 0).  The
 result is 
 \label{list:check-unordered-operands}
 \begin{enumerate}
 \item Let $\mathit{UC} = C$ and $UEQ = EQ$.  Let $S_k$ designate the $k^{th}$ subexpression.
-\item Visit the $n$ subexpressions in an order where the subexpression whose bounds is used to compute the bounds
-of this expression is visited last, accumulating results into $\mathit{UC}$ and $UEQ$.  If the current subexpression being visited is $S_i$,
+\item Visit the $n$ subexpressions  accumulating results into $\mathit{UC}$ and $UEQ$.  Choose an
+order where the subexpression whose bounds are used to compute the bounds
+of this expression is visited last.\footnote{We require this order so that bounds of the subexpression do
+not have to be passed to calls to $Check$.  The bounds of the subexpression already reflect the effect of
+assignments to variables in other subexpressions.  With other orders, if the bounds used variables assigned
+to by other subexpressions, the bounds would need to be updated by $Check$.}
+If the current subexpression being visited is $S_i$,
 \begin{enumerate}
 \item If $i = 1$ and $Form = PostIncDec$ or $Form = Compound$, $S_1$ has already
 been checked, so use the results from that.  Let $B_1 = FB, R_1 = \emptyset, W_1 = \emptyset$.  
@@ -1148,7 +1154,8 @@ If $S_1$ appears in some set $F$ in $UEQ$,  let $G_1 = F$. Otherwise, let $G_1 =
 \item Otherwise, let $(B_i, \mathit{UC}, UEQ, G_i, R_i, W_i) =$  $Check(S_i, \mathit{UC}, UEQ, No, None)$.
 \item For any subexpression $k$ whose bounds $B_k$ has already been computed,
 \begin{enumerate}
-\item Let $Q$ be the variables read by $B_k$.  If $Q \cup W_i$, let $B_i = $ \boundsunknown.  
+\item Let $Q$ be the variables read by $B_k$.  If $Q \cap W_i$ is non-empty, let $B_i = $ \boundsunknown
+(the $B_i$ does not reflect any changes to variables in $W_i$, so it is set conservatively to \boundsunknown).  
 \item  Also let $G_k = G_k - W_i$.
 \end{enumerate}
 \end{enumerate}
@@ -1174,7 +1181,7 @@ For each pair of subexpressions $(i, k)$, $CheckOverlap(R_i, W_i, R_k, W_k)$.
 
 The definition of $CheckLValue(e, C, EQ)$ is:
 \begin{enumerate}
-\item If $e$ is a variable $v$, let $\mathit{UC} = C$, $UEQ=EQ$,
+\item If $e$ is a variable $v$, let $\mathit{UC} = C$, $UEQ=EQ$, $R = \emptyset$, $W = \emptyset$,
 \begin{enumerate}
 \item If $v$ does not have array type,
 \begin{enumerate}
@@ -1314,7 +1321,7 @@ For any variable $v$ in $DC^\prime$, let $\mathit{UC}[v] = DC^\prime[v]$.
 to produce the set of sets.  Empty or singleton sets are removed.
 \item Let $G = G_1 \cap G_2$.  If $e$ has no side-effects,add $\{ e \}$ to $G$.  If a
 temporary was introduced for the value of $e$,  also add the temporary to $G$.
-\item Let $R = RC \cup R_1 \ cup R_2$.  Let $W = WC \cup W_1 \cup W_2$.
+\item Let $R = RC \cup R_1 \cup R_2$.  Let $W = WC \cup W_1 \cup W_2$.
 \item Make sure that all assignments to variables used in $DC^\prime$ have been seen before
 validating $DC^prime$ (otherwise the validation may be incorrect).
 For each bounds expression $B$ in $DC^\prime$, let $Q$ by the variables read by $B$.
@@ -1431,17 +1438,17 @@ $CheckFullExpr(e=$~\code{x = (len = getlen()) ? alloc(len) : 0}$)$\\
 \>\>\>\>\>\>$Check($\code{getlen()}$,C  =\{x\mapsto$\code{bounds(x, x + len)}$\}, EQ = \emptyset,
                          Form = No, FB = None)$\\
 \>\>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(x, x + len)}$ , UEQ = \emptyset,
-               G = \emptyset, R = \emptyset, G = \emptyset)$\\
+               G = \emptyset, R = \emptyset, W = \emptyset)$\\
 \>\>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$ , UEQ = \emptyset,
-               G = \emptyset)$\\
+               G = \emptyset, R = \emptyset, W = \emptyset)$\\
 \>\>\>\>$(B = $ \code{bounds(unknown)}$, \mathit{UC} = \{x\mapsto$\code{bounds(unknown)}$ , UEQ = \emptyset,
-          G = \emptyset)$\\  \\
+          G = \emptyset, R = \emptyset, W = \emptyset)$\\  \\
 % first arm
 \>\>\>{\tt Process the first arm:}\\
 \>\>\>$Check(e=$~\code{alloc(len)}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
          EQ=\emptyset, Form = No, FB = None)$\\
 \>\>\>\>$(B_1 = $ \code{bounds(tmp1, tmp1 + len)}$, \mathit{UC}_1 = \{x\mapsto$\code{bounds(unknown)}$,
-                {UEQ}_1 = \emptyset, G_1 = \{tmp1\})$\\
+                {UEQ}_1 = \emptyset, G_1 = \{tmp1\}, R_1 = \emptyset, W_1 = \emptyset)$\\
 
 % process the second arm
 \\
@@ -1449,9 +1456,9 @@ $CheckFullExpr(e=$~\code{x = (len = getlen()) ? alloc(len) : 0}$)$\\
 \>\>\>$Check(e=$~\code{0}$, C=\{x \mapsto$\code{bounds(unknown)}$\},
          EQ=\emptyset, Form = No, FB = None)$\\
 \>\>\>\>$(B_2 = $ \code{bounds(any)}$, \mathit{UC}_2 = \{x\mapsto$\code{bounds(unknown)}$,
-               {UEQ}_2 = \emptyset, G_2 = \{ 0 \}$\\ \\
+               {UEQ}_2 = \emptyset, G_2 = \{ 0 \}, R_2 = \emptyset, G_2 = \emptyset)$\\ \\
 
-\>\>\>{\tt Adjust the results for temporaries. Introduce a new temporary tmp2 for the result of}\\
+\>\>\>{\tt Adjust results for arms for temporaries. Introduce a new temporary tmp2 for the result of}\\
 \>\>\>{\tt the entire conditional expression.}\\
 \>\>\>\>$(B_1 = $\code{bounds(tmp2, tmp2 + len)}$, \mathit{UC}_1 = \{x\mapsto$\code{bounds(unknown)}$,
                 {UEQ}_1 = \emptyset)$\\


### PR DESCRIPTION
This changes simplifies the description of bounds declaration checking to use read/write sets of pending variable sets.  

Currently we are using a notion of pending variables in the description of checking of bounds declarations. They are computed by another function that is called during checking. This doesn't extend well to lvalue expressions because lvalue expressions depend on variables, which may be modified within an expression.

This change replaces pending variables with read/write summaries.  This allows a bottom computation of a summary of the effects of an expression.  We can then determine if the read/write summary for expression with an unspecified order of evaluation with respect to each other conflict. The read/write summaries for lvalue expressions can use variables defined in known frames of reference (states after an expression is evaluated).

There are some examples that still need to be updated.    I plan to add text to this change that notes where examples still need to be updated.
