### PR TITLE
[spec] Fixed typos and missed words in Chapter 2, 5, and 6.

### DIFF
--- a/spec/bounds_safety/core-extensions.tex
+++ b/spec/bounds_safety/core-extensions.tex
@@ -675,7 +675,7 @@ about whether the array type should be an unchecked or checked array.
 The type of a string literal with an element type \var{T} depends on whether the literal occurs
 in a checked scope or an unchecked scope:
 \begin{itemize}
-\item In a checked scope, the type is ``null-terminated checked array of \var{T}``.
+\item In a checked scope, the type is ``null-terminated checked array of \var{T}''
 \item In an unchecked scope, the type is ``unchecked array of \var{T}''.
 \end{itemize}
 
@@ -971,7 +971,7 @@ the ranges of signed integers and unsigned integers are different.
   signed integer. If \var{i} is an unsigned integer, the scaled result
   shall be treated as an unsigned integer. For a signed integer, the
   minimum and maximum range for \var{j} shall be \code{INTPTR_MIN} and
-  \code{INTPTR_MAX} For an unsigned integer, the minimum and maximum
+  \code{INTPTR_MAX}. For an unsigned integer, the minimum and maximum
   range for \var{j} shall be 0 and \code{UINTPTR_MAX}. If \var{j} is
   outside its valid range, the operation doing the scaling operation
   shall produce a runtime error.

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -1114,7 +1114,7 @@ Here are bounds safe-interfaces for other C standard library
 functions:
 \begin{lstlisting}
 itype_for_any(T) void *malloc(size_t size) :
-                    itype(array_ptr<T>) byte_count(size)
+                    itype(array_ptr<T>) byte_count(size);
 
 itype_for_any(T) void *calloc(size_t nmemb, size_t size : sizeof(T)) :
                     itype(array_ptr<T>) byte_count(nmemb * size);

--- a/spec/bounds_safety/interoperation.tex
+++ b/spec/bounds_safety/interoperation.tex
@@ -211,7 +211,7 @@ is needed.
    form \boundsrelval{\var{target-lb}}{\var{target-ub}}{\var{v}}.
    Check that \var{lb}  \code{<=} \var{target-lb} \code{&&} \var{target-ub} \code{<=} \var{ub}.
    Also check that \var{e1}, \var{target-lb}, and \var{target-lb} are relatively aligned 
-   with respect to\var{v}.
+   with respect to \var{v}.
 \end{itemize}
 \end{itemize}
 The \dynamicboundscast\ operator is not strictly needed.
@@ -1113,13 +1113,13 @@ bounds-safe interface declarations for parameters and return values.  The parame
 Here are bounds safe-interfaces for other C standard library
 functions:
 \begin{lstlisting}
-itype_for_any(T) void *malloc(size_t) :
+itype_for_any(T) void *malloc(size_t size) :
                     itype(array_ptr<T>) byte_count(size)
 
 itype_for_any(T) void *calloc(size_t nmemb, size_t size : sizeof(T)) :
                     itype(array_ptr<T>) byte_count(nmemb * size);
 
-itype_for_any(T) void free(void *pointer itype(array_ptr<T>) count(1));
+itype_for_any(T) void free(void *pointer : itype(array_ptr<T>) count(1));
 
 itype_for_any(T) void *memcpy(void * restrict dest :
                                  itype(array_ptr<T>) byte_count(n),

--- a/spec/bounds_safety/void-ptr-replacements.tex
+++ b/spec/bounds_safety/void-ptr-replacements.tex
@@ -21,7 +21,7 @@ static checking.  Uses include:
 \begin{itemize}
 \item As handles that hide details of API implementations.  An
 API may provide a handle that is typed as \uncheckedptrvoid\ for 
-using the API, with the API implementation using a pointer to an actual
+users of the API, with the API implementation using a pointer to an actual
 type.
 \item As pointers to arrays of bytes.  This is done by APIs such as \lstinline+memcpy+.
 \item In generic data structures or functions. For example, 

--- a/spec/bounds_safety/void-ptr-replacements.tex
+++ b/spec/bounds_safety/void-ptr-replacements.tex
@@ -21,7 +21,7 @@ static checking.  Uses include:
 \begin{itemize}
 \item As handles that hide details of API implementations.  An
 API may provide a handle that is typed as \uncheckedptrvoid\ for 
-users the API, with the API implementation using a pointer to an actual
+using the API, with the API implementation using a pointer to an actual
 type.
 \item As pointers to arrays of bytes.  This is done by APIs such as \lstinline+memcpy+.
 \item In generic data structures or functions. For example, 
@@ -31,7 +31,7 @@ to be used for many different types of list elements,
 even though in practice only one type of data may be stored in a list instance. 
 \item For registering callback functions that are to be provided with 
 user-supplied data at the callback.  Callback functions can take \uncheckedptrvoid{} arguments and 
-the user-suppled data can be cast to \uncheckedptrvoid{}.
+the user-supplied data can be cast to \uncheckedptrvoid{}.
 \item To provide a union of pointer types, without changing data representation.
 \end{itemize}
 
@@ -53,7 +53,7 @@ elements.  Generic functions can implement generic list operations such as \lsti
 user-supplied data.  Hidden types allow programmers to package up a callback function and data and
 say that they use  some type \lstinline+T+ whose details are hidden from the code that does
 the callback.   Enough details about \lstinline+T+ are available that the callback can be 
-implemented in a type-safe fashion efficently.  Hidden types hide details of the type 
+implemented in a type-safe fashion efficiently.  Hidden types hide details of the type
 of user-supplied data, instead of erasing it like \uncheckedptrvoid{} does.
 \end{itemize}
 


### PR DESCRIPTION
Fixed several typos and missed words in Chapter 2, 3 and 5 of the Language Specification.