### PR TITLE
Check return value bounds: update tests

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -639,8 +639,7 @@ void check_nullterm_return_use(void) {
   p = nullterm_return2(); // expected-error {{inferred bounds for 'p' are unknown after assignment}}
 }
 
-// TODO: Github issue #401.  We need to check that return expressions have bounds when expected.
 nt_array_ptr<char> check_nullterm_return1(void) {
   nt_array_ptr<char> p : bounds(unknown) = 0;
-  return p;
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'check_nullterm_return1' has bounds}}
 }

--- a/tests/typechecking/bounds.c
+++ b/tests/typechecking/bounds.c
@@ -904,11 +904,16 @@ array_ptr<void> fn11(void) : bounds(s1, s1 + 5) { return 0; }
 int *fn12(void) : bounds(s1, s1 + 5) { return 0; }
 
 // Test valid return bounds declarations for integer-typed values
-short int fn20(void) : byte_count(5 * sizeof(int)) { return (short int) s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
-int fn21(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
-long int fn22(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
-unsigned long int fn23(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
-enum E1 fn24(void) : byte_count(8) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}}
+short int fn20(void) : byte_count(5 * sizeof(int)) { return (short int) s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
+                                                                              // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'fn20'}}
+int fn21(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
+                                                                       // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'fn21'}}
+long int fn22(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
+                                                                            // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'fn22'}}
+unsigned long int fn23(void) : byte_count(5 * sizeof(int)) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
+                                                                                     // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'fn23'}}
+enum E1 fn24(void) : byte_count(8) { return (short int)s1; } // expected-warning {{cast to smaller integer type 'short' from '_Array_ptr<int>'}} \
+                                                             // expected-error {{it is not possible to prove that return value bounds imply declared return bounds for 'fn24'}}
 
 // bounds
 extern int fn25(void) : bounds(s1, s1 + 5);

--- a/tests/typechecking/checked_scope_interfaces.c
+++ b/tests/typechecking/checked_scope_interfaces.c
@@ -331,7 +331,7 @@ int *f30(void) : itype(ptr<int>) {
 int *f31(int len) : count(len) {
   checked{
     array_ptr<int> p = 0;
-  return p;
+    return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'f31' has bounds}}
   }
   return 0;
 }

--- a/tests/typechecking/interop_type_annotations.c
+++ b/tests/typechecking/interop_type_annotations.c
@@ -521,7 +521,7 @@ int ((*(r31e(int arg[10][10]) : itype(int[10][10])))[10]) { // expected-error {{
 }
 
 int(*(r31f(int arg[10][10]) : itype(int checked[10][10])))[10] { // expected-error {{array type not allowed}}
-  return arg;
+  return arg; // expected-error {{return value has unknown bounds, bounds expected because the function 'r31f' has bounds}}
 }
 
 // Return types that cannot have interface types

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -1698,8 +1698,7 @@ array_ptr<int> check_return21(int *p) {
 }
 
 array_ptr<int> check_return21a(int *p) : count(1) {
-  // TODO: github issue #403.  This should result in an error.
-  return p;
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'check_return21a' has bounds}}
 }
 
 array_ptr<int> check_return22(float *p) {
@@ -1834,8 +1833,7 @@ array_ptr<void> check_voidptr_return21(int *p) {
 }
 
 array_ptr<void> check_voidptr_return21a(int *p) : byte_count(sizeof(int)) {
-  // TODO: github issue #403.  This should result in an error.
-  return p;
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'check_voidptr_return21a' has bounds}}
 }
 
 array_ptr<void> check_voidptr_return21b(void *p) {
@@ -1843,8 +1841,7 @@ array_ptr<void> check_voidptr_return21b(void *p) {
 }
 
 array_ptr<void> check_voidptr_return21c(void *p) : byte_count(sizeof(int)) {
-  // TODO: github issue #403.  This should result in an error.
-  return p;
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'check_voidptr_return21c' has bounds}}
 }
 
 
@@ -1895,8 +1892,7 @@ checked array_ptr<void> check_voidptr_return31(ptr<int> p) {
 }
 
 checked array_ptr<void> check_voidptr_return31a(array_ptr<int> p) : byte_count(sizeof(int)) {
-  // TODO: github issue #403.  This should result in an error.
-  return p;
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'check_voidptr_return31a' has bounds}}
 }
 
 checked array_ptr<void> check_voidptr_return31b(array_ptr<void> p) {
@@ -1938,8 +1934,7 @@ array_ptr<void> check_voidptr_return42(ptr<int> p) {
 
 checked bounds_only
 array_ptr<void> check_voidptr_return42a(array_ptr<int> p) : byte_count(sizeof(int)) {
-  // TODO: github issue #403.  This should result in an error.
-  return p;
+  return p; // expected-error {{return value has unknown bounds, bounds expected because the function 'check_voidptr_return42a' has bounds}}
 }
 
 checked bounds_only


### PR DESCRIPTION
This PR updates test files to account for the new compiler behavior in [checkedc-clang/1150](https://github.com/microsoft/checkedc-clang/pull/1150): checking that the inferred bounds of a return expression imply the declared bounds (if any) for the enclosing function.