### PR TITLE
Record equality between target and source: tests

### DIFF
--- a/tests/dynamic_checking/bounds/deref_arith_call_expr.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr.c
@@ -14,11 +14,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// TODO: checkedc-clang issue #845: reenable the -Werror flag in the test run.
-// Currently, bounds checking warnings caused by missing initializer equality
-// would cause the test to fail if the -Werror flag was enabled.
-//
-// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Wno-unused-value %checkedc_target_flags
+// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.

--- a/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
@@ -15,11 +15,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// TODO: checkedc-clang issue #845: reenable the -Werror flag in the test run.
-// Currently, bounds checking warnings caused by missing initializer equality
-// would cause the test to fail if the -Werror flag was enabled.
-//
-// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %clang %S/subscript_call_expr.c -DPOINTER_ARITHMETIC -o %t1 -Werror -Wno-unused-value -O3 %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.

--- a/tests/dynamic_checking/bounds/subscript_call_expr.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr.c
@@ -20,11 +20,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// TODO: checkedc-clang issue #845: reenable the -Werror flag in the test run.
-// Currently, bounds checking warnings caused by missing initializer equality
-// would cause the test to fail if the -Werror flag was enabled.
-//
-// RUN: %clang %s -o %t1 -Wno-unused-value %checkedc_target_flags
+// RUN: %clang %s -o %t1 -Werror -Wno-unused-value %checkedc_target_flags
 //
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
@@ -763,8 +759,6 @@ int main(int argc, array_ptr<nt_array_ptr<char>> argv : count(argc)) {
   }
 
   int idx = 1;
-  // TODO: checkedc-clang issue #845: equality between test and arvg[idx]
-  // needs to be recorded in order to properly validate the bounds of test.
   nt_array_ptr<char> test = argv[idx];
   idx++; // TODO: fold back into prior line.
   if (strcmp(test, "constant_bounds") == 0) {

--- a/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
@@ -14,11 +14,7 @@
 // 
 // The following lines are for the clang automated test suite.
 //
-// TODO: checkedc-clang issue #845: reenable the -Werror flag in the test run.
-// Currently, bounds checking warnings caused by missing initializer equality
-// would cause the test to fail if the -Werror flag was enabled.
-//
-// RUN: %clang %S/subscript_call_expr.c -o %t1 -DBOUNDS_INTERFACE -Wno-unused-value %checkedc_target_flags
+// RUN: %clang %S/subscript_call_expr.c -o %t1 -DBOUNDS_INTERFACE -Werror -Wno-unused-value %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.

--- a/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
@@ -14,11 +14,7 @@
 //
 // The following lines are for the clang automated test suite.
 //
-// TODO: checkedc-clang issue #845: reenable the -Werror flag in the test run.
-// Currently, bounds checking warnings caused by missing initializer equality
-// would cause the test to fail if the -Werror flag was enabled.
-//
-// RUN: %clang %S/subscript_call_expr.c -o %t1 -Wno-unused-value -O3 %checkedc_target_flags
+// RUN: %clang %S/subscript_call_expr.c -o %t1 -Werror -Wno-unused-value -O3 %checkedc_target_flags
 //
 // Test operations on a pointer to 5 integers, where the integers are initialized to 0...4.
 // The 3rd argument = element to perform operation on.

--- a/tests/dynamic_checking/dynamic-bounds-cast-check.c
+++ b/tests/dynamic_checking/dynamic-bounds-cast-check.c
@@ -1,10 +1,6 @@
 // The following lines are for the clang automated test suite
 //
-// TODO: checkedc-clang issue #845: reenable the -Werror flag in the test run.
-// Currently, bounds checking warnings caused by missing initializer equality
-// would cause the test to fail if the -Werror flag was enabled.
-//
-// RUN: %clang %s -o %t
+// RUN: %clang %s -o %t -Werror
 // RUN: %t pass1 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-1
 // RUN: %t pass2 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-2
 // RUN: %t pass3 | FileCheck %s --check-prefixes=CHECK,CHECK-PASS,CHECK-PASS-3
@@ -119,8 +115,6 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
     // CHECK-FAIL-4-NOT: Unexpected Success
     failing_test_4(5);
   } else if (strcmp(argv[1], "fail5") == 0) {
-    // TODO: checkedc-clang issue #845: equality between p and "\0\0\0\0\0\0\0\0abcd"
-    // needs to be recorded in order to properly validate the bounds of p.
     array_ptr<char> p : count(12) = "\0\0\0\0\0\0\0\0abcd";
     // CHECK-FAIL-5: Successful pointer conversion
     // CHECK-FAIL-5-NOT: Unexpected Success
@@ -128,16 +122,12 @@ int main(int argc, array_ptr<char*> argv : count(argc)) {
     failing_test_5(p, sizeof(int) + 1);
     failing_test_5(p, sizeof(int) - 1);
   } else if (strcmp(argv[1], "fail6") == 0) {
-    // TODO: checkedc-clang issue #845: equality between p and "abcd"
-    // needs to be recorded in order to properly validate the bounds of p.
     array_ptr<char> p : count(4) = "abcd";
     // CHECK-FAIL-6: Successful conversion to ptr<void>
     // CHECK-FAIL-6-NOT: Unexpected Success
     failing_test_6(p, 1);
     failing_test_6(p, 0);
   } else if (strcmp(argv[1], "fail7") == 0) {
-    // TODO: checkedc-clang issue #845: equality between p and "abcd"
-    // needs to be recorded in order to properly validate the bounds of p.
     array_ptr<char> p : count(4) = "abcd";
     // CHECK-FAIL-7: Successful conversion to void *
     // CHECK-FAIL-7-NOT: Unexpected Success
@@ -183,8 +173,6 @@ void passing_test_1(void) {
   q = _Dynamic_bounds_cast<array_ptr<int>>(r, bounds(s, s+3));
   printf("Printable3\n");
 
-  // TODO: checkedc-clang issue #845: equality between p and "abcdef"
-  // needs to be recorded in order to properly validate the bounds of p.
   nt_array_ptr<const char> p : count(2) =
     _Dynamic_bounds_cast<nt_array_ptr<const char>>("abcdef", count(2));
   printf("Printable4\n");
@@ -323,8 +311,6 @@ void failing_test_7(array_ptr<char> pc : count(len), unsigned len) {
 // Test dynamic checks involving possibly failing conversions from
 // string literals.
 void failing_test_8(unsigned len) {
- // TODO: checkedc-clang issue #845: equality between p and "123456"
- // needs to be recorded in order to properly validate the bounds of p.
  nt_array_ptr<const char> p : count(len) =
    _Dynamic_bounds_cast<nt_array_ptr<const char>>("123456", count(len));
   if (len > 6)

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -232,9 +232,7 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   arg1 = &arr[1];         // expected-error {{incompatible type}}
   arg2 = &*arg1;          // expected-error {{inferred bounds for 'arg2' are unknown after statement}}
   arg2 = &*arg2;
-  // TODO: checkedc-clang issue #845: equality between arg2 and &*arg3
-  // needs to be recorded in order to properly validate the bounds of arg2.
-  arg2 = &*arg3;          // expected-warning {{cannot prove declared bounds for 'arg2' are valid after statement}}
+  arg2 = &*arg3;
   arg3 = &*arg1;          // expected-error {{inferred bounds for 'arg3' are unknown after statement}}
   arg3 = &*arg2;          // expected-error {{declared bounds for 'arg3' are invalid after statement}}
   arg3 = &*arg3;
@@ -395,9 +393,7 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   t3 = s.f2;          // expected-error {{declared bounds for 't3' are invalid after statement}}
   t3 = s.f3;
 
-  // TODO: checkedc-clang issue #845: equality between ntp and { 0, 1, 2, 3, 0 }
-  // needs to be recorded in order to properly validate the bounds of ntp.
-  nt_array_ptr<int> ntp = (int nt_checked[]) { 0, 1, 2, 3, 0 }; // expected-warning {{cannot prove declared bounds for 'ntp' are valid after statement}}
+  nt_array_ptr<int> ntp = (int nt_checked[]) { 0, 1, 2, 3, 0 };
 /* HACK:
   Taking the address of pointers with bounds is not allowed.  Disable this code and
   stop the verification checking by converting "expected-error" to "expected error".
@@ -619,12 +615,8 @@ extern void check_nullterm_call_bsi(int *arg1 : itype(nt_array_ptr<int>),
     *arg8 = arg3;
 
     arg3 = arg1;
-    // TODO: checkedc-clang issue #845: equality between arg3 and *arg7
-    // needs to be recorded in order to properly validate the bounds of arg3.
-    arg3 = *arg7;               // expected-warning {{cannot prove declared bounds for 'arg3' are valid after statement}}
-    // TODO: checkedc-clang issue #845: equality between arg3 and *arg7
-    // needs to be recorded in order to properly validate the bounds of arg3.
-    arg3 = *arg8;               // expected-warning {{cannot prove declared bounds for 'arg3' are valid after statement}}
+    arg3 = *arg7;
+    arg3 = *arg8;
 
     arg4 = *arg7;               // expected-error {{declared bounds for 'arg4' are invalid after statement}}
   }

--- a/tests/static_checking/initializers.c
+++ b/tests/static_checking/initializers.c
@@ -85,12 +85,8 @@ void f4(void) checked {
   char t33 = g33[4];
   char t34 = g34[4];
   char t35 = g35[1];
-  // TODO: checkedc-clang issue #845: equality between t36 and g36[1][0]
-  // needs to be recorded in order to properly validate the bounds of t36.
-  nt_array_ptr<char> t36 = g36[1][0]; // expected-warning {{cannot prove declared bounds for 't36' are valid after statement}}
-  // TODO: checkedc-clang issue #845: equality between t37 and g37[1]
-  // needs to be recorded in order to properly validate the bounds of t36.
-  nt_array_ptr<char> t37 = g37[1]; // expected-warning {{cannot prove declared bounds for 't37' are valid after statement}}
+  nt_array_ptr<char> t36 = g36[1][0];
+  nt_array_ptr<char> t37 = g37[1];
 
 
   f3("abc");   // expected-error {{passing 'char _Nt_checked[4]' to parameter of incompatible type 'char *'}}
@@ -98,9 +94,7 @@ void f4(void) checked {
     f3("abc");
   }
 
-  // TODO: checkedc-clang issue #845: equality between t100 and { 0, 1, 2, 3 }
-  // needs to be recorded in order to properly validate the bounds of t100.
-  nt_array_ptr<int> t100 : count(3) = (int[]) { 0, 1, 2, 3 }; // expected-warning {{cannot prove declared bounds for 't100' are valid after statement}}
+  nt_array_ptr<int> t100 : count(3) = (int[]) { 0, 1, 2, 3 };
 }
 
 void f5(void) checked {
@@ -122,34 +116,20 @@ void f5(void) checked {
   // Checked pointers with initialized array literals.
   //
 
-  // TODO: checkedc-clang issue #845: equality between t30 and { 0, [2] = 2, 3, 5, 0 }
-  // needs to be recorded in order to properly validate the bounds of t30.
-  nt_array_ptr<int> t30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 }; // expected-warning {{cannot prove declared bounds for 't30' are valid after statement}}
+  nt_array_ptr<int> t30 : count(4) = (int[]) { 0, [2] = 2, 3, 5, 0 };
 
-  // TODO: checkedc-clang issue #845: equality between t31 and { 0, [2] = 2, 3, 5, 0 }
-  // needs to be recorded in order to properly validate the bounds of t31.
-  nt_array_ptr<int> t31 = (int checked[]) { 0, [2] = 2, 3, 5, 0 }; // expected-warning {{cannot prove declared bounds for 't31' are valid after statement}}
-  // TODO: checkedc-clang issue #845: equality between t32 and "abcde"
-  // needs to be recorded in order to properly validate the bounds of t32.
-  nt_array_ptr<char> t32 : count(5) = "abcde"; // expected-warning {{cannot prove declared bounds for 't32' are valid after statement}}
+  nt_array_ptr<int> t31 = (int checked[]) { 0, [2] = 2, 3, 5, 0 };
+  nt_array_ptr<char> t32 : count(5) = "abcde";
 
-  // TODO: checkedc-clang issue #845: equality between t33 and "abcde"
-  // needs to be recorded in order to properly validate the bounds of t33.
-  array_ptr<char> t33 : count(5) = "abcde"; // expected-warning {{cannot prove declared bounds for 't33' are valid after statement}}
+  array_ptr<char> t33 : count(5) = "abcde";
   array_ptr<char> t34 = (char[5]) { 'a', 'b', 'c', 'd', 'e' };
-  // TODO: checkedc-clang issue #845: equality between t35 and { 'a', 'b', 'c', 'd', 'e' }
-  // needs to be recorded in order to properly validate the bounds of t35.
-  array_ptr<char> t35 : count(5) = (char checked[5]) { 'a', 'b', 'c', 'd', 'e' }; // expected-warning {{cannot prove declared bounds for 't35' are valid after statement}}
+  array_ptr<char> t35 : count(5) = (char checked[5]) { 'a', 'b', 'c', 'd', 'e' };
 
   //
   // Make sure parentheses are ignored.
   //
-  // TODO: checkedc-clang issue #845: equality between t36 and { 0, [2] = 2, 3, 5, 0 }
-  // needs to be recorded in order to properly validate the bounds of t36.
-  nt_array_ptr<int> t36 : count(4) = ((int[]) { 0, [2] = 2, 3, 5, 0 }); // expected-warning {{cannot prove declared bounds for 't36' are valid after statement}}
-  // TODO: checkedc-clang issue #845: equality between t37 and "abcde"
-  // needs to be recorded in order to properly validate the bounds of t37.
-  nt_array_ptr<char> t37 : count(5) = ("abcde"); // expected-warning {{cannot prove declared bounds for 't37' are valid after statement}}
+  nt_array_ptr<int> t36 : count(4) = ((int[]) { 0, [2] = 2, 3, 5, 0 });
+  nt_array_ptr<char> t37 : count(5) = ("abcde");
 
   //
   // Checked arrays of checked pointers.
@@ -160,9 +140,7 @@ void f5(void) checked {
 
   char c = ((char *[2]) { "abc", "def" })[0][0];  // expected-error {{type in a checked\
  scope must use only checked types or parameter/return types with bounds-safe interfaces}}
-  // TODO: checkedc-clang issue #845: equality between callback_table and { callback1, callback2, 0 }
-  // needs to be recorded in order to properly validate the bounds of callback_table.
-  nt_array_ptr<ptr<void(int)>> callback_table = (ptr<void(int)>[]) { callback1, callback2, 0 }; // expected-warning {{cannot prove declared bounds for 'callback_table' are valid after statement}}
+  nt_array_ptr<ptr<void(int)>> callback_table = (ptr<void(int)>[]) { callback1, callback2, 0 };
 
 }
 

--- a/tests/static_checking/static_check_bounds_cast.c
+++ b/tests/static_checking/static_check_bounds_cast.c
@@ -227,9 +227,7 @@ extern void f23() {
 }
 
 extern void f24() {
-  // TODO: checkedc-clang issue #845: equality between buf and "abc"
-  // needs to be recorded in order to properly validate the bounds of buf.
-  array_ptr<char> buf : count(3) = "abc"; // expected-warning {{cannot prove declared bounds for 'buf' are valid after statement}}
+  array_ptr<char> buf : count(3) = "abc";
   buf = _Dynamic_bounds_cast<array_ptr<char>>(h7(), bounds(buf, buf + 3)); // expected-error {{inferred bounds for 'buf' are unknown after statement}}
   char c = buf[3]; // expected-error {{out-of-bounds memory access}} \
                    // expected-note {{accesses memory at or above the upper bound}} \

--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -1745,9 +1745,7 @@ extern void test_cast_to_nt_array_ptr(void) checked {
   p8 = (nt_array_ptr<char>)p7; // expected-error {{'_Array_ptr<char>' cannot be cast to '_Nt_array_ptr<char>' in a checked scope because '_Array_ptr<char>' might not point to a null-terminated array}}
 
   // Test casting nt_array_ptr to nt_array_ptr
-  // TODO: checkedc-clang issue #845: equality between p9 and "hello"
-  // needs to be recorded in order to properly validate the bounds of p9.
-  nt_array_ptr<char> p9 = "hello"; // expected-warning {{cannot prove declared bounds for 'p9' are valid after statement}}
+  nt_array_ptr<char> p9 = "hello";
   nt_array_ptr<char> p10 = (nt_array_ptr<char>)p9;  // legal casting
 
   // Test casting to nt_array_ptr in a unchecked scope.


### PR DESCRIPTION
This PR modifies the Checked C tests to reflect the changes in [checkedc-clang/857](https://github.com/microsoft/checkedc-clang/pull/857).

The PR for bounds context validation [checkedc-clang/853](https://github.com/microsoft/checkedc-clang/pull/853) introduced bounds checking warnings due to missing equality information between a variable target and a source expression that was not included in CheckingState.EquivExprs. This PR removes those expected warnings from the tests due to the checkedc-clang PR to fix the extra warnings.