### PR TITLE
Bounds checking for pointer dereferences and array subscripts: update test

### DIFF
--- a/tests/static_checking/bounds_decl_checking.c
+++ b/tests/static_checking/bounds_decl_checking.c
@@ -612,8 +612,8 @@ extern void check_nullterm_call_bsi(int *arg1 : itype(nt_array_ptr<int>),
     test_nullterm_bsi_f3(arg6);  // expected-error {{parameter used in a checked scope must have a checked type or a bounds-safe interface}}
     test_nullterm_bsi_f4(test_nullterm_cmp);
     arg1 = arg2;                 // expected-error {{inferred bounds for 'arg1' are unknown after assignment}}
-    *arg7 = arg2;                // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds}}
-    *arg8 = arg2;                // expected-error {{expression has unknown bounds, right-hand side of assignment expected to have bounds}}
+    *arg7 = arg2;                // expected-error {{inferred bounds for '*arg7' are unknown after assignment}}
+    *arg8 = arg2;                // expected-error {{inferred bounds for '*arg8' are unknown after assignment}}
 
     arg2 = arg1;
     arg2 = *arg7;


### PR DESCRIPTION
This PR updates some expected error messages to reflect the behavior in [checkedc-clang/1176](https://github.com/microsoft/checkedc-clang/pull/1176): for a pointer dereference or array subscript with target bounds, bounds validation uses the existing framework in `UpdateAfterAssignment` and `ValidateBoundsContext` to validate these expressions. This means that the error messages emitted for pointer dereferences or array subscripts whose inferred bounds are unknown have been updated to be consistent with the error messages for checking variables and member expressions, so the expected error messages in the test file bounds_decl_checking.c are updated.