### PR TITLE
Undefing strdup in the case of GCC

### DIFF
--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -48,6 +48,7 @@
 #undef strncmp
 #undef strpbrk
 #undef strspn
+#undef strdup
 #endif
 
 // We wrap each definition in a complex conditional, there two boolean values:


### PR DESCRIPTION
We need to `undef strdup` to avoid conflicts with GNU's `strdup`.