### PR TITLE
spec: Fix typo that blocks the build when parskip.sty is not installed.

### DIFF
--- a/spec/bounds_safety/checkedc.tex
+++ b/spec/bounds_safety/checkedc.tex
@@ -29,7 +29,7 @@
 \usepackage{parskip}
 }{% else
 \setlength{\parindent}{0pt}
-\setlengt{\parskip}{6pt plus 2pt minus 1pt}
+\setlength{\parskip}{6pt plus 2pt minus 1pt}
 }
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
 \providecommand{\tightlist}{%


### PR DESCRIPTION
I'll probably install `parskip.sty` to match what your configuration must have been to successfully produce the released specs, but as long as you have this code path at all, it should work.