### PR TITLE
Treat address-of array subscripts the same way as address-of dereferences: update tests

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -237,8 +237,8 @@ extern void check_exprs_nullterm(nt_array_ptr<int> arg1 : bounds(unknown),
   arg1 = &*arg1;
   arg1 = &*arg2;
   arg1 = &*arg3;
-  arg1 = &*arr;           // TODO: investigate why this isn't a typechecking error.
-  arg1 = &arr[1];         // expected-error {{incompatible type}}
+  arg1 = &*arr;           // arg1 and &*arr both have type _Nt_array_ptr<int>.
+  arg1 = &arr[1];         // arg1 and &arr[1] both have type _Nt_array_ptr<int>.
   arg2 = &*arg1;          // expected-error {{inferred bounds for 'arg2' are unknown after assignment}}
   arg2 = &*arg2;
   arg2 = &*arg3;

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -3045,3 +3045,48 @@ void check_illegal_operators(void)
     +r;  // expected-error {{invalid argument type}}
     +s;  // expected-error {{invalid argument type}}
 }
+
+//
+// Test that address-of dereference and array subscript expressions
+// have the correct types.
+//
+
+extern void test_sprintf(char *s);
+
+void check_address_of_types(_Nt_array_ptr<char> str,
+                            _Array_ptr<char> arr : count(10),
+                            _Ptr<char> p) {
+  _Unchecked {
+    test_sprintf(str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(str + 0)); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&str[0]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&0[str]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+
+    test_sprintf(arr); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*arr); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(arr + 1)); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&arr[1]); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&1[arr]); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+
+    test_sprintf(p); // expected-error {{passing '_Ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*p); // expected-error {{passing '_Ptr<char>' to parameter of incompatible type 'char *'}}
+  }
+
+  _Checked {
+    test_sprintf(str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(str + 0)); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&str[0]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&0[str]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+
+    test_sprintf(arr); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*arr); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(arr + 1)); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&arr[1]); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&1[arr]); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+
+    test_sprintf(p); // expected-error {{passing '_Ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*p); // expected-error {{passing '_Ptr<char>' to parameter of incompatible type 'char *'}}
+  }
+}

--- a/tests/typechecking/pointer_types.c
+++ b/tests/typechecking/pointer_types.c
@@ -3053,10 +3053,31 @@ void check_illegal_operators(void)
 
 extern void test_sprintf(char *s);
 
-void check_address_of_types(_Nt_array_ptr<char> str,
+void check_address_of_types(char s[10],
+                            char *c : itype(char _Checked[10]),
+                            char buf _Nt_checked[],
+                            _Nt_array_ptr<char> str,
                             _Array_ptr<char> arr : count(10),
                             _Ptr<char> p) {
   _Unchecked {
+    test_sprintf(s);
+    test_sprintf(&*s);
+    test_sprintf(&*(s + 2));
+    test_sprintf(&s[2]);
+    test_sprintf(&2[s]);
+
+    test_sprintf(c);
+    test_sprintf(&*c);
+    test_sprintf(&*(c + 3));
+    test_sprintf(&c[3]);
+    test_sprintf(&3[c]);
+
+    test_sprintf(buf); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*buf); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(buf + 0)); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&buf[0]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&0[buf]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+
     test_sprintf(str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
     test_sprintf(&*str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
     test_sprintf(&*(str + 0)); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
@@ -3074,6 +3095,18 @@ void check_address_of_types(_Nt_array_ptr<char> str,
   }
 
   _Checked {
+    test_sprintf(c); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*c); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(c + 3)); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&c[3]); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&3[c]); // expected-error {{passing '_Array_ptr<char>' to parameter of incompatible type 'char *'}}
+
+    test_sprintf(buf); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*buf); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&*(buf + 0)); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&buf[0]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+    test_sprintf(&0[buf]); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
+
     test_sprintf(str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
     test_sprintf(&*str); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}
     test_sprintf(&*(str + 0)); // expected-error {{passing '_Nt_array_ptr<char>' to parameter of incompatible type 'char *'}}


### PR DESCRIPTION
This PR updates the tests to reflect the updated type checking behavior for address-of array subscripts in [checkedc-clang/1163](https://github.com/microsoft/checkedc-clang/pull/1163). If an expression `e` has type `T`, then `&e[idx]` and `&idx[e]` also have type `T`.