### PR TITLE
Get lvalue observed bounds: update test

### DIFF
--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -210,15 +210,24 @@ void write_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      s1->len = 0, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      int temp0 = s1->len;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp0)),
+        s1->len = 0,
+        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->len = 1, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      int temp1 = s1->len;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp1)),
+        s1->len = 1,
+        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->len = 2, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      int temp2 = s1->len;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp2)),
+        s1->len = 2,
+        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary write position for a3 (7th parameter)
@@ -405,15 +414,24 @@ void read_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      s1->len = 0, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      int temp0 = s1->len;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp0)),
+        s1->len = 0,
+        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->len = 1, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      int temp1 = s1->len;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp1)),
+        s1->len = 1,
+        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->len = 2, s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      int temp2 = s1->len;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp2)),
+        s1->len = 2,
+        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary read position for a3 (7th parameter)

--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -161,7 +161,6 @@ void write_driver(int failure_point, int *a1 : count(10),
                   char *b2 : itype(nt_array_ptr<char>),
                   struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
-  int temp = s1->len;
   switch (failure_point) {
     // Vary global variable.
     case 0: 
@@ -211,21 +210,15 @@ void write_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
-        s1->len = 0,
-        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 0;
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
-        s1->len = 1,
-        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 1;
       write_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
-        s1->len = 2,
-        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 2;
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary write position for a3 (7th parameter)
@@ -363,7 +356,6 @@ void read_driver(int failure_point, int *a1 : count(10),
                  char *b2 : itype(nt_array_ptr<char>),
                  struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
-  int temp = s1->len;
   switch (failure_point) {
     // Vary global variable.
     case 0:
@@ -413,21 +405,15 @@ void read_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
-        s1->len = 0,
-        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 0,
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
-        s1->len = 1,
-        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 1;
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
-        s1->len = 2,
-        s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 2;
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary read position for a3 (7th parameter)

--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -214,11 +214,11 @@ void write_driver(int failure_point, int *a1 : count(10),
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 1;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(1)), s1->len = 1;
       write_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 2;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(2)), s1->len = 2;
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary write position for a3 (7th parameter)
@@ -409,11 +409,11 @@ void read_driver(int failure_point, int *a1 : count(10),
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 1;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(1)), s1->len = 1;
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(0)), s1->len = 2;
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, count(2)), s1->len = 2;
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     // Vary read position for a3 (7th parameter)

--- a/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
+++ b/tests/dynamic_checking/bounds/bounds-safe-interfaces.c
@@ -161,6 +161,7 @@ void write_driver(int failure_point, int *a1 : count(10),
                   char *b2 : itype(nt_array_ptr<char>),
                   struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
+  int temp = s1->len;
   switch (failure_point) {
     // Vary global variable.
     case 0: 
@@ -210,22 +211,19 @@ void write_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      int temp0 = s1->len;
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp0)),
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
         s1->len = 0,
         s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      int temp1 = s1->len;
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp1)),
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
         s1->len = 1,
         s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      int temp2 = s1->len;
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp2)),
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
         s1->len = 2,
         s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       write_test(failure_point, a1, 10, a2, 10,  a3, 2, b1, 10, b2, 0, s1);
@@ -365,6 +363,7 @@ void read_driver(int failure_point, int *a1 : count(10),
                  char *b2 : itype(nt_array_ptr<char>),
                  struct S *s1 : itype(ptr<struct S>)) {
   dynamic_check(s1->len >= 5);
+  int temp = s1->len;
   switch (failure_point) {
     // Vary global variable.
     case 0:
@@ -414,22 +413,19 @@ void read_driver(int failure_point, int *a1 : count(10),
       break;
     // Vary structure lengths.
     case 13:
-      int temp0 = s1->len;
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp0)),
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
         s1->len = 0,
         s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 14:
-      int temp1 = s1->len;
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp1)),
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
         s1->len = 1,
         s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);
       break;
     case 15:
-      int temp2 = s1->len;
-      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp2)),
+      s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + temp)),
         s1->len = 2,
         s1->f = _Dynamic_bounds_cast<_Array_ptr<int>>(s1->f, bounds(s1->f, s1->f + s1->len));
       read_test(failure_point, a1, 10, a2, 10, a3, 2, b1, 10, b2, 0, s1);


### PR DESCRIPTION
This PR updates the bounds-safe-interface test file to account for the changes in [checkedc-clang/1183](https://github.com/microsoft/checkedc-clang/pull/1183).

With this change, the bounds for the value of the member expression `s1->f` are the observed bounds for `s1->f` as recorded in `CheckingState.ObservedBounds`. This means that, after the assignment `s1->len = 0`, the observed bounds for `s1->f` are `bounds(unknown)`. This results in an error when attempting to use `s1->f` in a dynamic bounds cast.

This PR uses an initial dynamic bounds cast so that the observed bounds of `s1->f` are depending on a temporary variable rather than `s1->len`, so that the assignment to `s1->len` does not impact the observed bounds of `s1->f`.