### PR TITLE
Change expected errors to 'initialization' rather than 'statement'

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -29,9 +29,9 @@ extern void check_exprs(int *arg1, ptr<int> arg2, array_ptr<int> arg3,
 
   // compound literals
   array_ptr<int> arr1 : count(3) = (int checked[3]){0, 1, 2};
-  array_ptr<int> arr2 : count(4) = (int checked[3]){0, 1, 2}; // expected-error {{declared bounds for 'arr2' are invalid after statement}}
+  array_ptr<int> arr2 : count(4) = (int checked[3]){0, 1, 2}; // expected-error {{declared bounds for 'arr2' are invalid after initialization}}
   array_ptr<struct S1> arr_struct1 : count(1) = &(struct S1){0};
-  array_ptr<struct S1> arr_struct2 : count(2) = &(struct S1){0}; // expected-error {{declared bounds for 'arr_struct2' are invalid after statement}}
+  array_ptr<struct S1> arr_struct2 : count(2) = &(struct S1){0}; // expected-error {{declared bounds for 'arr_struct2' are invalid after initialization}}
 
   // TODO: assignments of variables with array types
   // to pointer variables, and reads/writes of struct members.


### PR DESCRIPTION
This PR fixes the two new expected errors introduced by #414 to reflect the changes in #412 - expecting 'declared bounds for ... are invalid after initialization' rather than 'declared bounds for ... are invalid after statement'.