### PR TITLE
[LValue Generalization] Update tests for validating member bounds

### DIFF
--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -210,15 +210,15 @@ void write_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      s1->len = 0;
+      s1->len = 0, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->len = 1;
+      s1->len = 1, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->len = 2;
+      s1->len = 2, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary write position for a3 (7th parameter)
@@ -405,15 +405,15 @@ void read_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      s1->len = 0;
+      s1->len = 0, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->len = 1;
+      s1->len = 1, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->len = 2;
+      s1->len = 2, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary read position for a3 (7th parameter)

--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -382,12 +382,12 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   s.f1 = t2;
   s.f1 = t3;
 
-  s.f2 = t1;          // expected-error {{expression has unknown bounds}}
+  s.f2 = t1;          // expected-error {{inferred bounds for 's.f2' are unknown after assignment}}
   s.f2 = t2;
   s.f2 = t3;
 
-  s.f3 = t1;          // expected-error {{expression has unknown bounds}}
-  s.f3 = t2;          // expected-error {{declared bounds for s.f3 are invalid after assignment}}
+  s.f3 = t1;          // expected-error {{inferred bounds for 's.f3' are unknown after assignment}}
+  s.f3 = t2;          // expected-error {{declared bounds for 's.f3' are invalid after assignment}}
   s.f3 = t3;
 
   t1 = s.f1;


### PR DESCRIPTION
This PR updates test files to account for the new compiler behavior introduced by [checkedc-clang/1083](https://github.com/microsoft/checkedc-clang/pull/1083): validating the bounds context for member expressions. The compiler now emits errors and warnings for statements that invalidate member bounds by assigning to member expressions that are used in member bounds.