### PR TITLE
Update spec to include missing cases for bounds-safe interface assignments

### DIFF
--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -954,6 +954,18 @@ They are done at:
      implicitly to the unchecked pointer type.
 \item
     Member assignments: a similar conversion is done for member assignments.
+\item Assignments to pointer dereferences: if the pointer dereference expression
+  being assigned to has an unchecked pointer type and a bounds-safe interface, the
+  right-hand side expression has a checked pointer type, and the right-hand side
+  expression referent type is assignment compatible with the referent type of the
+  pointer dereference expression, then the right-hand side expression will be
+  converted implicitly to the unchecked pointer type.
+\item Assignments to array subscripts: if the array subscript expression being
+  assigned to has an unchecked pointer type and a bounds-safe interface, the
+  right-hand side expression has a checked pointer type, and the right-hand
+  side expression referent type is assignment compatible with the referent
+  type of the array subscript expression, then the right-hand side expression
+  wil be converted implicitly to the unchecked pointer type.
 \item Return statements: if a function has an unchecked pointer return type and a
   return bounds-safe interface, and a return statement in the body of the function
   has an expression with a checked pointer type, and the return statement expression is

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -966,6 +966,12 @@ They are done at:
   side expression referent type is assignment compatible with the referent
   type of the array subscript expression, then the right-hand side expression
   wil be converted implicitly to the unchecked pointer type.
+\item Assignments to null-terminated arrays: if the left-hand side expression
+  being assigned to has a checked null-terminated array type, the right-hand side
+  expression has an unchecked null-terminated array type and a bounds-safe interface,
+  and the referent type of the right-hand side expression is assignment compatible
+  with the referent type of the left-hand side, then the right-hand side expression
+  will be converted implicitly to the checked null-terminated array type.
 \item Return statements: if a function has an unchecked pointer return type and a
   return bounds-safe interface, and a return statement in the body of the function
   has an expression with a checked pointer type, and the return statement expression is


### PR DESCRIPTION
See issue #397 

This PR adds some missing cases for bounds-safe interface assignment compatibility to section 6.3.6 (Interoperation - Type checking).