### PR TITLE
Update description of checking conditional expressions

### DIFF
--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1312,7 +1312,7 @@ Let $DC^\prime$ be $DC$ restricted to variables in $W_1 \cup W_2$:
 for each variable $v \in dom(DC)$, keep the entry if $v \in W_1 \cup W_2$
 or $DC[v]$ uses the value of a variable in $W_1 \cup W_2$.
 \item For each arm $e_i$, call $Validate(DC^\prime, \mathit{UC}_i, {UEQ}_i)$.
-\item Let $\mathit{UC} = C$.  Update $\mathit{UC}$ so that any variables modified by the conditional expression
+\item Let $\mathit{UC} = \mathit{UC}_{e1}$.  Update $\mathit{UC}$ so that any variables modified by the conditional expression
 have the top-level declared bounds (which were just validated after each arm).
 For any variable $v$ in $DC^\prime$, let $\mathit{UC}[v] = DC^\prime[v]$.
 \end{enumerate}

--- a/spec/bounds_safety/checking-variable-bounds.tex
+++ b/spec/bounds_safety/checking-variable-bounds.tex
@@ -1287,7 +1287,7 @@ To keep checking from becoming too expensive, we disallow such expressions.
 \begin{enumerate}
 \item Let $(\_, \mathit{UC}_{e1}, {UEQ}_{e1}, \_, RC, WC)= Check(e1, C, EQ, No, None)$
 \item For each arm $e_i$ of the conditional branch,
-        let $(B_i, \mathit{UC}_i, {UEQ}_i, G_i, R_i, W_i) = Check(e_i, \mathit{UC}_{e1}, EQ, No, None)$.
+        let $(B_i, \mathit{UC}_i, {UEQ}_i, G_i, R_i, W_i) = Check(e_i, \mathit{UC}_{e1}$, ${UEQ}_{e1}, No, None)$.
 \item Handle uses of temporaries bound in only one branch.  These temporaries
 will be uninitialized when the other branch of the conditional arm is evaluated.
 If some $B_i$, $\mathit{UC}_i$ or ${UEQ}_i$ uses a temporary bound in $e_i$,


### PR DESCRIPTION
Fixes #416 

This PR updates the description of the algorithm for checking a conditional expression `e1 ? e2 : e3`.

#### Equivalent expression sets used to check branches
The set of equivalent expression sets used to check each arm `e2` and `e3` should be the set of equivalent expressions that was true after checking the test expression `e1`. Consider:

```
void f(array_ptr<int> a : count(1), array_ptr<int> b : count(2)) {
  (a = b) ? a : b;
}
```

The equality between `a` and `b` that is recorded in the test expression `e1` should be true at the end of checking the conditional expression. The final observed bounds context is `{ a => bounds(b, b + 2), b => bounds(b, b + 2) }`. The final set of equivalent expressions should contain `{ a, b } ` in order to check the updated observed bounds of `a`.

#### Test expression bounds in final observed bounds context
The final observed bounds context after checking a conditional expression should reflect variables whose observed bounds were updated in the test expression `e1`, but not updated in either arm `e2` or `e3`. Consider:

```
void f(array_ptr<int> a : count(1), array_ptr<int> b : count(2), array_ptr<int> c : count(3)) {
  (b = a) ? (c = 0) : c;
}
```

The initial bounds context `C` before doing any checking is `{ a => bounds(a, a + 1), b => bounds(b, b + 2), c=> bounds(c, c + 3) }`. The bounds context `UC_e1` from checking the test expression `e1` is `{ a => bounds(a, a + 1), b => bounds(a, a + 1), c => bounds(c, c + 3) }`. After checking the bounds context updated in the true arm `e2` (`{ c => bounds(any) }`) and in the false arm `e3` (`{ }`), the observed bounds of `c` are reset to their declared bounds `(c, c + 3)`. The final observed bounds context after checking the conditional expression should be `{ a => bounds(a, a + 1), b => bounds(a, a + 1), c => bounds(c, c + 3) }`. Validating this bounds context will emit an error for the observed bounds of `b` due to the assignment `b = a` in the test expression `e1`.