### PR TITLE
Add tests for bounds-safe interface assignments

### DIFF
--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1882,3 +1882,23 @@ extern void check_vla(int i) {
   int z checked[10][i]; // expected-error {{checked variable-length array not allowed}}
   int a nt_checked[i];  // expected-error {{checked variable-length array not allowed}}
 }
+
+// Test assigning an unchecked pointer with an nt_array_ptr
+// bounds-safe interface to a checked nt_array_ptr.
+extern void check_nt_bounds_safe_interface(const char *interop_string : itype(nt_array_ptr<const char>),
+                                           char **interop_ptr : itype(nt_array_ptr<ptr<char>>),
+                                           char checked_arr nt_checked[3],
+                                           char interop_arr[3] : itype(char nt_checked[3])) {
+  // LHS of assignment has nt_array_ptr<T> type and RHS of assignment
+  // is an unchecked pointer with nt_array_ptr<T> bounds-safe interface.
+  nt_array_ptr<const char> checked_str = interop_string;
+  nt_array_ptr<ptr<char>> checked_ptr = interop_ptr;
+
+  // LHS of assignment has nt_array_ptr<T> type and RHS of assigment
+  // is an unchecked pointer with nt_array_ptr<U> bounds-safe interface,
+  // where T and U are not assignment-compatible.
+  checked_str = interop_ptr; // expected-error {{assigning to '_Nt_array_ptr<const char>' from incompatible type 'char **'}}
+
+  // LHS of assignment does not have nt_array_ptr<T> type.
+  checked_arr = interop_arr; // expected-error {{assigning to '_Nt_array_ptr<char>' from incompatible type 'char *'}}
+}

--- a/tests/typechecking/checked_arrays.c
+++ b/tests/typechecking/checked_arrays.c
@@ -1888,7 +1888,7 @@ extern void check_vla(int i) {
 extern void check_nt_bounds_safe_interface(const char *interop_string : itype(nt_array_ptr<const char>),
                                            char **interop_ptr : itype(nt_array_ptr<ptr<char>>),
                                            char checked_arr nt_checked[3],
-                                           char interop_arr[3] : itype(char nt_checked[3])) {
+                                           char unchecked_arr[3]) {
   // LHS of assignment has nt_array_ptr<T> type and RHS of assignment
   // is an unchecked pointer with nt_array_ptr<T> bounds-safe interface.
   nt_array_ptr<const char> checked_str = interop_string;
@@ -1899,6 +1899,6 @@ extern void check_nt_bounds_safe_interface(const char *interop_string : itype(nt
   // where T and U are not assignment-compatible.
   checked_str = interop_ptr; // expected-error {{assigning to '_Nt_array_ptr<const char>' from incompatible type 'char **'}}
 
-  // LHS of assignment does not have nt_array_ptr<T> type.
-  checked_arr = interop_arr; // expected-error {{assigning to '_Nt_array_ptr<char>' from incompatible type 'char *'}}
+  // RHS of assignment has no bounds-safe interface type.
+  checked_arr = unchecked_arr; // expected-error {{assigning to '_Nt_array_ptr<char>' from incompatible type 'char *'}}
 }

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -607,3 +607,23 @@ void g82(callback_fn3 fn) {
   int arr checked[10][10];
   (*fn)(arr);
 }
+
+//
+// Test assignments involving non-variable lvalues
+// and bounds-safe interfaces
+//
+
+// Assign a checked pointer to the dereference of an
+// unchecked pointer with a bounds-safe interface.
+void g90(int **interop_ptr : itype(ptr<ptr<int>>), ptr<int> checked_ptr) {
+  *interop_ptr = checked_ptr;
+  *(interop_ptr - 1) = checked_ptr;
+  *(2 + interop_ptr) = checked_ptr;
+}
+
+// Assign a checked pointer to an element of an 
+// unchecked array with a bounds-safe interface.
+void g91(int *arr[3] : itype(ptr<int> checked [3]), ptr<int> checked_ptr) {
+  arr[0] = checked_ptr;
+  2[arr] = checked_ptr;
+}

--- a/tests/typechecking/interop.c
+++ b/tests/typechecking/interop.c
@@ -615,7 +615,7 @@ void g82(callback_fn3 fn) {
 
 // Assign a checked pointer to the dereference of an
 // unchecked pointer with a bounds-safe interface.
-void g90(int **interop_ptr : itype(ptr<ptr<int>>), ptr<int> checked_ptr) {
+void g90(int **interop_ptr : itype(array_ptr<ptr<int>>) count(3), ptr<int> checked_ptr) {
   *interop_ptr = checked_ptr;
   *(interop_ptr - 1) = checked_ptr;
   *(2 + interop_ptr) = checked_ptr;


### PR DESCRIPTION
This PR adds Checked C tests for clang PR [#813](https://github.com/microsoft/checkedc-clang/pull/813), which fills in two missing cases for bounds-safe interface assignment compatibility.