### PR TITLE
Clang 11 upgrade: update Checked C tests

### DIFF
--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -333,7 +333,7 @@ union U3 {
 #define untag_int(p) ((p) & ~1)
 
 union U4 {
-  array_ptr<int> ip : bounds(ip, is_tagged_int(ip) ? ip : ip + 5);
+  array_ptr<int> ip : bounds(ip, is_tagged_int(ip) ? ip : ip + 5); // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
   int i;
 };
 

--- a/tests/parsing/member_bounds.c
+++ b/tests/parsing/member_bounds.c
@@ -322,21 +322,6 @@ union U3 {
   int i;
 };
 
-// Unions of pointers and integers, where the least significant
-// bit is used as a tag.
-
-// We tag integers with 1 instead of trying to tag pointers with 1.
-// Null pointers tagged with 1 are not allowed by the current 
-// Checked C definition.
-
-#define is_tagged_int(p) ((int)(p) & 1)
-#define untag_int(p) ((p) & ~1)
-
-union U4 {
-  array_ptr<int> ip : bounds(ip, is_tagged_int(ip) ? ip : ip + 5); // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
-  int i;
-};
-
 // Union of pointers where lengths depend on a tag in an enclosing structure
 struct S32 {
   int len : 31;

--- a/tests/parsing/pointer-larger-int/lit.local.cfg
+++ b/tests/parsing/pointer-larger-int/lit.local.cfg
@@ -1,0 +1,8 @@
+import re
+
+# On 32-bit windows a pointer is not larger than int
+if not re.match(r'^i686-pc.*-(windows-msvc|windows-gnu)$', config.target_triple):
+    config.available_features.add('pointer-larger-int')
+
+if not 'pointer-larger-int' in config.available_features:
+    config.unsupported = True

--- a/tests/parsing/pointer-larger-int/member_bounds.c
+++ b/tests/parsing/pointer-larger-int/member_bounds.c
@@ -1,0 +1,25 @@
+// Feature tests of parsing new Checked C member bounds declarations.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -verify %s
+
+#include <stdchecked.h>
+
+_Static_assert(sizeof(void*) > sizeof(int),
+  "Pointers must be larger than ints");
+
+// Unions of pointers and integers, where the least significant
+// bit is used as a tag.
+
+// We tag integers with 1 instead of trying to tag pointers with 1.
+// Null pointers tagged with 1 are not allowed by the current 
+// Checked C definition.
+
+#define is_tagged_int(p) ((int)(p) & 1)
+#define untag_int(p) ((p) & ~1)
+
+union U4 {
+  array_ptr<int> ip : bounds(ip, is_tagged_int(ip) ? ip : ip + 5); // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  int i;
+};

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -565,17 +565,17 @@ void int_local_var_bounds_decl(void) {
   int a1 checked[5];
 
   // byte_count
-  short int t20 : byte_count(5 * sizeof(int)) = (short int)a1;
-  int t21 : byte_count(5 * sizeof(int)) = (int)a1;
-  long int t22 : byte_count(5 * sizeof(int)) = (long int)a1;
-  unsigned long int t23 : byte_count(5 * sizeof(int)) = (unsigned long int) a1;
+  short int t20 : byte_count(5 * sizeof(int)) = (short int)a1; // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+  int t21 : byte_count(5 * sizeof(int)) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  long int t22 : byte_count(5 * sizeof(int)) = (long int)a1; // expected-warning {{cast to smaller integer type 'long' from '_Array_ptr<int>'}}
+  unsigned long int t23 : byte_count(5 * sizeof(int)) = (unsigned long int) a1; // expected-warning {{cast to smaller integer type 'unsigned long' from '_Array_ptr<int>'}}
   enum E1 t24 : byte_count(8) = EnumVal1;
 
   // bounds
-  int t25 : bounds(a1, a1 + 5) = (int)a1;
-  long int t26 : bounds(a1, a1 + 5) = (int)a1;
-  unsigned long int t27 : bounds(a1, a1 + 5) = (int)a1;
-  enum E1 t28 : bounds(a1, a1 + 5) = (int)a1;
+  int t25 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  long int t26 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  unsigned long int t27 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  enum E1 t28 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
 }
 
 void invalid_local_var_bounds_decl(void)
@@ -913,11 +913,11 @@ array_ptr<void> fn11(void) : bounds(s1, s1 + 5) { return 0; }
 int *fn12(void) : bounds(s1, s1 + 5) { return 0; }
 
 // Test valid return bounds declarations for integer-typed values
-short int fn20(void) : byte_count(5 * sizeof(int)) { return (short int) s1; }
-int fn21(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
-long int fn22(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
-unsigned long int fn23(void) : byte_count(5 * sizeof(int)) { return (short int)s1; }
-enum E1 fn24(void) : byte_count(8) { return (short int)s1; }
+short int fn20(void) : byte_count(5 * sizeof(int)) { return (short int) s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+int fn21(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+long int fn22(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+unsigned long int fn23(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+enum E1 fn24(void) : byte_count(8) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
 
 // bounds
 extern int fn25(void) : bounds(s1, s1 + 5);

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -566,14 +566,7 @@ void int_local_var_bounds_decl(void) {
 
   // byte_count
   short int t20 : byte_count(5 * sizeof(int)) = (short int)a1; // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
-  int t21 : byte_count(5 * sizeof(int)) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
   enum E1 t24 : byte_count(8) = EnumVal1;
-
-  // bounds
-  int t25 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
-  long int t26 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
-  unsigned long int t27 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
-  enum E1 t28 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
 }
 
 void invalid_local_var_bounds_decl(void)

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -1092,7 +1092,7 @@ void function_pointers(void) {
   nt_array_ptr<int>(*t13a)(void) : bounds(s1, s1 + 5) = fn10a;
   int *(*t14)(void) = fn12;
   int *(*t15)(void) : bounds(s1, s1 + 5) = fn12;
-  int *(*t16)(void) : bounds(s1, s1 + 6) = fn12;    // expected-warning {{incompatible pointer types}}
+  int *(*t16)(void) : bounds(s1, s1 + 6) = fn12;    // expected-warning {{incompatible function pointer types}}
   ptr<int *(void) : bounds(s1, s1 + 6)> t17 = fn12; // expected-error {{incompatible type}}
 
   // Unchecked pointer to function assigned to checked pointer to
@@ -1111,8 +1111,8 @@ void function_pointers(void) {
   fn204(fn104);
   // These are mismatched unchecked function pointers with bounds-safe interfaces
   // on parameters.
-  fn204(fn104a); // expected-warning {{incompatible pointer types}}
-  fn204(fn104b); // expected-warning {{incompatible pointer types}}
+  fn204(fn104a); // expected-warning {{incompatible function pointer types}}
+  fn204(fn104b); // expected-warning {{incompatible function pointer types}}
   fn205(fn105);
   fn206(fn106);
   fn207(fn107);

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -567,8 +567,6 @@ void int_local_var_bounds_decl(void) {
   // byte_count
   short int t20 : byte_count(5 * sizeof(int)) = (short int)a1; // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
   int t21 : byte_count(5 * sizeof(int)) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
-  long int t22 : byte_count(5 * sizeof(int)) = (long int)a1; // expected-warning {{cast to smaller integer type 'long' from '_Array_ptr<int>'}}
-  unsigned long int t23 : byte_count(5 * sizeof(int)) = (unsigned long int) a1; // expected-warning {{cast to smaller integer type 'unsigned long' from '_Array_ptr<int>'}}
   enum E1 t24 : byte_count(8) = EnumVal1;
 
   // bounds

--- a/tests/typechecking/pointer-larger-int/bounds.c
+++ b/tests/typechecking/pointer-larger-int/bounds.c
@@ -1,0 +1,32 @@
+// Feature tests of typechecking new Checked C bounds declarations.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -Wno-check-bounds-decls -verify -verify-ignore-unexpected=note %s
+
+#include <stdchecked.h>
+
+_Static_assert(sizeof(void*) > sizeof(int),
+  "Pointers must be larger than ints");
+
+enum E1 {
+  EnumVal1,
+  EnumVal2
+};
+
+void int_local_var_bounds_decl(void) {
+  // bounds declarations are allowed for integer variables to support
+  // casting of pointers to integers and back.  We usually expect this
+  // to happen within expressions, but to allow uniform use of language
+  // features, we allow bounds on integer-typed variables.
+  int a1 checked[5];
+
+  // byte_count
+  int t21 : byte_count(5 * sizeof(int)) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+
+  // bounds
+  int t25 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  long int t26 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  unsigned long int t27 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+  enum E1 t28 : bounds(a1, a1 + 5) = (int)a1; // expected-warning {{cast to smaller integer type 'int' from '_Array_ptr<int>'}}
+}

--- a/tests/typechecking/pointer-larger-int/lit.local.cfg
+++ b/tests/typechecking/pointer-larger-int/lit.local.cfg
@@ -1,0 +1,8 @@
+import re
+
+# On 32-bit windows a pointer is not larger than int
+if not re.match(r'^i686-pc.*-(windows-msvc|windows-gnu)$', config.target_triple):
+    config.available_features.add('pointer-larger-int')
+
+if not 'pointer-larger-int' in config.available_features:
+    config.unsupported = True

--- a/tests/typechecking/pointer-larger-long/bounds.c
+++ b/tests/typechecking/pointer-larger-long/bounds.c
@@ -1,0 +1,21 @@
+// Feature tests of typechecking new Checked C bounds declarations.
+//
+// The following lines are for the LLVM test harness:
+//
+// RUN: %clang_cc1 -Wno-check-bounds-decls -verify -verify-ignore-unexpected=note %s
+
+#include <stdchecked.h>
+
+_Static_assert(sizeof(void*) > sizeof(long),
+  "Pointers must be larger than longs");
+
+void int_local_var_bounds_decl(void) {
+  // bounds declarations are allowed for integer variables to support
+  // casting of pointers to integers and back.  We usually expect this
+  // to happen within expressions, but to allow uniform use of language
+  // features, we allow bounds on integer-typed variables.
+  int a1 checked[5];
+
+  long int t22 : byte_count(5 * sizeof(int)) = (long int)a1; // expected-warning {{cast to smaller integer type 'long' from '_Array_ptr<int>'}}
+  unsigned long int t23 : byte_count(5 * sizeof(int)) = (unsigned long int) a1; // expected-warning {{cast to smaller integer type 'unsigned long' from '_Array_ptr<int>'}}
+}

--- a/tests/typechecking/pointer-larger-long/lit.local.cfg
+++ b/tests/typechecking/pointer-larger-long/lit.local.cfg
@@ -1,0 +1,8 @@
+import re
+
+# On 64-bit windows a pointer is larger than long
+if re.match(r'^x86_64.*-(windows-msvc|windows-gnu)$', config.target_triple):
+    config.available_features.add('pointer-larger-long')
+
+if not 'pointer-larger-long' in config.available_features:
+    config.unsupported = True

--- a/tests/typechecking/pointer-sized-long-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long-long/pointer_casts.c
@@ -63,6 +63,7 @@ extern int f10(int a, _Array_ptr<int> b,
                 _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (long long) b + a));
 extern int f10(int a, _Array_ptr<int> b,
                _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (short) b + a)); // expected-error {{function redeclaration has conflicting parameter bounds}} \
+                                                                                 // expected-warning 2 {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
                                                                                  // expected-warning 2 {{cast to '_Array_ptr<int>' from smaller integer type 'short'}}
 
 extern int f11(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));

--- a/tests/typechecking/pointer-sized-long/pointer_casts.c
+++ b/tests/typechecking/pointer-sized-long/pointer_casts.c
@@ -67,7 +67,8 @@ extern int f10(int a, _Array_ptr<int> b,
                 _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (long) b + a));
 extern int f10(int a, _Array_ptr<int> b,
                _Array_ptr<char> p : bounds(b, (_Array_ptr<int>) (short) b + a)); // expected-error {{function redeclaration has conflicting parameter bounds}} \
-                                                                                 // expected-warning 2 {{cast to '_Array_ptr<int>' from smaller integer type 'short'}}
+                                                                                 // expected-warning 2 {{cast to '_Array_ptr<int>' from smaller integer type 'short'}} \
+                                                                                 // expected-warning 2 {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
 
 extern int f11(int a, _Array_ptr<int> b, _Array_ptr<char> p : bounds(b, b + a));
 extern int f11(int a, _Array_ptr<int> b,


### PR DESCRIPTION
Update some Checked C test files to account for changes made to checkedc-clang during the upgrade to Clang/LLVM 11.0 (see the updated-master-11-last branch of checkedc-clang).