### PR TITLE
docs: fix simple typo, performanc -> perform an

### DIFF
--- a/tests/dynamic_checking/bounds/deref_arith_call_expr.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr.c
@@ -143,7 +143,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i .e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to performanc an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/deref_arith_call_expr.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr.c
@@ -143,7 +143,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i .e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to perform an an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
@@ -144,7 +144,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i.e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to perform an an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c
@@ -144,7 +144,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i.e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to performanc an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
@@ -145,7 +145,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i.e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to perform an an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_bsi.c
@@ -145,7 +145,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i.e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to performanc an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
@@ -143,7 +143,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i.e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to performanc an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL

--- a/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
+++ b/tests/dynamic_checking/bounds/subscript_call_expr_opt.c
@@ -143,7 +143,7 @@
 // to n 3-d integer arrays, where the integers are initialized by the sequence 1, 3, 5 ...  (i - 1) * 3 * 2 + 5),
 // i.e. with a stride of 2.
 // The 3rd argument = the array length (n), the 4th and 5th argument specify the
-// element to perform an an operation on.  The 4th argument is the 1st dimension index,
+// element to perform an operation on.  The 4th argument is the 1st dimension index,
 // and the 5th argument is the 2nd dimension index.  
 //
 // RUN: %checkedc_rununder %t1 md_dependent_bounds read 2 2 0   | FileCheck %S/subscript_call_expr.c --check-prefixes=MD-DB-READ-START,MD-DB-READ-FAIL


### PR DESCRIPTION
There is a small typo in tests/dynamic_checking/bounds/deref_arith_call_expr.c, tests/dynamic_checking/bounds/deref_arith_call_expr_opt.c, tests/dynamic_checking/bounds/subscript_call_expr_bsi.c, tests/dynamic_checking/bounds/subscript_call_expr_opt.c.

Should read `perform an` rather than `performanc`.

