### PR TITLE
Get variable and constant: update tests

### DIFF
--- a/tests/typechecking/checked_scope_basic.c
+++ b/tests/typechecking/checked_scope_basic.c
@@ -1506,8 +1506,7 @@ SCOPE_KIND void check_cast_operator(void) {
 
   // ptr to array, ptr to unchecked array
   parr = (ptr<int checked[5]>) &arr;
-  parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr); // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int _Checked[5]>'}} \
-                                                            // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int _Checked[]>'}}
+  parr = (ptr<int checked[5]>) ((ptr<int checked[]>) &arr); // expected-warning {{cannot prove cast source bounds are wide enough for '_Ptr<int _Checked[5]>'}}
   parr = (ptr<int [5]>) &arr;   // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
   parr = (ptr<int *>) &arr;     // expected-error {{type in a checked scope must use only checked types or parameter/return types with bounds-safe interfaces}}
 


### PR DESCRIPTION
This PR updates tests for [checkedc-clang/1135](https://github.com/microsoft/checkedc-clang/pull/1135). When the new method `GetVariableAndConstant` is used to compare two upper bounds expressions, the bounds checker is able to prove that the inferred bounds `bounds(arr, arr + 5)` are equivalent to the required cast bounds `bounds((_Array_ptr<int _Checked[]>)&arr, (_Array_ptr<int _Checked[]>)&arr + 1))`