### PR TITLE
Bounds context: update after assignments (tests)

### DIFF
--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -97,7 +97,7 @@ extern void f10() {
 extern void f11() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4)  rel_align(int));
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4)  rel_align(int)); // expected-error {{expression has unknown bounds}}
   q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 

--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -97,7 +97,16 @@ extern void f10() {
 extern void f11() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
+
+  // The declared bounds of h4() use the value of r, but r is overwritten
+  // in the assignment. The value of r (used in the declared bounds (r, r + 4))
+  // is lost, so the inferred bounds for the cast expression are unknown.
   r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4)  rel_align(int)); // expected-error {{expression has unknown bounds}}
+  
+  // The declared bounds of h4() do not use the value of r, so the bounds of the
+  // cast expression are not invalidated.
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), count(4));
+
   q = _Assume_bounds_cast<ptr<int>>(h4());
 }
 

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -33,7 +33,7 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   // address-of
   int tmp1 = 0;
   arg4 = &tmp1;
-  arg4 = &*arg4;
+  arg4 = &*arg4;          // expected-error {{expression has unknown bounds}}
   arg4 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg4 = &s.f;
   ptr<struct S1> ps = &s;
@@ -230,11 +230,11 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   arg1 = &*arr;           // TODO: investigate why this isn't a typechecking error.
   arg1 = &arr[1];         // expected-error {{incompatible type}}
   arg2 = &*arg1;          // expected-error {{expression has unknown bounds}}
-  arg2 = &*arg2;
+  arg2 = &*arg2;          // expected-error {{expression has unknown bounds}}
   arg2 = &*arg3;
   arg3 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg3 = &*arg2;          // expected-error {{declared bounds for arg3 are invalid after assignment}}
-  arg3 = &*arg3;
+  arg3 = &*arg3;          // expected-error {{expression has unknown bounds}}
 
   // variables
 

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -151,10 +151,8 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
 
   // nested assignments
   array_ptr<int> t5 : count(1) = 0;
-  // TODO: handle equalities created by nested assignments during checking of
-  // bounds declarations.
-  t5 = (arg4 = t4);   // expected-warning {{cannot prove declared bounds for t5 are valid after assignment}}
-  t5 = (t4 = arg4);   // expected-warning {{cannot prove declared bounds for t5 are valid after assignment}}
+  t5 = (arg4 = t4);
+  t5 = (t4 = arg4);
   t5 = (t4 = t3);     // expected-error 2 {{expression has unknown bounds}}
 
   // assignment through pointer
@@ -323,12 +321,10 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   // expressions
 
   // nested assignments
-   // TODO: handle equalities created by nested assignments during checking of
-  // bounds declarations.
   nt_array_ptr<int> t4 : count(1) = 0;
-  t4 = (arg3 = t3);   // expected-warning {{cannot prove declared bounds for t4 are valid after assignment}}
-  t4 = (t3 = arg3);   // expected-warning {{cannot prove declared bounds for t4 are valid after assignment}}
-  t4 = (t2 = arg3);   // expected-warning {{cannot prove declared bounds for t4 are valid after assignment}}
+  t4 = (arg3 = t3);
+  t4 = (t3 = arg3);
+  t4 = (t2 = arg3);
   t4 = (t2 = t1);     // expected-error 2 {{expression has unknown bounds}}
 
   // assignment through pointer

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -33,7 +33,7 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
   // address-of
   int tmp1 = 0;
   arg4 = &tmp1;
-  arg4 = &*arg4;          // expected-error {{expression has unknown bounds}}
+  arg4 = &*arg4;
   arg4 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg4 = &s.f;
   ptr<struct S1> ps = &s;
@@ -230,11 +230,11 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   arg1 = &*arr;           // TODO: investigate why this isn't a typechecking error.
   arg1 = &arr[1];         // expected-error {{incompatible type}}
   arg2 = &*arg1;          // expected-error {{expression has unknown bounds}}
-  arg2 = &*arg2;          // expected-error {{expression has unknown bounds}}
+  arg2 = &*arg2;
   arg2 = &*arg3;
   arg3 = &*arg1;          // expected-error {{expression has unknown bounds}}
   arg3 = &*arg2;          // expected-error {{declared bounds for arg3 are invalid after assignment}}
-  arg3 = &*arg3;          // expected-error {{expression has unknown bounds}}
+  arg3 = &*arg3;
 
   // variables
 

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -152,7 +152,7 @@ extern void f18(int i) {
   r = _Dynamic_bounds_cast<array_ptr<int>>(q, bounds(q, q + 1)); // expected-error {{arithmetic on _Ptr type}}
 
   r = _Dynamic_bounds_cast<array_ptr<int>>(r, count(1));        // expected-error {{declared bounds for r are invalid after assignment}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(r, r + 1)); // expected-error {{declared bounds for r are invalid after assignment}}
+  r = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(r, r + 1)); // expected-error {{expression has unknown bounds}} TODO: revert to 'declared bounds for r are invalid after assignment' after checkedc-clang PR #834 is merged
 
   p = _Dynamic_bounds_cast<char *>(p); // expected-warning{{incompatible pointer types assigning}} expected-error{{expression has unknown bounds}}
 
@@ -228,7 +228,7 @@ extern void f23() {
 
 extern void f24() {
   array_ptr<char> buf : count(3) = "abc";
-  buf = _Dynamic_bounds_cast<array_ptr<char>>(h7(), bounds(buf, buf + 3));
+  buf = _Dynamic_bounds_cast<array_ptr<char>>(h7(), bounds(buf, buf + 3)); // expected-error {{expression has unknown bounds}}
   char c = buf[3]; // expected-error {{out-of-bounds memory access}} \
                    // expected-note {{accesses memory at or above the upper bound}} \
                    // expected-note {{(expanded) inferred bounds are 'bounds(buf, buf + 3)'}}

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -152,7 +152,7 @@ extern void f18(int i) {
   r = _Dynamic_bounds_cast<array_ptr<int>>(q, bounds(q, q + 1)); // expected-error {{arithmetic on _Ptr type}}
 
   r = _Dynamic_bounds_cast<array_ptr<int>>(r, count(1));        // expected-error {{declared bounds for r are invalid after assignment}}
-  r = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(r, r + 1)); // expected-error {{expression has unknown bounds}} TODO: revert to 'declared bounds for r are invalid after assignment' after checkedc-clang PR #834 is merged
+  r = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(r, r + 1)); // expected-error {{declared bounds for r are invalid after assignment}}
 
   p = _Dynamic_bounds_cast<char *>(p); // expected-warning{{incompatible pointer types assigning}} expected-error{{expression has unknown bounds}}
 

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -2049,8 +2049,8 @@ void check_pointer_arithmetic(void)
    s_tmp = s--;
    s_tmp = ++s;
    s_tmp = --s;
-   s_tmp = (s += 1);
-   s_tmp = (s -= 1);
+   s_tmp = (s += 1); // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
+   s_tmp = (s -= 1); // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
    // 0 interpreted as an integer, not null
    s_tmp = s + 0;
    s_tmp = 0 + s;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -2045,10 +2045,10 @@ void check_pointer_arithmetic(void)
    s_tmp = 5 + s;
    s_tmp = s_tmp - 2;
    s_tmp = 2 - s_tmp; // expected-error {{invalid operands to binary expression}}
-   s_tmp = s++;
-   s_tmp = s--;
-   s_tmp = ++s;
-   s_tmp = --s;
+   s_tmp = s++; // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
+   s_tmp = s--; // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
+   s_tmp = ++s; // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
+   s_tmp = --s; // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
    s_tmp = (s += 1); // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
    s_tmp = (s -= 1); // expected-warning {{cannot prove declared bounds for s are valid after assignment}}
    // 0 interpreted as an integer, not null

--- a/tests/typechecking/type_check_bounds_cast.c
+++ b/tests/typechecking/type_check_bounds_cast.c
@@ -114,7 +114,7 @@ extern void f8() {
 extern void f9() {
   array_ptr<int> r : count(3) = 0;
   ptr<int> q = 0;
-  r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4) rel_align(int));
+  r = _Assume_bounds_cast<array_ptr<int>>(h4(), bounds(r, r + 4) rel_align(int)); // expected-error {{expression has unknown bounds}}
   q = _Assume_bounds_cast<ptr<int>>(h4(), bounds(r, r + 4) rel_align_value(sizeof(int))); // expected-error {{expected _Array_ptr type}}
 }
 


### PR DESCRIPTION
This PR updates checked-c tests to add expected warnings and errors since the checkedc-clang PR [836](https://github.com/microsoft/checkedc-clang/pull/836) updates the observed bounds context after an assignment to a variable.