### PR TITLE
Fix failing test resulting from free variables merge

### DIFF
--- a/tests/parsing/pointer_bounds_cast.c
+++ b/tests/parsing/pointer_bounds_cast.c
@@ -136,7 +136,7 @@ extern void f13(array_ptr<int> arr : count(5)) {
 
   x = _Dynamic_bounds_cast<array_ptr<int>>(p, count(10));
   x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(p, p + 10));
-  x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(cache1 - 2, cache1 + 3)); // expected-error {{declared bounds for 'x' are invalid after assignment}}
+  x = _Dynamic_bounds_cast<array_ptr<int>>(p, bounds(cache1 - 2, cache1 + 3)); // expected-error {{it is not possible to prove that the inferred bounds of 'x' imply the declared bounds of 'x' after assignment}}
   x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr, arr + len));  // expected-error {{it is not possible to prove that the inferred bounds of 'x' imply the declared bounds of 'x' after assignment}}
   x = _Dynamic_bounds_cast<array_ptr<int>>(x, bounds(arr)); // expected-error {{expected ','}}
   x = _Dynamic_bounds_cast<array_ptr<int>>(x, count(3 + 2));// expected-error {{declared bounds for 'x' are invalid after assignment}}


### PR DESCRIPTION
The parsing/pointer_bounds_cast.c test expected an error where the bounds of 'x' are invalid after a dynamic bounds cast. The actual error is that it is impossible to prove that the bounds of 'x' are valid since there is no relational information between the variables 'cache1' in the inferred bounds and 'x' in the declared bounds.